### PR TITLE
[DES-CORE-003] Implement dicom_dataset Class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 add_library(pacs_core
     src/core/dicom_tag.cpp
     src/core/dicom_element.cpp
+    src/core/dicom_dataset.cpp
 )
 target_include_directories(pacs_core
     PUBLIC
@@ -76,6 +77,7 @@ if(PACS_BUILD_TESTS)
     add_executable(core_tests
         tests/core/dicom_tag_test.cpp
         tests/core/dicom_element_test.cpp
+        tests/core/dicom_dataset_test.cpp
     )
     target_link_libraries(core_tests
         PRIVATE

--- a/include/pacs/core/dicom_dataset.hpp
+++ b/include/pacs/core/dicom_dataset.hpp
@@ -2,43 +2,75 @@
  * @file dicom_dataset.hpp
  * @brief DICOM Dataset - ordered collection of Data Elements
  *
- * This file provides the basic definition of dicom_dataset class.
- * The full implementation will be completed in DES-CORE-003 (Issue #12).
+ * This file provides the dicom_dataset class which represents an ordered
+ * collection of DICOM Data Elements as specified in DICOM PS3.5.
  *
  * @see DICOM PS3.5 Section 7.1 - Data Set
  */
 
 #pragma once
 
+#include "dicom_element.hpp"
 #include "dicom_tag.hpp"
 
+#include <pacs/encoding/vr_type.hpp>
+
+#include <initializer_list>
 #include <map>
-#include <memory>
 #include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <type_traits>
 
 namespace pacs::core {
-
-// Forward declaration
-class dicom_element;
 
 /**
  * @brief Represents a DICOM Dataset (ordered collection of Data Elements)
  *
  * A DICOM Dataset is an ordered collection of Data Elements, where each
  * element is uniquely identified by its tag. Elements are stored in
- * ascending tag order.
+ * ascending tag order as required by the DICOM standard.
  *
- * @note This is a placeholder implementation. Full functionality will be
- *       added in DES-CORE-003 (Issue #12).
+ * Thread Safety: This class is NOT thread-safe. External synchronization
+ * is required for concurrent access.
  *
  * @example
  * @code
  * dicom_dataset ds;
- * ds.insert(dicom_element::from_string(tags::patient_name, vr_type::PN, "DOE^JOHN"));
+ *
+ * // Set string values
+ * ds.set_string(tags::patient_name, encoding::vr_type::PN, "DOE^JOHN");
+ * ds.set_string(tags::patient_id, encoding::vr_type::LO, "12345");
+ *
+ * // Set numeric values
+ * ds.set_numeric<uint16_t>(tags::rows, encoding::vr_type::US, 512);
+ *
+ * // Access values
+ * std::string name = ds.get_string(tags::patient_name);
+ * uint16_t rows = ds.get_numeric<uint16_t>(tags::rows).value_or(0);
+ *
+ * // Iterate over elements
+ * for (const auto& [tag, element] : ds) {
+ *     std::cout << tag.to_string() << ": " << element.as_string() << "\n";
+ * }
  * @endcode
  */
 class dicom_dataset {
 public:
+    /// Storage type for elements (ordered by tag)
+    using storage_type = std::map<dicom_tag, dicom_element>;
+
+    /// Iterator type
+    using iterator = storage_type::iterator;
+
+    /// Const iterator type
+    using const_iterator = storage_type::const_iterator;
+
+    // ========================================================================
+    // Construction
+    // ========================================================================
+
     /**
      * @brief Default constructor - creates an empty dataset
      */
@@ -69,25 +101,218 @@ public:
      */
     ~dicom_dataset() = default;
 
+    // ========================================================================
+    // Element Access
+    // ========================================================================
+
     /**
-     * @brief Check if the dataset is empty
-     * @return true if no elements are present
+     * @brief Check if the dataset contains an element with the given tag
+     * @param tag The DICOM tag to check
+     * @return true if an element with this tag exists
      */
-    [[nodiscard]] auto empty() const noexcept -> bool {
-        return elements_.empty();
-    }
+    [[nodiscard]] auto contains(dicom_tag tag) const noexcept -> bool;
+
+    /**
+     * @brief Get a pointer to the element with the given tag
+     * @param tag The DICOM tag to look up
+     * @return Pointer to the element, or nullptr if not found
+     */
+    [[nodiscard]] auto get(dicom_tag tag) noexcept -> dicom_element*;
+
+    /**
+     * @brief Get a const pointer to the element with the given tag
+     * @param tag The DICOM tag to look up
+     * @return Const pointer to the element, or nullptr if not found
+     */
+    [[nodiscard]] auto get(dicom_tag tag) const noexcept -> const dicom_element*;
+
+    // ========================================================================
+    // Convenience Accessors
+    // ========================================================================
+
+    /**
+     * @brief Get the string value of an element
+     * @param tag The DICOM tag to look up
+     * @param default_value Value to return if element not found
+     * @return The element's string value, or default_value if not found
+     */
+    [[nodiscard]] auto get_string(dicom_tag tag,
+                                  std::string_view default_value = "") const
+        -> std::string;
+
+    /**
+     * @brief Get the numeric value of an element
+     * @tparam T The numeric type to return
+     * @param tag The DICOM tag to look up
+     * @return Optional containing the value, or nullopt if not found/conversion fails
+     */
+    template <typename T>
+        requires std::is_arithmetic_v<T>
+    [[nodiscard]] auto get_numeric(dicom_tag tag) const -> std::optional<T>;
+
+    // ========================================================================
+    // Modification
+    // ========================================================================
+
+    /**
+     * @brief Insert or replace an element in the dataset
+     * @param element The element to insert (copied or moved)
+     *
+     * If an element with the same tag already exists, it will be replaced.
+     * Use std::move() when passing the element to avoid unnecessary copies.
+     */
+    void insert(dicom_element element);
+
+    /**
+     * @brief Set a string value for the given tag
+     * @param tag The DICOM tag
+     * @param vr The value representation
+     * @param value The string value
+     *
+     * Creates a new element or updates an existing one.
+     */
+    void set_string(dicom_tag tag, encoding::vr_type vr, std::string_view value);
+
+    /**
+     * @brief Set a numeric value for the given tag
+     * @tparam T The numeric type
+     * @param tag The DICOM tag
+     * @param vr The value representation
+     * @param value The numeric value
+     */
+    template <typename T>
+        requires std::is_arithmetic_v<T>
+    void set_numeric(dicom_tag tag, encoding::vr_type vr, T value);
+
+    /**
+     * @brief Remove an element from the dataset
+     * @param tag The tag of the element to remove
+     * @return true if an element was removed, false if not found
+     */
+    auto remove(dicom_tag tag) -> bool;
+
+    /**
+     * @brief Remove all elements from the dataset
+     */
+    void clear() noexcept;
+
+    // ========================================================================
+    // Iteration
+    // ========================================================================
+
+    /**
+     * @brief Get iterator to the first element
+     * @return Iterator to the beginning
+     */
+    [[nodiscard]] auto begin() noexcept -> iterator;
+
+    /**
+     * @brief Get iterator past the last element
+     * @return Iterator to the end
+     */
+    [[nodiscard]] auto end() noexcept -> iterator;
+
+    /**
+     * @brief Get const iterator to the first element
+     * @return Const iterator to the beginning
+     */
+    [[nodiscard]] auto begin() const noexcept -> const_iterator;
+
+    /**
+     * @brief Get const iterator past the last element
+     * @return Const iterator to the end
+     */
+    [[nodiscard]] auto end() const noexcept -> const_iterator;
+
+    /**
+     * @brief Get const iterator to the first element
+     * @return Const iterator to the beginning
+     */
+    [[nodiscard]] auto cbegin() const noexcept -> const_iterator;
+
+    /**
+     * @brief Get const iterator past the last element
+     * @return Const iterator to the end
+     */
+    [[nodiscard]] auto cend() const noexcept -> const_iterator;
+
+    // ========================================================================
+    // Size Operations
+    // ========================================================================
 
     /**
      * @brief Get the number of elements in the dataset
      * @return The element count
      */
-    [[nodiscard]] auto size() const noexcept -> size_t {
-        return elements_.size();
-    }
+    [[nodiscard]] auto size() const noexcept -> size_t;
+
+    /**
+     * @brief Check if the dataset is empty
+     * @return true if no elements are present
+     */
+    [[nodiscard]] auto empty() const noexcept -> bool;
+
+    // ========================================================================
+    // Utility Operations
+    // ========================================================================
+
+    /**
+     * @brief Create a copy containing only the specified tags
+     * @param tags List of tags to include in the copy
+     * @return A new dataset containing only the specified elements
+     */
+    [[nodiscard]] auto copy_with_tags(std::initializer_list<dicom_tag> tags) const
+        -> dicom_dataset;
+
+    /**
+     * @brief Create a copy containing only the specified tags
+     * @param tags Span of tags to include in the copy
+     * @return A new dataset containing only the specified elements
+     */
+    [[nodiscard]] auto copy_with_tags(std::span<const dicom_tag> tags) const
+        -> dicom_dataset;
+
+    /**
+     * @brief Merge elements from another dataset
+     * @param other The dataset to merge from
+     *
+     * Elements from 'other' will overwrite existing elements with the same tag.
+     */
+    void merge(const dicom_dataset& other);
+
+    /**
+     * @brief Merge elements from another dataset (move version)
+     * @param other The dataset to merge from (moved)
+     */
+    void merge(dicom_dataset&& other);
 
 private:
-    // Using map to maintain tag ordering (will be enhanced in Issue #12)
-    std::map<dicom_tag, std::shared_ptr<dicom_element>> elements_;
+    storage_type elements_;
 };
+
+// ============================================================================
+// Template Implementations
+// ============================================================================
+
+template <typename T>
+    requires std::is_arithmetic_v<T>
+auto dicom_dataset::get_numeric(dicom_tag tag) const -> std::optional<T> {
+    const auto* elem = get(tag);
+    if (elem == nullptr) {
+        return std::nullopt;
+    }
+
+    try {
+        return elem->as_numeric<T>();
+    } catch (const value_conversion_error&) {
+        return std::nullopt;
+    }
+}
+
+template <typename T>
+    requires std::is_arithmetic_v<T>
+void dicom_dataset::set_numeric(dicom_tag tag, encoding::vr_type vr, T value) {
+    insert(dicom_element::from_numeric<T>(tag, vr, value));
+}
 
 }  // namespace pacs::core

--- a/include/pacs/core/dicom_element.hpp
+++ b/include/pacs/core/dicom_element.hpp
@@ -11,7 +11,6 @@
 
 #pragma once
 
-#include "dicom_dataset.hpp"
 #include "dicom_tag.hpp"
 
 #include <pacs/encoding/vr_type.hpp>
@@ -26,6 +25,9 @@
 #include <vector>
 
 namespace pacs::core {
+
+// Forward declaration to break circular dependency
+class dicom_dataset;
 
 /**
  * @brief Exception thrown when value conversion fails
@@ -82,29 +84,29 @@ public:
                   std::span<const uint8_t> data);
 
     /**
-     * @brief Default copy constructor
+     * @brief Copy constructor
      */
-    dicom_element(const dicom_element&) = default;
+    dicom_element(const dicom_element&);
 
     /**
-     * @brief Default move constructor
+     * @brief Move constructor
      */
-    dicom_element(dicom_element&&) noexcept = default;
+    dicom_element(dicom_element&&) noexcept;
 
     /**
-     * @brief Default copy assignment
+     * @brief Copy assignment
      */
-    auto operator=(const dicom_element&) -> dicom_element& = default;
+    auto operator=(const dicom_element&) -> dicom_element&;
 
     /**
-     * @brief Default move assignment
+     * @brief Move assignment
      */
-    auto operator=(dicom_element&&) noexcept -> dicom_element& = default;
+    auto operator=(dicom_element&&) noexcept -> dicom_element&;
 
     /**
-     * @brief Default destructor
+     * @brief Destructor
      */
-    ~dicom_element() = default;
+    ~dicom_element();
 
     // ========================================================================
     // Factory Methods

--- a/src/core/dicom_dataset.cpp
+++ b/src/core/dicom_dataset.cpp
@@ -1,0 +1,145 @@
+/**
+ * @file dicom_dataset.cpp
+ * @brief Implementation of DICOM Dataset
+ */
+
+#include <pacs/core/dicom_dataset.hpp>
+
+namespace pacs::core {
+
+// ============================================================================
+// Element Access
+// ============================================================================
+
+auto dicom_dataset::contains(dicom_tag tag) const noexcept -> bool {
+    return elements_.contains(tag);
+}
+
+auto dicom_dataset::get(dicom_tag tag) noexcept -> dicom_element* {
+    auto it = elements_.find(tag);
+    if (it == elements_.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+auto dicom_dataset::get(dicom_tag tag) const noexcept -> const dicom_element* {
+    auto it = elements_.find(tag);
+    if (it == elements_.end()) {
+        return nullptr;
+    }
+    return &it->second;
+}
+
+// ============================================================================
+// Convenience Accessors
+// ============================================================================
+
+auto dicom_dataset::get_string(dicom_tag tag,
+                               std::string_view default_value) const
+    -> std::string {
+    const auto* elem = get(tag);
+    if (elem == nullptr) {
+        return std::string{default_value};
+    }
+    return elem->as_string();
+}
+
+// ============================================================================
+// Modification
+// ============================================================================
+
+void dicom_dataset::insert(dicom_element element) {
+    elements_.insert_or_assign(element.tag(), std::move(element));
+}
+
+void dicom_dataset::set_string(dicom_tag tag, encoding::vr_type vr,
+                               std::string_view value) {
+    insert(dicom_element::from_string(tag, vr, value));
+}
+
+auto dicom_dataset::remove(dicom_tag tag) -> bool {
+    return elements_.erase(tag) > 0;
+}
+
+void dicom_dataset::clear() noexcept {
+    elements_.clear();
+}
+
+// ============================================================================
+// Iteration
+// ============================================================================
+
+auto dicom_dataset::begin() noexcept -> iterator {
+    return elements_.begin();
+}
+
+auto dicom_dataset::end() noexcept -> iterator {
+    return elements_.end();
+}
+
+auto dicom_dataset::begin() const noexcept -> const_iterator {
+    return elements_.begin();
+}
+
+auto dicom_dataset::end() const noexcept -> const_iterator {
+    return elements_.end();
+}
+
+auto dicom_dataset::cbegin() const noexcept -> const_iterator {
+    return elements_.cbegin();
+}
+
+auto dicom_dataset::cend() const noexcept -> const_iterator {
+    return elements_.cend();
+}
+
+// ============================================================================
+// Size Operations
+// ============================================================================
+
+auto dicom_dataset::size() const noexcept -> size_t {
+    return elements_.size();
+}
+
+auto dicom_dataset::empty() const noexcept -> bool {
+    return elements_.empty();
+}
+
+// ============================================================================
+// Utility Operations
+// ============================================================================
+
+auto dicom_dataset::copy_with_tags(std::initializer_list<dicom_tag> tags) const
+    -> dicom_dataset {
+    return copy_with_tags(std::span{tags.begin(), tags.size()});
+}
+
+auto dicom_dataset::copy_with_tags(std::span<const dicom_tag> tags) const
+    -> dicom_dataset {
+    dicom_dataset result;
+
+    for (const auto& tag : tags) {
+        const auto* elem = get(tag);
+        if (elem != nullptr) {
+            result.insert(*elem);
+        }
+    }
+
+    return result;
+}
+
+void dicom_dataset::merge(const dicom_dataset& other) {
+    for (const auto& [tag, element] : other) {
+        insert(element);
+    }
+}
+
+void dicom_dataset::merge(dicom_dataset&& other) {
+    for (auto& [tag, element] : other.elements_) {
+        insert(std::move(element));
+    }
+    other.clear();
+}
+
+}  // namespace pacs::core

--- a/src/core/dicom_element.cpp
+++ b/src/core/dicom_element.cpp
@@ -23,6 +23,12 @@ dicom_element::dicom_element(dicom_tag tag, encoding::vr_type vr,
                              std::span<const uint8_t> data)
     : tag_{tag}, vr_{vr}, data_(data.begin(), data.end()), sequence_items_{} {}
 
+dicom_element::dicom_element(const dicom_element&) = default;
+dicom_element::dicom_element(dicom_element&&) noexcept = default;
+auto dicom_element::operator=(const dicom_element&) -> dicom_element& = default;
+auto dicom_element::operator=(dicom_element&&) noexcept -> dicom_element& = default;
+dicom_element::~dicom_element() = default;
+
 // ============================================================================
 // Factory Methods
 // ============================================================================

--- a/tests/core/dicom_dataset_test.cpp
+++ b/tests/core/dicom_dataset_test.cpp
@@ -1,0 +1,550 @@
+/**
+ * @file dicom_dataset_test.cpp
+ * @brief Unit tests for dicom_dataset class
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+
+#include <algorithm>
+#include <vector>
+
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+// ============================================================================
+// Construction Tests
+// ============================================================================
+
+TEST_CASE("dicom_dataset construction", "[core][dicom_dataset]") {
+    SECTION("default construction creates empty dataset") {
+        dicom_dataset ds;
+
+        CHECK(ds.empty());
+        CHECK(ds.size() == 0);
+    }
+
+    SECTION("copy construction") {
+        dicom_dataset original;
+        original.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+        original.set_string(tags::patient_id, vr_type::LO, "12345");
+
+        dicom_dataset copy{original};
+
+        CHECK(copy.size() == 2);
+        CHECK(copy.get_string(tags::patient_name) == "DOE^JOHN");
+        CHECK(copy.get_string(tags::patient_id) == "12345");
+    }
+
+    SECTION("move construction") {
+        dicom_dataset original;
+        original.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        dicom_dataset moved{std::move(original)};
+
+        CHECK(moved.size() == 1);
+        CHECK(moved.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+
+    SECTION("copy assignment") {
+        dicom_dataset original;
+        original.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        dicom_dataset copy;
+        copy = original;
+
+        CHECK(copy.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+
+    SECTION("move assignment") {
+        dicom_dataset original;
+        original.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        dicom_dataset moved;
+        moved = std::move(original);
+
+        CHECK(moved.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+}
+
+// ============================================================================
+// Element Access Tests
+// ============================================================================
+
+TEST_CASE("dicom_dataset element access", "[core][dicom_dataset]") {
+    dicom_dataset ds;
+    ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+    SECTION("contains returns true for existing element") {
+        CHECK(ds.contains(tags::patient_name));
+    }
+
+    SECTION("contains returns false for non-existing element") {
+        CHECK_FALSE(ds.contains(tags::patient_id));
+    }
+
+    SECTION("get returns pointer for existing element") {
+        auto* elem = ds.get(tags::patient_name);
+
+        REQUIRE(elem != nullptr);
+        CHECK(elem->as_string() == "DOE^JOHN");
+    }
+
+    SECTION("get returns nullptr for non-existing element") {
+        auto* elem = ds.get(tags::patient_id);
+
+        CHECK(elem == nullptr);
+    }
+
+    SECTION("const get works correctly") {
+        const auto& const_ds = ds;
+        const auto* elem = const_ds.get(tags::patient_name);
+
+        REQUIRE(elem != nullptr);
+        CHECK(elem->as_string() == "DOE^JOHN");
+    }
+}
+
+// ============================================================================
+// Convenience Accessor Tests
+// ============================================================================
+
+TEST_CASE("dicom_dataset convenience accessors", "[core][dicom_dataset]") {
+    dicom_dataset ds;
+    ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+    ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 512);
+    ds.set_numeric<uint16_t>(tags::columns, vr_type::US, 256);
+
+    SECTION("get_string returns value for existing element") {
+        CHECK(ds.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+
+    SECTION("get_string returns default for non-existing element") {
+        CHECK(ds.get_string(tags::patient_id) == "");
+        CHECK(ds.get_string(tags::patient_id, "UNKNOWN") == "UNKNOWN");
+    }
+
+    SECTION("get_numeric returns value for existing element") {
+        auto rows = ds.get_numeric<uint16_t>(tags::rows);
+
+        REQUIRE(rows.has_value());
+        CHECK(*rows == 512);
+    }
+
+    SECTION("get_numeric returns nullopt for non-existing element") {
+        auto bits = ds.get_numeric<uint16_t>(tags::bits_allocated);
+
+        CHECK_FALSE(bits.has_value());
+    }
+
+    SECTION("get_numeric with wrong type returns nullopt") {
+        // Try to read 2-byte value as 4-byte
+        auto value = ds.get_numeric<uint32_t>(tags::rows);
+
+        CHECK_FALSE(value.has_value());
+    }
+}
+
+// ============================================================================
+// Modification Tests
+// ============================================================================
+
+TEST_CASE("dicom_dataset modification", "[core][dicom_dataset]") {
+    SECTION("insert adds new element") {
+        dicom_dataset ds;
+        auto elem = dicom_element::from_string(
+            tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        ds.insert(elem);
+
+        CHECK(ds.size() == 1);
+        CHECK(ds.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+
+    SECTION("insert replaces existing element") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "OLD^NAME");
+
+        auto elem = dicom_element::from_string(
+            tags::patient_name, vr_type::PN, "NEW^NAME");
+        ds.insert(elem);
+
+        CHECK(ds.size() == 1);
+        CHECK(ds.get_string(tags::patient_name) == "NEW^NAME");
+    }
+
+    SECTION("insert with move") {
+        dicom_dataset ds;
+        auto elem = dicom_element::from_string(
+            tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        ds.insert(std::move(elem));
+
+        CHECK(ds.size() == 1);
+        CHECK(ds.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+
+    SECTION("set_string adds new element") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        CHECK(ds.contains(tags::patient_name));
+        CHECK(ds.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+
+    SECTION("set_string replaces existing element") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "OLD");
+        ds.set_string(tags::patient_name, vr_type::PN, "NEW");
+
+        CHECK(ds.size() == 1);
+        CHECK(ds.get_string(tags::patient_name) == "NEW");
+    }
+
+    SECTION("set_numeric adds numeric element") {
+        dicom_dataset ds;
+        ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 512);
+
+        CHECK(ds.get_numeric<uint16_t>(tags::rows) == 512);
+    }
+
+    SECTION("remove existing element returns true") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        bool removed = ds.remove(tags::patient_name);
+
+        CHECK(removed);
+        CHECK_FALSE(ds.contains(tags::patient_name));
+        CHECK(ds.empty());
+    }
+
+    SECTION("remove non-existing element returns false") {
+        dicom_dataset ds;
+
+        bool removed = ds.remove(tags::patient_name);
+
+        CHECK_FALSE(removed);
+    }
+
+    SECTION("clear removes all elements") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+        ds.set_string(tags::patient_id, vr_type::LO, "12345");
+        ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 512);
+
+        ds.clear();
+
+        CHECK(ds.empty());
+        CHECK(ds.size() == 0);
+    }
+}
+
+// ============================================================================
+// Iteration Tests
+// ============================================================================
+
+TEST_CASE("dicom_dataset iteration", "[core][dicom_dataset]") {
+    dicom_dataset ds;
+    // Insert in non-sorted order
+    ds.set_string({0x0020, 0x000D}, vr_type::UI, "1.2.3");  // Study UID
+    ds.set_string({0x0010, 0x0010}, vr_type::PN, "DOE^JOHN");  // Patient Name
+    ds.set_string({0x0010, 0x0020}, vr_type::LO, "12345");  // Patient ID
+
+    SECTION("elements are iterated in ascending tag order") {
+        std::vector<dicom_tag> tags;
+        for (const auto& [tag, elem] : ds) {
+            tags.push_back(tag);
+        }
+
+        REQUIRE(tags.size() == 3);
+        // Must be in ascending order
+        CHECK(tags[0] == dicom_tag{0x0010, 0x0010});  // Patient Name first
+        CHECK(tags[1] == dicom_tag{0x0010, 0x0020});  // Patient ID second
+        CHECK(tags[2] == dicom_tag{0x0020, 0x000D});  // Study UID third
+    }
+
+    SECTION("begin and end work correctly") {
+        auto it = ds.begin();
+        auto end = ds.end();
+
+        int count = 0;
+        while (it != end) {
+            ++count;
+            ++it;
+        }
+
+        CHECK(count == 3);
+    }
+
+    SECTION("const iteration works") {
+        const auto& const_ds = ds;
+        int count = 0;
+
+        for ([[maybe_unused]] const auto& [tag, elem] : const_ds) {
+            ++count;
+        }
+
+        CHECK(count == 3);
+    }
+
+    SECTION("cbegin and cend work correctly") {
+        auto it = ds.cbegin();
+        auto end = ds.cend();
+
+        CHECK(it != end);
+        CHECK(std::distance(it, end) == 3);
+    }
+
+    SECTION("range-based for with modification") {
+        for (auto& [tag, elem] : ds) {
+            if (tag == dicom_tag{0x0010, 0x0010}) {
+                elem.set_string("SMITH^JANE");
+            }
+        }
+
+        CHECK(ds.get_string({0x0010, 0x0010}) == "SMITH^JANE");
+    }
+}
+
+// ============================================================================
+// Size Operations Tests
+// ============================================================================
+
+TEST_CASE("dicom_dataset size operations", "[core][dicom_dataset]") {
+    SECTION("empty dataset") {
+        dicom_dataset ds;
+
+        CHECK(ds.empty());
+        CHECK(ds.size() == 0);
+    }
+
+    SECTION("non-empty dataset") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        CHECK_FALSE(ds.empty());
+        CHECK(ds.size() == 1);
+    }
+
+    SECTION("size increases with inserts") {
+        dicom_dataset ds;
+
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+        CHECK(ds.size() == 1);
+
+        ds.set_string(tags::patient_id, vr_type::LO, "12345");
+        CHECK(ds.size() == 2);
+
+        // Same tag should not increase size
+        ds.set_string(tags::patient_name, vr_type::PN, "NEW^NAME");
+        CHECK(ds.size() == 2);
+    }
+
+    SECTION("size decreases with removes") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+        ds.set_string(tags::patient_id, vr_type::LO, "12345");
+
+        ds.remove(tags::patient_name);
+        CHECK(ds.size() == 1);
+
+        ds.remove(tags::patient_id);
+        CHECK(ds.size() == 0);
+        CHECK(ds.empty());
+    }
+}
+
+// ============================================================================
+// Utility Operations Tests
+// ============================================================================
+
+TEST_CASE("dicom_dataset copy_with_tags", "[core][dicom_dataset]") {
+    dicom_dataset ds;
+    ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+    ds.set_string(tags::patient_id, vr_type::LO, "12345");
+    ds.set_string(tags::study_instance_uid, vr_type::UI, "1.2.3.4");
+    ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 512);
+
+    SECTION("copy with initializer list") {
+        auto copy = ds.copy_with_tags({tags::patient_name, tags::patient_id});
+
+        CHECK(copy.size() == 2);
+        CHECK(copy.contains(tags::patient_name));
+        CHECK(copy.contains(tags::patient_id));
+        CHECK_FALSE(copy.contains(tags::study_instance_uid));
+        CHECK_FALSE(copy.contains(tags::rows));
+    }
+
+    SECTION("copy with span") {
+        std::vector<dicom_tag> tags_to_copy = {
+            tags::patient_name, tags::study_instance_uid};
+        auto copy = ds.copy_with_tags(tags_to_copy);
+
+        CHECK(copy.size() == 2);
+        CHECK(copy.get_string(tags::patient_name) == "DOE^JOHN");
+        CHECK(copy.get_string(tags::study_instance_uid) == "1.2.3.4");
+    }
+
+    SECTION("copy with non-existing tags") {
+        auto copy = ds.copy_with_tags({tags::patient_name, tags::modality});
+
+        CHECK(copy.size() == 1);  // Only patient_name exists
+        CHECK(copy.contains(tags::patient_name));
+        CHECK_FALSE(copy.contains(tags::modality));
+    }
+
+    SECTION("copy with empty tag list") {
+        auto copy = ds.copy_with_tags({});
+
+        CHECK(copy.empty());
+    }
+
+    SECTION("copied elements are independent") {
+        auto copy = ds.copy_with_tags({tags::patient_name});
+
+        // Modify original
+        ds.set_string(tags::patient_name, vr_type::PN, "MODIFIED");
+
+        // Copy should be unchanged
+        CHECK(copy.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+}
+
+TEST_CASE("dicom_dataset merge", "[core][dicom_dataset]") {
+    SECTION("merge adds new elements") {
+        dicom_dataset ds1;
+        ds1.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        dicom_dataset ds2;
+        ds2.set_string(tags::patient_id, vr_type::LO, "12345");
+
+        ds1.merge(ds2);
+
+        CHECK(ds1.size() == 2);
+        CHECK(ds1.contains(tags::patient_name));
+        CHECK(ds1.contains(tags::patient_id));
+    }
+
+    SECTION("merge overwrites existing elements") {
+        dicom_dataset ds1;
+        ds1.set_string(tags::patient_name, vr_type::PN, "OLD^NAME");
+
+        dicom_dataset ds2;
+        ds2.set_string(tags::patient_name, vr_type::PN, "NEW^NAME");
+
+        ds1.merge(ds2);
+
+        CHECK(ds1.size() == 1);
+        CHECK(ds1.get_string(tags::patient_name) == "NEW^NAME");
+    }
+
+    SECTION("merge with move") {
+        dicom_dataset ds1;
+        ds1.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        dicom_dataset ds2;
+        ds2.set_string(tags::patient_id, vr_type::LO, "12345");
+        ds2.set_numeric<uint16_t>(tags::rows, vr_type::US, 512);
+
+        ds1.merge(std::move(ds2));
+
+        CHECK(ds1.size() == 3);
+        CHECK(ds1.contains(tags::patient_name));
+        CHECK(ds1.contains(tags::patient_id));
+        CHECK(ds1.contains(tags::rows));
+        CHECK(ds2.empty());  // Source should be cleared after move
+    }
+
+    SECTION("merge empty dataset has no effect") {
+        dicom_dataset ds1;
+        ds1.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        dicom_dataset ds2;
+
+        ds1.merge(ds2);
+
+        CHECK(ds1.size() == 1);
+    }
+
+    SECTION("merge into empty dataset") {
+        dicom_dataset ds1;
+
+        dicom_dataset ds2;
+        ds2.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        ds1.merge(ds2);
+
+        CHECK(ds1.size() == 1);
+        CHECK(ds1.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+TEST_CASE("dicom_dataset edge cases", "[core][dicom_dataset]") {
+    SECTION("large number of elements") {
+        dicom_dataset ds;
+
+        // Insert 100 elements
+        for (uint16_t i = 0; i < 100; ++i) {
+            dicom_tag tag{0x0010, static_cast<uint16_t>(0x1000 + i)};
+            ds.set_string(tag, vr_type::LO, std::to_string(i));
+        }
+
+        CHECK(ds.size() == 100);
+
+        // Verify ordering is maintained
+        uint16_t expected_elem = 0x1000;
+        for (const auto& [tag, elem] : ds) {
+            CHECK(tag.group() == 0x0010);
+            CHECK(tag.element() == expected_elem);
+            ++expected_elem;
+        }
+    }
+
+    SECTION("elements across different groups maintain order") {
+        dicom_dataset ds;
+        ds.set_string({0x0020, 0x0010}, vr_type::SH, "StudyID");
+        ds.set_string({0x0008, 0x0050}, vr_type::SH, "AccNum");
+        ds.set_string({0x0010, 0x0020}, vr_type::LO, "PatID");
+
+        std::vector<uint16_t> groups;
+        for (const auto& [tag, elem] : ds) {
+            groups.push_back(tag.group());
+        }
+
+        // Groups should be in ascending order
+        REQUIRE(groups.size() == 3);
+        CHECK(groups[0] == 0x0008);
+        CHECK(groups[1] == 0x0010);
+        CHECK(groups[2] == 0x0020);
+    }
+
+    SECTION("self-assignment is safe") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        // Test self-assignment (suppress warning for this intentional test)
+        auto& self_ref = ds;
+        ds = self_ref;
+
+        CHECK(ds.size() == 1);
+        CHECK(ds.get_string(tags::patient_name) == "DOE^JOHN");
+    }
+
+    SECTION("mutable element access allows modification") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        auto* elem = ds.get(tags::patient_name);
+        REQUIRE(elem != nullptr);
+        elem->set_string("MODIFIED^NAME");
+
+        CHECK(ds.get_string(tags::patient_name) == "MODIFIED^NAME");
+    }
+}


### PR DESCRIPTION
## Summary

Implements the `dicom_dataset` class as an ordered collection of DICOM elements, completing the Core Module's data structure foundation.

### Key Features
- **Ordered element storage** using `std::map<dicom_tag, dicom_element>` for automatic tag ordering (DICOM requirement)
- **Element access**: `contains()`, `get()` with pointer/const semantics
- **Convenience accessors**: `get_string()`, `get_numeric<T>()` with default values
- **Modification methods**: `insert()`, `set_string()`, `set_numeric()`, `remove()`, `clear()`
- **Full iterator support**: `begin()`/`end()`, `cbegin()`/`cend()` for range-based for loops
- **Utility operations**: `copy_with_tags()`, `merge()` for dataset manipulation

### Technical Notes
- Resolved circular dependency between `dicom_dataset` and `dicom_element` using forward declaration pattern
- Special member functions (copy/move/destructor) defined in `.cpp` to allow incomplete type in header
- Thread safety: NOT thread-safe (documented, external synchronization required)

## Test Plan
- [x] All 54 unit tests pass (including 9 new dataset tests)
- [x] Build succeeds with `-Werror` enabled
- [x] Element ordering verified in ascending tag order
- [x] Copy/move semantics tested
- [x] Merge operations verified

Closes #12