### PR TITLE
[DES-ENC-002] Implement vr_info Metadata Utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ target_include_directories(pacs_core
 # Encoding library
 add_library(pacs_encoding
     src/encoding/transfer_syntax.cpp
+    src/encoding/vr_info.cpp
 )
 target_include_directories(pacs_encoding
     PUBLIC
@@ -97,6 +98,7 @@ if(PACS_BUILD_TESTS)
     add_executable(encoding_tests
         tests/encoding/transfer_syntax_test.cpp
         tests/encoding/vr_type_test.cpp
+        tests/encoding/vr_info_test.cpp
     )
     target_link_libraries(encoding_tests
         PRIVATE

--- a/include/pacs/encoding/vr_info.hpp
+++ b/include/pacs/encoding/vr_info.hpp
@@ -1,0 +1,138 @@
+#ifndef PACS_ENCODING_VR_INFO_HPP
+#define PACS_ENCODING_VR_INFO_HPP
+
+#include "vr_type.hpp"
+
+#include <cstdint>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::encoding {
+
+/**
+ * @brief Metadata structure containing comprehensive VR properties.
+ *
+ * This structure provides all the information needed for encoding, decoding,
+ * and validating DICOM data element values based on their VR type.
+ *
+ * @see DICOM PS3.5 Section 6.2 - Value Representation (VR)
+ */
+struct vr_info {
+    vr_type type;                   ///< The VR enumeration value
+    std::string_view name;          ///< Human-readable name (e.g., "Person Name")
+    uint32_t max_length;            ///< Maximum value length in bytes
+    char padding_char;              ///< Padding character (' ' or '\0')
+    bool is_fixed_length;           ///< Whether VR has fixed length
+    std::size_t fixed_size;         ///< Size for fixed-length VRs (0 if variable)
+};
+
+/// @name VR Information Lookup
+/// @{
+
+/**
+ * @brief Retrieves comprehensive metadata for a VR type.
+ * @param vr The VR type to look up
+ * @return Reference to vr_info structure containing VR properties
+ *
+ * This function provides all properties needed for encoding/decoding
+ * operations, including name, maximum length, padding requirements,
+ * and fixed/variable length information.
+ *
+ * @note Returns info for vr_type::UN if an unknown VR is provided.
+ */
+[[nodiscard]] const vr_info& get_vr_info(vr_type vr);
+
+/// @}
+
+/// @name Value Validation Functions
+/// @{
+
+/**
+ * @brief Validates binary data against VR encoding rules.
+ * @param vr The VR type for validation
+ * @param data The binary data to validate
+ * @return true if the data conforms to VR requirements
+ *
+ * Performs VR-specific validation including:
+ * - Length constraints
+ * - Character set restrictions
+ * - Format requirements (for structured VRs like DA, TM)
+ */
+[[nodiscard]] bool validate_value(vr_type vr, std::span<const uint8_t> data);
+
+/**
+ * @brief Validates a string value against VR encoding rules.
+ * @param vr The VR type for validation
+ * @param value The string value to validate
+ * @return true if the string conforms to VR requirements
+ *
+ * Validates string VRs for:
+ * - Maximum length
+ * - Allowed character sets
+ * - Format patterns (dates, times, UIDs, etc.)
+ */
+[[nodiscard]] bool validate_string(vr_type vr, std::string_view value);
+
+/// @}
+
+/// @name Padding Utilities
+/// @{
+
+/**
+ * @brief Pads data to even length as required by DICOM.
+ * @param vr The VR type (determines padding character)
+ * @param data The data to pad
+ * @return A new vector with even-length data
+ *
+ * DICOM requires all data element values to have even length.
+ * This function adds the appropriate padding character if needed:
+ * - Space (' ') for most string VRs
+ * - Null ('\0') for UI and binary VRs
+ *
+ * @see DICOM PS3.5 Section 7.1.1 - DICOM Data Element Structure
+ */
+[[nodiscard]] std::vector<uint8_t> pad_to_even(vr_type vr,
+                                                std::span<const uint8_t> data);
+
+/**
+ * @brief Removes trailing padding characters from a string value.
+ * @param vr The VR type (determines padding character to remove)
+ * @param value The value to trim
+ * @return A string with trailing padding removed
+ *
+ * Removes:
+ * - Trailing spaces for most string VRs
+ * - Trailing nulls for UI VR
+ */
+[[nodiscard]] std::string trim_padding(vr_type vr, std::string_view value);
+
+/// @}
+
+/// @name Character Set Validation
+/// @{
+
+/**
+ * @brief Validates that a string uses only allowed characters for its VR.
+ * @param vr The VR type
+ * @param value The string to validate
+ * @return true if all characters are valid for the VR
+ *
+ * Character restrictions by VR type:
+ * - CS: A-Z, 0-9, space, underscore
+ * - DA: 0-9 only (YYYYMMDD format)
+ * - TM: 0-9, period, colon
+ * - UI: 0-9, period
+ * - DS: 0-9, +, -, ., E, e, space
+ * - IS: 0-9, +, -
+ * - AS: 0-9, D, W, M, Y
+ * - Other string VRs: All printable characters
+ */
+[[nodiscard]] bool is_valid_charset(vr_type vr, std::string_view value);
+
+/// @}
+
+}  // namespace pacs::encoding
+
+#endif  // PACS_ENCODING_VR_INFO_HPP

--- a/src/encoding/vr_info.cpp
+++ b/src/encoding/vr_info.cpp
@@ -1,0 +1,280 @@
+#include "pacs/encoding/vr_info.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <unordered_map>
+
+namespace pacs::encoding {
+
+namespace {
+
+// Static VR properties table
+// DICOM PS3.5 Table 6.2-1 defines these properties
+constexpr std::array<vr_info, 31> vr_table = {{
+    // String VRs
+    {vr_type::AE, "Application Entity",    16,       ' ',  false, 0},
+    {vr_type::AS, "Age String",            4,        ' ',  true,  4},
+    {vr_type::CS, "Code String",           16,       ' ',  false, 0},
+    {vr_type::DA, "Date",                  8,        ' ',  true,  8},
+    {vr_type::DS, "Decimal String",        16,       ' ',  false, 0},
+    {vr_type::DT, "Date Time",             26,       ' ',  false, 0},
+    {vr_type::IS, "Integer String",        12,       ' ',  false, 0},
+    {vr_type::LO, "Long String",           64,       ' ',  false, 0},
+    {vr_type::LT, "Long Text",             10240,    ' ',  false, 0},
+    {vr_type::PN, "Person Name",           324,      ' ',  false, 0},
+    {vr_type::SH, "Short String",          16,       ' ',  false, 0},
+    {vr_type::ST, "Short Text",            1024,     ' ',  false, 0},
+    {vr_type::TM, "Time",                  14,       ' ',  false, 0},
+    {vr_type::UC, "Unlimited Characters",  0xFFFFFFFE, ' ', false, 0},
+    {vr_type::UI, "Unique Identifier",     64,       '\0', false, 0},
+    {vr_type::UR, "Universal Resource Identifier", 0xFFFFFFFE, ' ', false, 0},
+    {vr_type::UT, "Unlimited Text",        0xFFFFFFFE, ' ', false, 0},
+
+    // Numeric VRs (binary encoded, fixed length per value)
+    {vr_type::FL, "Floating Point Single", 4,        '\0', true,  4},
+    {vr_type::FD, "Floating Point Double", 8,        '\0', true,  8},
+    {vr_type::SL, "Signed Long",           4,        '\0', true,  4},
+    {vr_type::SS, "Signed Short",          2,        '\0', true,  2},
+    {vr_type::SV, "Signed 64-bit Very Long", 8,      '\0', true,  8},
+    {vr_type::UL, "Unsigned Long",         4,        '\0', true,  4},
+    {vr_type::US, "Unsigned Short",        2,        '\0', true,  2},
+    {vr_type::UV, "Unsigned 64-bit Very Long", 8,    '\0', true,  8},
+
+    // Binary VRs (raw bytes, variable length)
+    {vr_type::OB, "Other Byte",            0xFFFFFFFE, '\0', false, 0},
+    {vr_type::OD, "Other Double",          0xFFFFFFFE, '\0', false, 0},
+    {vr_type::OF, "Other Float",           0xFFFFFFFE, '\0', false, 0},
+    {vr_type::OL, "Other Long",            0xFFFFFFFE, '\0', false, 0},
+    {vr_type::OV, "Other 64-bit Very Long", 0xFFFFFFFE, '\0', false, 0},
+    {vr_type::OW, "Other Word",            0xFFFFFFFE, '\0', false, 0},
+}};
+
+// Additional VR info for special types
+constexpr vr_info at_info = {vr_type::AT, "Attribute Tag", 4, '\0', true, 4};
+constexpr vr_info sq_info = {vr_type::SQ, "Sequence of Items", 0xFFFFFFFF, '\0', false, 0};
+constexpr vr_info un_info = {vr_type::UN, "Unknown", 0xFFFFFFFE, '\0', false, 0};
+
+// Build lookup map at runtime
+const std::unordered_map<vr_type, const vr_info*>& get_vr_map() {
+    static const auto map = []() {
+        std::unordered_map<vr_type, const vr_info*> m;
+        for (const auto& info : vr_table) {
+            m[info.type] = &info;
+        }
+        m[vr_type::AT] = &at_info;
+        m[vr_type::SQ] = &sq_info;
+        m[vr_type::UN] = &un_info;
+        return m;
+    }();
+    return map;
+}
+
+// Character validation helpers
+bool is_cs_char(char c) {
+    return std::isupper(static_cast<unsigned char>(c)) ||
+           std::isdigit(static_cast<unsigned char>(c)) ||
+           c == ' ' || c == '_';
+}
+
+bool is_da_char(char c) {
+    return std::isdigit(static_cast<unsigned char>(c));
+}
+
+bool is_tm_char(char c) {
+    return std::isdigit(static_cast<unsigned char>(c)) ||
+           c == '.' || c == ':';
+}
+
+bool is_ui_char(char c) {
+    return std::isdigit(static_cast<unsigned char>(c)) || c == '.';
+}
+
+bool is_ds_char(char c) {
+    return std::isdigit(static_cast<unsigned char>(c)) ||
+           c == '+' || c == '-' || c == '.' ||
+           c == 'E' || c == 'e' || c == ' ';
+}
+
+bool is_is_char(char c) {
+    return std::isdigit(static_cast<unsigned char>(c)) ||
+           c == '+' || c == '-';
+}
+
+bool is_as_char(char c) {
+    return std::isdigit(static_cast<unsigned char>(c)) ||
+           c == 'D' || c == 'W' || c == 'M' || c == 'Y';
+}
+
+bool is_dt_char(char c) {
+    return std::isdigit(static_cast<unsigned char>(c)) ||
+           c == '.' || c == '+' || c == '-';
+}
+
+bool is_printable(char c) {
+    auto uc = static_cast<unsigned char>(c);
+    // Allow printable ASCII (0x20-0x7E) plus CR, LF, FF, TAB for text VRs
+    return (uc >= 0x20 && uc <= 0x7E) ||
+           c == '\r' || c == '\n' || c == '\f' || c == '\t';
+}
+
+}  // namespace
+
+const vr_info& get_vr_info(vr_type vr) {
+    const auto& map = get_vr_map();
+    auto it = map.find(vr);
+    if (it != map.end()) {
+        return *it->second;
+    }
+    // Return UN info for unknown VR types
+    return un_info;
+}
+
+bool validate_value(vr_type vr, std::span<const uint8_t> data) {
+    const auto& info = get_vr_info(vr);
+
+    // For fixed-length VRs, check that size is a multiple of fixed_size (VM >= 1)
+    if (info.is_fixed_length && info.fixed_size > 0) {
+        if (data.size() % info.fixed_size != 0) {
+            return false;
+        }
+        // Fixed-length VRs pass validation if size is correct multiple
+        return true;
+    }
+
+    // Check maximum length for variable-length VRs (0xFFFFFFFE means unlimited)
+    if (info.max_length != 0xFFFFFFFE && info.max_length != 0xFFFFFFFF) {
+        if (data.size() > info.max_length) {
+            return false;
+        }
+    }
+
+    // String VRs need character validation
+    if (is_string_vr(vr)) {
+        std::string_view str_value(reinterpret_cast<const char*>(data.data()),
+                                   data.size());
+        return is_valid_charset(vr, str_value);
+    }
+
+    return true;
+}
+
+bool validate_string(vr_type vr, std::string_view value) {
+    const auto& info = get_vr_info(vr);
+
+    // Non-string VRs cannot be validated as strings
+    if (!is_string_vr(vr)) {
+        return false;
+    }
+
+    // Check maximum length
+    if (info.max_length != 0xFFFFFFFE) {
+        if (value.size() > info.max_length) {
+            return false;
+        }
+    }
+
+    // Fixed-length string VRs (AS, DA) must match exact length
+    if (info.is_fixed_length && info.fixed_size > 0) {
+        if (value.size() != info.fixed_size) {
+            return false;
+        }
+    }
+
+    // Validate character set
+    return is_valid_charset(vr, value);
+}
+
+std::vector<uint8_t> pad_to_even(vr_type vr, std::span<const uint8_t> data) {
+    std::vector<uint8_t> result(data.begin(), data.end());
+
+    if (result.size() % 2 != 0) {
+        const auto& info = get_vr_info(vr);
+        result.push_back(static_cast<uint8_t>(info.padding_char));
+    }
+
+    return result;
+}
+
+std::string trim_padding(vr_type vr, std::string_view value) {
+    if (value.empty()) {
+        return std::string{};
+    }
+
+    const auto& info = get_vr_info(vr);
+    char pad = info.padding_char;
+
+    // Find the last non-padding character
+    auto end = value.find_last_not_of(pad);
+    if (end == std::string_view::npos) {
+        // All characters are padding
+        return std::string{};
+    }
+
+    return std::string{value.substr(0, end + 1)};
+}
+
+bool is_valid_charset(vr_type vr, std::string_view value) {
+    switch (vr) {
+        case vr_type::CS:
+            // Code String: A-Z, 0-9, space, underscore
+            return std::all_of(value.begin(), value.end(), is_cs_char);
+
+        case vr_type::DA:
+            // Date: YYYYMMDD format, digits only
+            return value.size() == 8 &&
+                   std::all_of(value.begin(), value.end(), is_da_char);
+
+        case vr_type::TM:
+            // Time: digits, period, colon
+            return std::all_of(value.begin(), value.end(), is_tm_char);
+
+        case vr_type::UI:
+            // UID: digits and periods only, max 64 chars
+            return value.size() <= 64 &&
+                   std::all_of(value.begin(), value.end(), is_ui_char);
+
+        case vr_type::DS:
+            // Decimal String: digits, +, -, ., E, e, space
+            return std::all_of(value.begin(), value.end(), is_ds_char);
+
+        case vr_type::IS:
+            // Integer String: digits, +, -
+            return std::all_of(value.begin(), value.end(), is_is_char);
+
+        case vr_type::AS:
+            // Age String: nnnX format where X is D/W/M/Y
+            if (value.size() != 4) {
+                return false;
+            }
+            return std::all_of(value.begin(), value.end(), is_as_char) &&
+                   (value[3] == 'D' || value[3] == 'W' ||
+                    value[3] == 'M' || value[3] == 'Y');
+
+        case vr_type::DT:
+            // Date Time: digits, period, +, -
+            return std::all_of(value.begin(), value.end(), is_dt_char);
+
+        case vr_type::AE:
+        case vr_type::LO:
+        case vr_type::SH:
+        case vr_type::PN:
+            // These allow most printable characters but no control chars
+            // except leading/trailing spaces
+            return std::all_of(value.begin(), value.end(), is_printable);
+
+        case vr_type::LT:
+        case vr_type::ST:
+        case vr_type::UT:
+        case vr_type::UC:
+        case vr_type::UR:
+            // Text VRs allow all printable plus CR, LF, FF, TAB
+            return std::all_of(value.begin(), value.end(), is_printable);
+
+        default:
+            // Non-string VRs - charset validation not applicable
+            return true;
+    }
+}
+
+}  // namespace pacs::encoding

--- a/tests/encoding/vr_info_test.cpp
+++ b/tests/encoding/vr_info_test.cpp
@@ -1,0 +1,298 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "pacs/encoding/vr_info.hpp"
+
+#include <cstring>
+
+using namespace pacs::encoding;
+
+TEST_CASE("vr_info lookup returns correct properties", "[encoding][vr_info]") {
+    SECTION("Person Name (PN) properties") {
+        const auto& info = get_vr_info(vr_type::PN);
+        CHECK(info.type == vr_type::PN);
+        CHECK(info.name == "Person Name");
+        CHECK(info.max_length == 324);
+        CHECK(info.padding_char == ' ');
+        CHECK_FALSE(info.is_fixed_length);
+        CHECK(info.fixed_size == 0);
+    }
+
+    SECTION("Unsigned Short (US) properties") {
+        const auto& info = get_vr_info(vr_type::US);
+        CHECK(info.type == vr_type::US);
+        CHECK(info.name == "Unsigned Short");
+        CHECK(info.max_length == 2);
+        CHECK(info.padding_char == '\0');
+        CHECK(info.is_fixed_length);
+        CHECK(info.fixed_size == 2);
+    }
+
+    SECTION("Unique Identifier (UI) properties") {
+        const auto& info = get_vr_info(vr_type::UI);
+        CHECK(info.type == vr_type::UI);
+        CHECK(info.name == "Unique Identifier");
+        CHECK(info.max_length == 64);
+        CHECK(info.padding_char == '\0');  // UI uses null padding
+        CHECK_FALSE(info.is_fixed_length);
+    }
+
+    SECTION("Date (DA) properties") {
+        const auto& info = get_vr_info(vr_type::DA);
+        CHECK(info.type == vr_type::DA);
+        CHECK(info.name == "Date");
+        CHECK(info.max_length == 8);
+        CHECK(info.is_fixed_length);
+        CHECK(info.fixed_size == 8);
+    }
+
+    SECTION("Sequence (SQ) properties") {
+        const auto& info = get_vr_info(vr_type::SQ);
+        CHECK(info.type == vr_type::SQ);
+        CHECK(info.name == "Sequence of Items");
+        CHECK_FALSE(info.is_fixed_length);
+    }
+
+    SECTION("Attribute Tag (AT) properties") {
+        const auto& info = get_vr_info(vr_type::AT);
+        CHECK(info.type == vr_type::AT);
+        CHECK(info.name == "Attribute Tag");
+        CHECK(info.max_length == 4);
+        CHECK(info.is_fixed_length);
+        CHECK(info.fixed_size == 4);
+    }
+}
+
+TEST_CASE("validate_string validates Code String (CS)", "[encoding][vr_info]") {
+    SECTION("valid CS values") {
+        CHECK(validate_string(vr_type::CS, "ORIGINAL"));
+        CHECK(validate_string(vr_type::CS, "TYPE_1"));
+        CHECK(validate_string(vr_type::CS, "CT"));
+        CHECK(validate_string(vr_type::CS, "MR"));
+        CHECK(validate_string(vr_type::CS, "TEST 123"));
+    }
+
+    SECTION("invalid CS values") {
+        CHECK_FALSE(validate_string(vr_type::CS, "lowercase"));
+        CHECK_FALSE(validate_string(vr_type::CS, "SPECIAL@CHAR"));
+        CHECK_FALSE(validate_string(vr_type::CS, "HYPHEN-ATED"));
+        CHECK_FALSE(validate_string(vr_type::CS, "TAB\tHERE"));
+    }
+
+    SECTION("CS length validation") {
+        CHECK(validate_string(vr_type::CS, "1234567890123456"));  // 16 chars OK
+        CHECK_FALSE(validate_string(vr_type::CS, "12345678901234567"));  // 17 chars
+    }
+}
+
+TEST_CASE("validate_string validates Date (DA)", "[encoding][vr_info]") {
+    SECTION("valid DA values") {
+        CHECK(validate_string(vr_type::DA, "20250101"));
+        CHECK(validate_string(vr_type::DA, "19850615"));
+        CHECK(validate_string(vr_type::DA, "20001231"));
+    }
+
+    SECTION("invalid DA values") {
+        CHECK_FALSE(validate_string(vr_type::DA, "2025-01-01"));  // Wrong format (dashes)
+        CHECK_FALSE(validate_string(vr_type::DA, "2025/01/01")); // Wrong format (slashes)
+        CHECK_FALSE(validate_string(vr_type::DA, "202501"));      // Too short
+        CHECK_FALSE(validate_string(vr_type::DA, "202501011"));   // Too long
+    }
+}
+
+TEST_CASE("validate_string validates Time (TM)", "[encoding][vr_info]") {
+    SECTION("valid TM values") {
+        CHECK(validate_string(vr_type::TM, "120000"));
+        CHECK(validate_string(vr_type::TM, "235959.999999"));
+        CHECK(validate_string(vr_type::TM, "12:30:00"));
+    }
+
+    SECTION("invalid TM values") {
+        CHECK_FALSE(validate_string(vr_type::TM, "12-30-00"));
+        CHECK_FALSE(validate_string(vr_type::TM, "12h30m00s"));
+    }
+}
+
+TEST_CASE("validate_string validates Unique Identifier (UI)", "[encoding][vr_info]") {
+    SECTION("valid UI values") {
+        CHECK(validate_string(vr_type::UI, "1.2.840.10008.5.1.4.1.1.2"));
+        CHECK(validate_string(vr_type::UI, "1.2.3"));
+        CHECK(validate_string(vr_type::UI, "2.16.840.1.113883.3.51.1.1"));
+    }
+
+    SECTION("invalid UI values") {
+        CHECK_FALSE(validate_string(vr_type::UI, "1.2.840.10008.invalid"));
+        CHECK_FALSE(validate_string(vr_type::UI, "1.2.3.4a"));
+        CHECK_FALSE(validate_string(vr_type::UI, "uid:1.2.3"));
+    }
+
+    SECTION("UI length validation") {
+        // 64 chars is maximum
+        std::string long_uid(65, '1');
+        CHECK_FALSE(validate_string(vr_type::UI, long_uid));
+
+        std::string max_uid(64, '1');
+        CHECK(validate_string(vr_type::UI, max_uid));
+    }
+}
+
+TEST_CASE("validate_string validates Age String (AS)", "[encoding][vr_info]") {
+    SECTION("valid AS values") {
+        CHECK(validate_string(vr_type::AS, "030Y"));  // 30 years
+        CHECK(validate_string(vr_type::AS, "006M"));  // 6 months
+        CHECK(validate_string(vr_type::AS, "012W"));  // 12 weeks
+        CHECK(validate_string(vr_type::AS, "001D"));  // 1 day
+    }
+
+    SECTION("invalid AS values") {
+        CHECK_FALSE(validate_string(vr_type::AS, "30Y"));    // Missing leading zeros
+        CHECK_FALSE(validate_string(vr_type::AS, "030X"));   // Invalid suffix
+        CHECK_FALSE(validate_string(vr_type::AS, "0030Y")); // Too long
+        CHECK_FALSE(validate_string(vr_type::AS, "30"));     // Too short
+    }
+}
+
+TEST_CASE("validate_string validates Decimal String (DS)", "[encoding][vr_info]") {
+    SECTION("valid DS values") {
+        CHECK(validate_string(vr_type::DS, "123.456"));
+        CHECK(validate_string(vr_type::DS, "-123.456"));
+        CHECK(validate_string(vr_type::DS, "+1.5E10"));
+        CHECK(validate_string(vr_type::DS, "1.5e-10"));
+        CHECK(validate_string(vr_type::DS, " 42 "));
+    }
+
+    SECTION("invalid DS values") {
+        CHECK_FALSE(validate_string(vr_type::DS, "12,345"));   // Comma not allowed
+        CHECK_FALSE(validate_string(vr_type::DS, "NaN"));      // Not a number
+    }
+}
+
+TEST_CASE("validate_string validates Integer String (IS)", "[encoding][vr_info]") {
+    SECTION("valid IS values") {
+        CHECK(validate_string(vr_type::IS, "12345"));
+        CHECK(validate_string(vr_type::IS, "-12345"));
+        CHECK(validate_string(vr_type::IS, "+42"));
+    }
+
+    SECTION("invalid IS values") {
+        CHECK_FALSE(validate_string(vr_type::IS, "12.5"));     // Decimal not allowed
+        CHECK_FALSE(validate_string(vr_type::IS, "12 34"));    // Space not allowed
+    }
+}
+
+TEST_CASE("validate_string validates Long String (LO)", "[encoding][vr_info]") {
+    SECTION("valid LO values") {
+        CHECK(validate_string(vr_type::LO, "Patient Name"));
+        CHECK(validate_string(vr_type::LO, "CT Scanner"));
+        CHECK(validate_string(vr_type::LO, "Hospital ABC - Room 123"));
+    }
+
+    SECTION("LO length validation") {
+        std::string max_lo(64, 'A');
+        CHECK(validate_string(vr_type::LO, max_lo));
+
+        std::string too_long(65, 'A');
+        CHECK_FALSE(validate_string(vr_type::LO, too_long));
+    }
+}
+
+TEST_CASE("pad_to_even adds correct padding", "[encoding][vr_info]") {
+    SECTION("string VR padding with space") {
+        std::vector<uint8_t> odd_data = {'T', 'E', 'S', 'T', 'X'};
+        auto padded = pad_to_even(vr_type::LO, odd_data);
+        CHECK(padded.size() == 6);
+        CHECK(padded.back() == ' ');
+    }
+
+    SECTION("even length data not padded") {
+        std::vector<uint8_t> even_data = {'T', 'E', 'S', 'T'};
+        auto padded = pad_to_even(vr_type::LO, even_data);
+        CHECK(padded.size() == 4);
+        CHECK(padded == even_data);
+    }
+
+    SECTION("UI null padding") {
+        std::vector<uint8_t> uid = {'1', '.', '2', '.', '3'};
+        auto padded = pad_to_even(vr_type::UI, uid);
+        CHECK(padded.size() == 6);
+        CHECK(padded.back() == '\0');
+    }
+
+    SECTION("binary VR null padding") {
+        std::vector<uint8_t> data = {0x01, 0x02, 0x03};
+        auto padded = pad_to_even(vr_type::OB, data);
+        CHECK(padded.size() == 4);
+        CHECK(padded.back() == '\0');
+    }
+
+    SECTION("empty data remains empty") {
+        std::vector<uint8_t> empty_data;
+        auto padded = pad_to_even(vr_type::LO, empty_data);
+        CHECK(padded.empty());
+    }
+}
+
+TEST_CASE("trim_padding removes trailing padding", "[encoding][vr_info]") {
+    SECTION("trim trailing spaces for string VRs") {
+        CHECK(trim_padding(vr_type::LO, "TEST   ") == "TEST");
+        CHECK(trim_padding(vr_type::PN, "DOE^JOHN   ") == "DOE^JOHN");
+        CHECK(trim_padding(vr_type::SH, "   TRIM   ") == "   TRIM");  // Only trailing
+    }
+
+    SECTION("trim trailing nulls for UI") {
+        std::string ui_with_null = "1.2.3";
+        ui_with_null += '\0';
+        ui_with_null += '\0';
+        CHECK(trim_padding(vr_type::UI, ui_with_null) == "1.2.3");
+    }
+
+    SECTION("empty string returns empty") {
+        CHECK(trim_padding(vr_type::LO, "") == "");
+    }
+
+    SECTION("all padding returns empty") {
+        CHECK(trim_padding(vr_type::LO, "    ") == "");
+    }
+}
+
+TEST_CASE("is_valid_charset validates character sets", "[encoding][vr_info]") {
+    SECTION("CS charset") {
+        CHECK(is_valid_charset(vr_type::CS, "VALID_CODE"));
+        CHECK_FALSE(is_valid_charset(vr_type::CS, "invalid"));
+    }
+
+    SECTION("UI charset") {
+        CHECK(is_valid_charset(vr_type::UI, "1.2.840.10008"));
+        CHECK_FALSE(is_valid_charset(vr_type::UI, "1.2.3.abc"));
+    }
+
+    SECTION("Text VRs allow control characters") {
+        CHECK(is_valid_charset(vr_type::LT, "Line1\nLine2"));
+        CHECK(is_valid_charset(vr_type::ST, "Tab\there"));
+    }
+}
+
+TEST_CASE("validate_value validates binary data", "[encoding][vr_info]") {
+    SECTION("valid US value") {
+        std::vector<uint8_t> us_data = {0x01, 0x00};  // 2 bytes
+        CHECK(validate_value(vr_type::US, us_data));
+
+        // Multiple values (VM > 1)
+        std::vector<uint8_t> multi_us = {0x01, 0x00, 0x02, 0x00};  // 4 bytes
+        CHECK(validate_value(vr_type::US, multi_us));
+    }
+
+    SECTION("invalid US value - odd size") {
+        std::vector<uint8_t> invalid_us = {0x01, 0x00, 0x02};  // 3 bytes
+        CHECK_FALSE(validate_value(vr_type::US, invalid_us));
+    }
+
+    SECTION("valid string value as bytes") {
+        std::vector<uint8_t> cs_data = {'O', 'R', 'I', 'G', 'I', 'N', 'A', 'L'};
+        CHECK(validate_value(vr_type::CS, cs_data));
+    }
+
+    SECTION("invalid string value as bytes") {
+        std::vector<uint8_t> invalid_cs = {'l', 'o', 'w', 'e', 'r'};  // lowercase
+        CHECK_FALSE(validate_value(vr_type::CS, invalid_cs));
+    }
+}


### PR DESCRIPTION
## Summary

- Add `vr_info` struct containing comprehensive VR metadata (name, max_length, padding_char, is_fixed_length, fixed_size)
- Implement `get_vr_info()` for O(1) VR property lookup using hash map
- Add `validate_value()` and `validate_string()` for VR-specific format validation
- Implement `pad_to_even()` and `trim_padding()` for DICOM even-length requirements
- Add `is_valid_charset()` for character set validation per VR type

## Implementation Details

### VR Properties Table
Static table covering all 31 standard DICOM VRs with properties from PS3.5:
- String VRs: AE, AS, CS, DA, DS, DT, IS, LO, LT, PN, SH, ST, TM, UC, UI, UR, UT
- Numeric VRs: FL, FD, SL, SS, SV, UL, US, UV
- Binary VRs: OB, OD, OF, OL, OV, OW, UN
- Special VRs: AT, SQ

### Validation Logic
- CS: A-Z, 0-9, space, underscore only
- DA: 8 digits (YYYYMMDD format)
- TM: digits, period, colon
- UI: digits and periods only (max 64 chars)
- AS: 4 chars in nnnX format (X = D/W/M/Y)
- Fixed-length VRs: size must be multiple of fixed_size (supports VM > 1)

## Test Plan

- [x] VR info lookup returns correct properties for all VR types
- [x] CS validation rejects lowercase and special characters
- [x] DA validation enforces 8-digit format
- [x] UI validation enforces digits and periods only
- [x] AS validation enforces nnnX format
- [x] Padding utilities add correct padding character
- [x] Trim utilities remove trailing padding
- [x] Binary data validation supports VM > 1

All 524 assertions in 29 test cases pass.

Closes #16