### PR TITLE
[DES-STOR-001] Implement storage_interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,6 +344,7 @@ message(STATUS "  [OK] pacs_services: ON")
 # Storage library
 if(PACS_BUILD_STORAGE AND SQLITE3_FOUND)
     add_library(pacs_storage
+        src/storage/storage_interface.cpp
         src/storage/migration_runner.cpp
         src/storage/index_database.cpp
     )
@@ -365,6 +366,9 @@ if(PACS_BUILD_STORAGE AND SQLITE3_FOUND)
     else()
         target_link_libraries(pacs_storage PUBLIC SQLite::SQLite3)
     endif()
+
+    # Link pacs_core for dicom_dataset
+    target_link_libraries(pacs_storage PUBLIC pacs_core)
 
     message(STATUS "  [OK] pacs_storage: ON (SQLite3)")
 else()
@@ -473,6 +477,7 @@ if(PACS_BUILD_TESTS)
     # Storage tests
     if(TARGET pacs_storage)
         add_executable(storage_tests
+            tests/storage/storage_interface_test.cpp
             tests/storage/migration_runner_test.cpp
             tests/storage/index_database_test.cpp
         )

--- a/include/pacs/storage/storage_interface.hpp
+++ b/include/pacs/storage/storage_interface.hpp
@@ -1,0 +1,227 @@
+/**
+ * @file storage_interface.hpp
+ * @brief Abstract storage interface for DICOM persistent storage backends
+ *
+ * This file defines the abstract storage_interface class which provides
+ * a unified API for DICOM data persistence. Concrete implementations
+ * (file_storage, cloud_storage, etc.) must inherit from this interface.
+ *
+ * @see SRS-STOR-001, FR-4.1
+ */
+
+#pragma once
+
+#include <pacs/core/dicom_dataset.hpp>
+
+#include <kcenon/common/patterns/result.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::storage {
+
+/// Result type alias for operations returning a value
+template <typename T>
+using Result = kcenon::common::Result<T>;
+
+/// Result type alias for void operations
+using VoidResult = kcenon::common::VoidResult;
+
+/**
+ * @brief Storage statistics structure
+ *
+ * Contains aggregated metrics about the storage backend's state.
+ */
+struct storage_statistics {
+    /// Total number of DICOM instances stored
+    std::size_t total_instances{0};
+
+    /// Total storage size in bytes
+    std::size_t total_bytes{0};
+
+    /// Number of unique studies
+    std::size_t studies_count{0};
+
+    /// Number of unique series
+    std::size_t series_count{0};
+
+    /// Number of unique patients
+    std::size_t patients_count{0};
+};
+
+/**
+ * @brief Abstract storage interface for DICOM persistence
+ *
+ * Provides a unified API for storing, retrieving, and querying DICOM data.
+ * All concrete storage implementations must inherit from this interface.
+ *
+ * Thread Safety:
+ * - All methods must be thread-safe in concrete implementations
+ * - Concurrent reads are allowed
+ * - Writes must be atomic
+ *
+ * @example
+ * @code
+ * // Using a concrete implementation (e.g., file_storage)
+ * std::unique_ptr<storage_interface> storage =
+ *     std::make_unique<file_storage>("/path/to/storage");
+ *
+ * // Store a DICOM dataset
+ * core::dicom_dataset dataset;
+ * // ... populate dataset ...
+ * auto result = storage->store(dataset);
+ *
+ * // Retrieve by SOP Instance UID
+ * auto retrieved = storage->retrieve("1.2.3.4.5.6.7.8.9");
+ *
+ * // Query for studies
+ * core::dicom_dataset query;
+ * query.set_string(tags::patient_id, vr_type::LO, "12345");
+ * auto matches = storage->find(query);
+ * @endcode
+ */
+class storage_interface {
+public:
+    /// Virtual destructor for proper polymorphic destruction
+    virtual ~storage_interface() = default;
+
+    // =========================================================================
+    // CRUD Operations
+    // =========================================================================
+
+    /**
+     * @brief Store a DICOM dataset
+     *
+     * Stores the dataset using its SOP Instance UID as the key.
+     * If a dataset with the same UID already exists, it will be replaced.
+     *
+     * @param dataset The DICOM dataset to store
+     * @return VoidResult Success or error information
+     *
+     * @note The dataset must contain a valid SOP Instance UID (0008,0018)
+     */
+    [[nodiscard]] virtual auto store(const core::dicom_dataset& dataset)
+        -> VoidResult = 0;
+
+    /**
+     * @brief Retrieve a DICOM dataset by SOP Instance UID
+     *
+     * @param sop_instance_uid The unique identifier for the instance
+     * @return Result containing the dataset or error information
+     */
+    [[nodiscard]] virtual auto retrieve(std::string_view sop_instance_uid)
+        -> Result<core::dicom_dataset> = 0;
+
+    /**
+     * @brief Remove a DICOM dataset by SOP Instance UID
+     *
+     * @param sop_instance_uid The unique identifier for the instance to remove
+     * @return VoidResult Success or error information
+     *
+     * @note Removing a non-existent instance is not considered an error
+     */
+    [[nodiscard]] virtual auto remove(std::string_view sop_instance_uid)
+        -> VoidResult = 0;
+
+    /**
+     * @brief Check if a DICOM instance exists
+     *
+     * @param sop_instance_uid The unique identifier to check
+     * @return true if the instance exists, false otherwise
+     */
+    [[nodiscard]] virtual auto exists(std::string_view sop_instance_uid) const
+        -> bool = 0;
+
+    // =========================================================================
+    // Query Operations
+    // =========================================================================
+
+    /**
+     * @brief Find DICOM datasets matching query criteria
+     *
+     * Performs a search using DICOM C-FIND semantics. The query dataset
+     * contains the search criteria where empty values act as wildcards.
+     *
+     * @param query The query dataset containing search criteria
+     * @return Result containing matching datasets or error information
+     *
+     * @note Supports standard DICOM wildcard matching (* and ?)
+     */
+    [[nodiscard]] virtual auto find(const core::dicom_dataset& query)
+        -> Result<std::vector<core::dicom_dataset>> = 0;
+
+    // =========================================================================
+    // Batch Operations
+    // =========================================================================
+
+    /**
+     * @brief Store multiple DICOM datasets in a single operation
+     *
+     * Default implementation calls store() for each dataset.
+     * Concrete implementations may override for better performance.
+     *
+     * @param datasets The collection of datasets to store
+     * @return VoidResult Success or error information
+     *
+     * @note On error, some datasets may have been stored
+     */
+    [[nodiscard]] virtual auto store_batch(
+        const std::vector<core::dicom_dataset>& datasets) -> VoidResult;
+
+    /**
+     * @brief Retrieve multiple DICOM datasets by their SOP Instance UIDs
+     *
+     * Default implementation calls retrieve() for each UID.
+     * Concrete implementations may override for better performance.
+     *
+     * @param sop_instance_uids The collection of UIDs to retrieve
+     * @return Result containing found datasets or error information
+     *
+     * @note Missing instances are silently skipped in the result
+     */
+    [[nodiscard]] virtual auto retrieve_batch(
+        const std::vector<std::string>& sop_instance_uids)
+        -> Result<std::vector<core::dicom_dataset>>;
+
+    // =========================================================================
+    // Maintenance Operations
+    // =========================================================================
+
+    /**
+     * @brief Get storage statistics
+     *
+     * Returns aggregated metrics about the current state of storage.
+     *
+     * @return Storage statistics structure
+     */
+    [[nodiscard]] virtual auto get_statistics() const
+        -> storage_statistics = 0;
+
+    /**
+     * @brief Verify storage integrity
+     *
+     * Performs a consistency check on the storage backend.
+     * The specific checks depend on the implementation.
+     *
+     * @return VoidResult Success if integrity is verified, error otherwise
+     */
+    [[nodiscard]] virtual auto verify_integrity() -> VoidResult = 0;
+
+protected:
+    /// Protected default constructor for derived classes
+    storage_interface() = default;
+
+    /// Non-copyable
+    storage_interface(const storage_interface&) = delete;
+    storage_interface& operator=(const storage_interface&) = delete;
+
+    /// Movable
+    storage_interface(storage_interface&&) = default;
+    storage_interface& operator=(storage_interface&&) = default;
+};
+
+}  // namespace pacs::storage

--- a/src/storage/storage_interface.cpp
+++ b/src/storage/storage_interface.cpp
@@ -1,0 +1,46 @@
+/**
+ * @file storage_interface.cpp
+ * @brief Default implementations for storage_interface batch operations
+ */
+
+#include <pacs/storage/storage_interface.hpp>
+
+namespace pacs::storage {
+
+// Use common_system's ok() function
+using kcenon::common::ok;
+using kcenon::common::make_error;
+
+// ============================================================================
+// Default Batch Operation Implementations
+// ============================================================================
+
+auto storage_interface::store_batch(
+    const std::vector<core::dicom_dataset>& datasets) -> VoidResult {
+    for (const auto& dataset : datasets) {
+        auto result = store(dataset);
+        if (result.is_err()) {
+            return result;
+        }
+    }
+    return ok();
+}
+
+auto storage_interface::retrieve_batch(
+    const std::vector<std::string>& sop_instance_uids)
+    -> Result<std::vector<core::dicom_dataset>> {
+    std::vector<core::dicom_dataset> results;
+    results.reserve(sop_instance_uids.size());
+
+    for (const auto& uid : sop_instance_uids) {
+        auto result = retrieve(uid);
+        if (result.is_ok()) {
+            results.push_back(std::move(result.value()));
+        }
+        // Silently skip missing instances as per interface contract
+    }
+
+    return results;
+}
+
+}  // namespace pacs::storage

--- a/tests/storage/storage_interface_test.cpp
+++ b/tests/storage/storage_interface_test.cpp
@@ -1,0 +1,285 @@
+/**
+ * @file storage_interface_test.cpp
+ * @brief Unit tests for storage_interface abstract class
+ *
+ * Tests the storage_interface contract using a mock implementation.
+ */
+
+#include <pacs/storage/storage_interface.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <map>
+#include <string>
+
+using namespace pacs::storage;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+namespace {
+
+/**
+ * @brief Mock storage implementation for testing
+ *
+ * Implements storage_interface using an in-memory map.
+ */
+class mock_storage : public storage_interface {
+public:
+    mock_storage() = default;
+
+    auto store(const dicom_dataset& dataset) -> VoidResult override {
+        // Extract SOP Instance UID for key
+        auto uid = dataset.get_string(dicom_tag{0x0008, 0x0018});
+        if (uid.empty()) {
+            return kcenon::common::make_error<std::monostate>(
+                -1, "SOP Instance UID is required", "storage");
+        }
+
+        storage_[uid] = dataset;
+        return kcenon::common::ok();
+    }
+
+    auto retrieve(std::string_view sop_instance_uid)
+        -> Result<dicom_dataset> override {
+        auto it = storage_.find(std::string{sop_instance_uid});
+        if (it == storage_.end()) {
+            return kcenon::common::make_error<dicom_dataset>(
+                -1, "Instance not found", "storage");
+        }
+        return it->second;
+    }
+
+    auto remove(std::string_view sop_instance_uid) -> VoidResult override {
+        storage_.erase(std::string{sop_instance_uid});
+        return kcenon::common::ok();
+    }
+
+    auto exists(std::string_view sop_instance_uid) const -> bool override {
+        return storage_.contains(std::string{sop_instance_uid});
+    }
+
+    auto find(const dicom_dataset& query)
+        -> Result<std::vector<dicom_dataset>> override {
+        std::vector<dicom_dataset> results;
+
+        // Simple implementation: return all if query is empty
+        auto query_patient_id = query.get_string(dicom_tag{0x0010, 0x0020});
+
+        for (const auto& [uid, dataset] : storage_) {
+            if (query_patient_id.empty()) {
+                results.push_back(dataset);
+            } else {
+                auto ds_patient_id =
+                    dataset.get_string(dicom_tag{0x0010, 0x0020});
+                if (ds_patient_id == query_patient_id) {
+                    results.push_back(dataset);
+                }
+            }
+        }
+
+        return results;
+    }
+
+    auto get_statistics() const -> storage_statistics override {
+        storage_statistics stats;
+        stats.total_instances = storage_.size();
+        return stats;
+    }
+
+    auto verify_integrity() -> VoidResult override {
+        return kcenon::common::ok();
+    }
+
+private:
+    std::map<std::string, dicom_dataset> storage_;
+};
+
+/**
+ * @brief Helper to create a test dataset with SOP Instance UID
+ */
+auto create_test_dataset(const std::string& sop_uid,
+                         const std::string& patient_id = "P001")
+    -> dicom_dataset {
+    dicom_dataset ds;
+    ds.set_string(dicom_tag{0x0008, 0x0018}, vr_type::UI, sop_uid);
+    ds.set_string(dicom_tag{0x0010, 0x0020}, vr_type::LO, patient_id);
+    return ds;
+}
+
+}  // namespace
+
+// ============================================================================
+// Interface Contract Tests
+// ============================================================================
+
+TEST_CASE("storage_interface: store and retrieve", "[storage][interface]") {
+    mock_storage storage;
+
+    auto dataset = create_test_dataset("1.2.3.4.5.6.7", "PAT001");
+
+    SECTION("store returns success") {
+        auto result = storage.store(dataset);
+        REQUIRE(result.is_ok());
+    }
+
+    SECTION("retrieve after store returns dataset") {
+        REQUIRE(storage.store(dataset).is_ok());
+
+        auto result = storage.retrieve("1.2.3.4.5.6.7");
+        REQUIRE(result.is_ok());
+        CHECK(result.value().get_string(dicom_tag{0x0010, 0x0020}) == "PAT001");
+    }
+
+    SECTION("retrieve non-existent returns error") {
+        auto result = storage.retrieve("nonexistent");
+        REQUIRE(result.is_err());
+    }
+}
+
+TEST_CASE("storage_interface: exists check", "[storage][interface]") {
+    mock_storage storage;
+
+    auto dataset = create_test_dataset("1.2.3.4.5.6.7");
+
+    CHECK_FALSE(storage.exists("1.2.3.4.5.6.7"));
+
+    REQUIRE(storage.store(dataset).is_ok());
+
+    CHECK(storage.exists("1.2.3.4.5.6.7"));
+    CHECK_FALSE(storage.exists("nonexistent"));
+}
+
+TEST_CASE("storage_interface: remove", "[storage][interface]") {
+    mock_storage storage;
+
+    auto dataset = create_test_dataset("1.2.3.4.5.6.7");
+    REQUIRE(storage.store(dataset).is_ok());
+    CHECK(storage.exists("1.2.3.4.5.6.7"));
+
+    auto result = storage.remove("1.2.3.4.5.6.7");
+    REQUIRE(result.is_ok());
+    CHECK_FALSE(storage.exists("1.2.3.4.5.6.7"));
+
+    // Remove non-existent should not error
+    result = storage.remove("nonexistent");
+    CHECK(result.is_ok());
+}
+
+TEST_CASE("storage_interface: find", "[storage][interface]") {
+    mock_storage storage;
+
+    auto ds1 = create_test_dataset("1.2.3.1", "PAT001");
+    auto ds2 = create_test_dataset("1.2.3.2", "PAT001");
+    auto ds3 = create_test_dataset("1.2.3.3", "PAT002");
+
+    REQUIRE(storage.store(ds1).is_ok());
+    REQUIRE(storage.store(ds2).is_ok());
+    REQUIRE(storage.store(ds3).is_ok());
+
+    SECTION("find all") {
+        dicom_dataset empty_query;
+        auto result = storage.find(empty_query);
+
+        REQUIRE(result.is_ok());
+        CHECK(result.value().size() == 3);
+    }
+
+    SECTION("find by patient") {
+        dicom_dataset query;
+        query.set_string(dicom_tag{0x0010, 0x0020}, vr_type::LO,
+                         "PAT001");
+
+        auto result = storage.find(query);
+
+        REQUIRE(result.is_ok());
+        CHECK(result.value().size() == 2);
+    }
+}
+
+// ============================================================================
+// Batch Operation Tests
+// ============================================================================
+
+TEST_CASE("storage_interface: store_batch default implementation",
+          "[storage][interface][batch]") {
+    mock_storage storage;
+
+    std::vector<dicom_dataset> datasets;
+    datasets.push_back(create_test_dataset("1.2.3.1", "PAT001"));
+    datasets.push_back(create_test_dataset("1.2.3.2", "PAT002"));
+    datasets.push_back(create_test_dataset("1.2.3.3", "PAT003"));
+
+    auto result = storage.store_batch(datasets);
+
+    REQUIRE(result.is_ok());
+    CHECK(storage.exists("1.2.3.1"));
+    CHECK(storage.exists("1.2.3.2"));
+    CHECK(storage.exists("1.2.3.3"));
+}
+
+TEST_CASE("storage_interface: retrieve_batch default implementation",
+          "[storage][interface][batch]") {
+    mock_storage storage;
+
+    REQUIRE(storage.store(create_test_dataset("1.2.3.1", "PAT001")).is_ok());
+    REQUIRE(storage.store(create_test_dataset("1.2.3.2", "PAT002")).is_ok());
+    REQUIRE(storage.store(create_test_dataset("1.2.3.3", "PAT003")).is_ok());
+
+    SECTION("retrieve existing instances") {
+        std::vector<std::string> uids{"1.2.3.1", "1.2.3.2", "1.2.3.3"};
+        auto result = storage.retrieve_batch(uids);
+
+        REQUIRE(result.is_ok());
+        CHECK(result.value().size() == 3);
+    }
+
+    SECTION("retrieve with some missing instances") {
+        std::vector<std::string> uids{"1.2.3.1", "nonexistent", "1.2.3.3"};
+        auto result = storage.retrieve_batch(uids);
+
+        REQUIRE(result.is_ok());
+        CHECK(result.value().size() == 2);  // Missing ones silently skipped
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("storage_interface: get_statistics", "[storage][interface]") {
+    mock_storage storage;
+
+    auto stats = storage.get_statistics();
+    CHECK(stats.total_instances == 0);
+
+    REQUIRE(storage.store(create_test_dataset("1.2.3.1")).is_ok());
+    REQUIRE(storage.store(create_test_dataset("1.2.3.2")).is_ok());
+
+    stats = storage.get_statistics();
+    CHECK(stats.total_instances == 2);
+}
+
+// ============================================================================
+// Integrity Verification Tests
+// ============================================================================
+
+TEST_CASE("storage_interface: verify_integrity", "[storage][interface]") {
+    mock_storage storage;
+
+    auto result = storage.verify_integrity();
+    CHECK(result.is_ok());
+}
+
+// ============================================================================
+// Storage Statistics Structure Tests
+// ============================================================================
+
+TEST_CASE("storage_statistics: default initialization", "[storage][interface]") {
+    storage_statistics stats;
+
+    CHECK(stats.total_instances == 0);
+    CHECK(stats.total_bytes == 0);
+    CHECK(stats.studies_count == 0);
+    CHECK(stats.series_count == 0);
+    CHECK(stats.patients_count == 0);
+}


### PR DESCRIPTION
## Summary
- Implement abstract storage interface for DICOM persistent storage backends
- Define CRUD operations (store, retrieve, remove, exists)
- Add query operation with C-FIND semantics
- Implement default batch operations for bulk processing
- Include storage_statistics for metrics and verify_integrity for health checks
- Add comprehensive unit tests using mock implementation

## Acceptance Criteria
- [x] Interface defined with all CRUD operations
- [x] Query operation defined
- [x] Batch operation defaults implemented
- [x] Statistics structure added
- [x] Documentation complete
- [x] Unit tests pass (809 assertions in 108 test cases)

## Test plan
- [x] Run `./build/bin/storage_tests` - All tests pass
- [x] Verify new interface tests cover store, retrieve, remove, exists
- [x] Verify batch operations work with default implementation
- [x] Verify statistics structure initialization

Closes #32