### PR TITLE
feat(services): implement MPPS SCP (N-CREATE/N-SET)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,7 @@ add_library(pacs_services
     src/services/query_scp.cpp
     src/services/retrieve_scp.cpp
     src/services/worklist_scp.cpp
+    src/services/mpps_scp.cpp
 )
 target_include_directories(pacs_services
     PUBLIC
@@ -611,6 +612,7 @@ if(PACS_BUILD_TESTS)
         tests/services/query_scp_test.cpp
         tests/services/retrieve_scp_test.cpp
         tests/services/worklist_scp_test.cpp
+        tests/services/mpps_scp_test.cpp
     )
     target_link_libraries(services_tests
         PRIVATE

--- a/include/pacs/services/mpps_scp.hpp
+++ b/include/pacs/services/mpps_scp.hpp
@@ -1,0 +1,450 @@
+/**
+ * @file mpps_scp.hpp
+ * @brief DICOM MPPS (Modality Performed Procedure Step) SCP service
+ *
+ * This file provides the mpps_scp class for handling N-CREATE and N-SET
+ * requests to track exam progress from modality devices.
+ *
+ * @see DICOM PS3.4 Section F - MPPS SOP Class
+ * @see DICOM PS3.7 Section 10 - DIMSE-N Services
+ * @see DES-SVC-007 - MPPS SCP Design Specification
+ */
+
+#ifndef PACS_SERVICES_MPPS_SCP_HPP
+#define PACS_SERVICES_MPPS_SCP_HPP
+
+#include "scp_service.hpp"
+
+#include <atomic>
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace pacs::services {
+
+// =============================================================================
+// SOP Class UID
+// =============================================================================
+
+/// MPPS (Modality Performed Procedure Step) SOP Class UID
+inline constexpr std::string_view mpps_sop_class_uid = "1.2.840.10008.3.1.2.3.3";
+
+// =============================================================================
+// MPPS Types
+// =============================================================================
+
+/**
+ * @brief MPPS status enumeration
+ *
+ * Defines valid states for a Modality Performed Procedure Step.
+ * COMPLETED and DISCONTINUED are final (terminal) states.
+ */
+enum class mpps_status {
+    in_progress,   ///< Procedure is currently being performed
+    completed,     ///< Procedure completed successfully
+    discontinued   ///< Procedure was stopped/cancelled
+};
+
+/**
+ * @brief Convert mpps_status to DICOM string representation
+ *
+ * @param status The status enum value
+ * @return DICOM-compliant string ("IN PROGRESS", "COMPLETED", "DISCONTINUED")
+ */
+[[nodiscard]] inline auto to_string(mpps_status status) -> std::string_view {
+    switch (status) {
+        case mpps_status::in_progress:
+            return "IN PROGRESS";
+        case mpps_status::completed:
+            return "COMPLETED";
+        case mpps_status::discontinued:
+            return "DISCONTINUED";
+        default:
+            return "IN PROGRESS";
+    }
+}
+
+/**
+ * @brief Parse DICOM string to mpps_status enum
+ *
+ * @param str The DICOM string representation
+ * @return Optional containing the status if valid, nullopt otherwise
+ */
+[[nodiscard]] inline auto parse_mpps_status(std::string_view str)
+    -> std::optional<mpps_status> {
+    if (str == "IN PROGRESS") {
+        return mpps_status::in_progress;
+    }
+    if (str == "COMPLETED") {
+        return mpps_status::completed;
+    }
+    if (str == "DISCONTINUED") {
+        return mpps_status::discontinued;
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief MPPS instance data structure
+ *
+ * Contains information extracted from N-CREATE requests.
+ */
+struct mpps_instance {
+    /// SOP Instance UID - unique identifier for this MPPS
+    std::string sop_instance_uid;
+
+    /// Current status (always IN PROGRESS for N-CREATE)
+    mpps_status status{mpps_status::in_progress};
+
+    /// Performing station AE Title
+    std::string station_ae;
+
+    /// Complete MPPS dataset from the request
+    core::dicom_dataset data;
+};
+
+// =============================================================================
+// Handler Types
+// =============================================================================
+
+/**
+ * @brief N-CREATE handler function type
+ *
+ * Called when an N-CREATE request is received to create a new MPPS instance.
+ *
+ * @param instance The MPPS instance data from the N-CREATE request
+ * @return Success if the instance was created, error description otherwise
+ */
+using mpps_create_handler = std::function<network::Result<std::monostate>(
+    const mpps_instance& instance)>;
+
+/**
+ * @brief N-SET handler function type
+ *
+ * Called when an N-SET request is received to update an existing MPPS instance.
+ *
+ * @param sop_instance_uid The SOP Instance UID of the MPPS to update
+ * @param modifications The dataset containing the modifications
+ * @param new_status The new status (COMPLETED or DISCONTINUED)
+ * @return Success if the instance was updated, error description otherwise
+ */
+using mpps_set_handler = std::function<network::Result<std::monostate>(
+    const std::string& sop_instance_uid,
+    const core::dicom_dataset& modifications,
+    mpps_status new_status)>;
+
+// =============================================================================
+// MPPS SCP Class
+// =============================================================================
+
+/**
+ * @brief MPPS SCP service for handling N-CREATE and N-SET requests
+ *
+ * The MPPS SCP (Service Class Provider) responds to MPPS N-CREATE and N-SET
+ * requests from modality devices. It tracks the progress of performed
+ * procedure steps and enables workflow integration with RIS/HIS systems.
+ *
+ * ## MPPS Message Flow
+ *
+ * ```
+ * Modality (CT/MR/etc)                    PACS/RIS (MPPS SCP)
+ *  │                                       │
+ *  │  [Exam Started]                       │
+ *  │                                       │
+ *  │  N-CREATE-RQ                          │
+ *  │  ┌───────────────────────────────────┐│
+ *  │  │ AffectedSOPClass: MPPS            ││
+ *  │  │ AffectedSOPInstance: 1.2.3...     ││
+ *  │  │ Status: "IN PROGRESS"             ││
+ *  │  │ PerformedStationAETitle: CT_01    ││
+ *  │  │ PerformedProcedureStepStartDate   ││
+ *  │  │ ScheduledStepAttributesSequence   ││
+ *  │  └───────────────────────────────────┘│
+ *  │──────────────────────────────────────►│
+ *  │                                       │
+ *  │                               Store   │
+ *  │                               instance│
+ *  │                                       │
+ *  │  N-CREATE-RSP (Success)               │
+ *  │◄──────────────────────────────────────│
+ *  │                                       │
+ *  │  [Exam Completed]                     │
+ *  │                                       │
+ *  │  N-SET-RQ                             │
+ *  │  ┌───────────────────────────────────┐│
+ *  │  │ RequestedSOPInstance: 1.2.3...    ││
+ *  │  │ Status: "COMPLETED"               ││
+ *  │  │ PerformedProcedureStepEndDate     ││
+ *  │  │ PerformedSeriesSequence           ││
+ *  │  └───────────────────────────────────┘│
+ *  │──────────────────────────────────────►│
+ *  │                                       │
+ *  │  N-SET-RSP (Success)                  │
+ *  │◄──────────────────────────────────────│
+ * ```
+ *
+ * ## MPPS State Machine
+ *
+ * ```
+ *     N-CREATE (status = "IN PROGRESS")
+ *                   │
+ *                   ▼
+ *          ┌─────────────────┐
+ *          │   IN PROGRESS   │
+ *          └────────┬────────┘
+ *                   │
+ *       ┌───────────┼───────────┐
+ *       │ N-SET     │     N-SET │
+ *       │ COMPLETED │ DISCONTINUED
+ *       ▼                       ▼
+ *  ┌───────────┐       ┌──────────────┐
+ *  │ COMPLETED │       │ DISCONTINUED │
+ *  └───────────┘       └──────────────┘
+ *
+ *  Note: COMPLETED and DISCONTINUED are final states
+ * ```
+ *
+ * @example Usage
+ * @code
+ * mpps_scp scp;
+ *
+ * // Set up N-CREATE handler
+ * scp.set_create_handler([&database](const mpps_instance& inst) {
+ *     return database.create_mpps(inst);
+ * });
+ *
+ * // Set up N-SET handler
+ * scp.set_set_handler([&database](const auto& uid, const auto& mods, auto status) {
+ *     return database.update_mpps(uid, mods, status);
+ * });
+ *
+ * // Handle incoming MPPS request
+ * auto result = scp.handle_message(association, context_id, request);
+ * @endcode
+ */
+class mpps_scp final : public scp_service {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    mpps_scp();
+    ~mpps_scp() override = default;
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    /**
+     * @brief Set the N-CREATE handler function
+     *
+     * The handler is called for each N-CREATE request to create a new
+     * MPPS instance in the database or forward to RIS/HIS.
+     *
+     * @param handler The N-CREATE handler function
+     */
+    void set_create_handler(mpps_create_handler handler);
+
+    /**
+     * @brief Set the N-SET handler function
+     *
+     * The handler is called for each N-SET request to update an existing
+     * MPPS instance with COMPLETED or DISCONTINUED status.
+     *
+     * @param handler The N-SET handler function
+     */
+    void set_set_handler(mpps_set_handler handler);
+
+    // =========================================================================
+    // scp_service Interface Implementation
+    // =========================================================================
+
+    /**
+     * @brief Get supported SOP Class UIDs
+     *
+     * @return Vector containing MPPS SOP Class UID
+     */
+    [[nodiscard]] std::vector<std::string> supported_sop_classes() const override;
+
+    /**
+     * @brief Handle an incoming DIMSE message (N-CREATE-RQ or N-SET-RQ)
+     *
+     * Processes N-CREATE and N-SET requests for MPPS management.
+     *
+     * @param assoc The association on which the message was received
+     * @param context_id The presentation context ID for the message
+     * @param request The incoming N-CREATE-RQ or N-SET-RQ message
+     * @return Success or error if the message cannot be processed
+     */
+    [[nodiscard]] network::Result<std::monostate> handle_message(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request) override;
+
+    /**
+     * @brief Get the service name
+     *
+     * @return "MPPS SCP"
+     */
+    [[nodiscard]] std::string_view service_name() const noexcept override;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    /**
+     * @brief Get total number of N-CREATE requests processed
+     *
+     * @return Number of MPPS instances created
+     */
+    [[nodiscard]] size_t creates_processed() const noexcept;
+
+    /**
+     * @brief Get total number of N-SET requests processed
+     *
+     * @return Number of MPPS instances updated
+     */
+    [[nodiscard]] size_t sets_processed() const noexcept;
+
+    /**
+     * @brief Get number of MPPS completed successfully
+     *
+     * @return Number of MPPS with COMPLETED status
+     */
+    [[nodiscard]] size_t mpps_completed() const noexcept;
+
+    /**
+     * @brief Get number of MPPS discontinued
+     *
+     * @return Number of MPPS with DISCONTINUED status
+     */
+    [[nodiscard]] size_t mpps_discontinued() const noexcept;
+
+    /**
+     * @brief Reset statistics counters
+     */
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    /**
+     * @brief Handle N-CREATE request
+     *
+     * Creates a new MPPS instance with IN PROGRESS status.
+     *
+     * @param assoc The association
+     * @param context_id The presentation context ID
+     * @param request The N-CREATE-RQ message
+     * @return Success or error
+     */
+    [[nodiscard]] network::Result<std::monostate> handle_n_create(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    /**
+     * @brief Handle N-SET request
+     *
+     * Updates an existing MPPS instance to COMPLETED or DISCONTINUED.
+     *
+     * @param assoc The association
+     * @param context_id The presentation context ID
+     * @param request The N-SET-RQ message
+     * @return Success or error
+     */
+    [[nodiscard]] network::Result<std::monostate> handle_n_set(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    /**
+     * @brief Send N-CREATE response
+     *
+     * @param assoc The association
+     * @param context_id The presentation context ID
+     * @param message_id The original request message ID
+     * @param sop_instance_uid The SOP Instance UID
+     * @param status The response status code
+     * @return Success or error
+     */
+    [[nodiscard]] network::Result<std::monostate> send_n_create_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid,
+        network::dimse::status_code status);
+
+    /**
+     * @brief Send N-SET response
+     *
+     * @param assoc The association
+     * @param context_id The presentation context ID
+     * @param message_id The original request message ID
+     * @param sop_instance_uid The SOP Instance UID
+     * @param status The response status code
+     * @return Success or error
+     */
+    [[nodiscard]] network::Result<std::monostate> send_n_set_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid,
+        network::dimse::status_code status);
+
+    // =========================================================================
+    // Member Variables
+    // =========================================================================
+
+    mpps_create_handler create_handler_;
+    mpps_set_handler set_handler_;
+
+    std::atomic<size_t> creates_processed_{0};
+    std::atomic<size_t> sets_processed_{0};
+    std::atomic<size_t> mpps_completed_{0};
+    std::atomic<size_t> mpps_discontinued_{0};
+};
+
+// =============================================================================
+// MPPS DICOM Tags (Group 0x0040)
+// =============================================================================
+
+namespace mpps_tags {
+
+/// Performed Station AE Title (0040,0241)
+inline constexpr core::dicom_tag performed_station_ae_title{0x0040, 0x0241};
+
+/// Performed Station Name (0040,0242)
+inline constexpr core::dicom_tag performed_station_name{0x0040, 0x0242};
+
+/// Performed Location (0040,0243)
+inline constexpr core::dicom_tag performed_location{0x0040, 0x0243};
+
+/// Performed Procedure Step End Date (0040,0250)
+inline constexpr core::dicom_tag performed_procedure_step_end_date{0x0040, 0x0250};
+
+/// Performed Procedure Step End Time (0040,0251)
+inline constexpr core::dicom_tag performed_procedure_step_end_time{0x0040, 0x0251};
+
+/// Performed Procedure Step Status (0040,0252)
+inline constexpr core::dicom_tag performed_procedure_step_status{0x0040, 0x0252};
+
+/// Performed Procedure Step ID (0040,0253)
+inline constexpr core::dicom_tag performed_procedure_step_id{0x0040, 0x0253};
+
+/// Performed Series Sequence (0040,0340)
+inline constexpr core::dicom_tag performed_series_sequence{0x0040, 0x0340};
+
+/// Scheduled Step Attributes Sequence (0040,0270)
+inline constexpr core::dicom_tag scheduled_step_attributes_sequence{0x0040, 0x0270};
+
+/// Referenced Study Sequence (0008,1110)
+inline constexpr core::dicom_tag referenced_study_sequence{0x0008, 0x1110};
+
+}  // namespace mpps_tags
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_MPPS_SCP_HPP

--- a/src/services/mpps_scp.cpp
+++ b/src/services/mpps_scp.cpp
@@ -1,0 +1,341 @@
+/**
+ * @file mpps_scp.cpp
+ * @brief Implementation of the MPPS (Modality Performed Procedure Step) SCP service
+ */
+
+#include "pacs/services/mpps_scp.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+mpps_scp::mpps_scp() = default;
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+void mpps_scp::set_create_handler(mpps_create_handler handler) {
+    create_handler_ = std::move(handler);
+}
+
+void mpps_scp::set_set_handler(mpps_set_handler handler) {
+    set_handler_ = std::move(handler);
+}
+
+// =============================================================================
+// scp_service Interface Implementation
+// =============================================================================
+
+std::vector<std::string> mpps_scp::supported_sop_classes() const {
+    return {std::string(mpps_sop_class_uid)};
+}
+
+network::Result<std::monostate> mpps_scp::handle_message(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Route to appropriate handler based on command type
+    switch (request.command()) {
+        case command_field::n_create_rq:
+            return handle_n_create(assoc, context_id, request);
+
+        case command_field::n_set_rq:
+            return handle_n_set(assoc, context_id, request);
+
+        default:
+#ifdef PACS_WITH_COMMON_SYSTEM
+            return kcenon::common::error_info(
+                std::string("Unexpected command for MPPS SCP: ") +
+                std::string(to_string(request.command())));
+#else
+            return std::string("Unexpected command for MPPS SCP: ") +
+                   std::string(to_string(request.command()));
+#endif
+    }
+}
+
+std::string_view mpps_scp::service_name() const noexcept {
+    return "MPPS SCP";
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t mpps_scp::creates_processed() const noexcept {
+    return creates_processed_.load();
+}
+
+size_t mpps_scp::sets_processed() const noexcept {
+    return sets_processed_.load();
+}
+
+size_t mpps_scp::mpps_completed() const noexcept {
+    return mpps_completed_.load();
+}
+
+size_t mpps_scp::mpps_discontinued() const noexcept {
+    return mpps_discontinued_.load();
+}
+
+void mpps_scp::reset_statistics() noexcept {
+    creates_processed_ = 0;
+    sets_processed_ = 0;
+    mpps_completed_ = 0;
+    mpps_discontinued_ = 0;
+}
+
+// =============================================================================
+// Private Implementation - N-CREATE Handler
+// =============================================================================
+
+network::Result<std::monostate> mpps_scp::handle_n_create(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Verify we have a handler configured
+    if (!create_handler_) {
+#ifdef PACS_WITH_COMMON_SYSTEM
+        return kcenon::common::error_info(
+            std::string("No N-CREATE handler configured for MPPS SCP"));
+#else
+        return std::string("No N-CREATE handler configured for MPPS SCP");
+#endif
+    }
+
+    // Verify the SOP Class is MPPS
+    auto sop_class_uid = request.affected_sop_class_uid();
+    if (sop_class_uid != mpps_sop_class_uid) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            "", status_refused_sop_class_not_supported);
+    }
+
+    // Get the SOP Instance UID from the request
+    auto sop_instance_uid = request.affected_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            "", status_error_missing_attribute);
+    }
+
+    // Verify we have a dataset
+    if (!request.has_dataset()) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_cannot_understand);
+    }
+
+    const auto& dataset = request.dataset();
+
+    // Build MPPS instance from request data
+    mpps_instance instance;
+    instance.sop_instance_uid = sop_instance_uid;
+    instance.status = mpps_status::in_progress;
+    instance.data = dataset;
+
+    // Extract Performed Station AE Title if present
+    if (dataset.contains(mpps_tags::performed_station_ae_title)) {
+        instance.station_ae = dataset.get_string(mpps_tags::performed_station_ae_title);
+    }
+
+    // Validate initial status is IN PROGRESS
+    if (dataset.contains(mpps_tags::performed_procedure_step_status)) {
+        auto status_str = dataset.get_string(mpps_tags::performed_procedure_step_status);
+        auto parsed_status = parse_mpps_status(status_str);
+
+        if (!parsed_status.has_value() ||
+            parsed_status.value() != mpps_status::in_progress) {
+            // N-CREATE must have IN PROGRESS status
+            return send_n_create_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, status_error_cannot_understand);
+        }
+    }
+
+    // Call the handler to create the MPPS instance
+    auto result = create_handler_(instance);
+    if (result.is_err()) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_unable_to_process);
+    }
+
+    // Update statistics
+    ++creates_processed_;
+
+    // Send success response
+    return send_n_create_response(
+        assoc, context_id, request.message_id(),
+        sop_instance_uid, status_success);
+}
+
+// =============================================================================
+// Private Implementation - N-SET Handler
+// =============================================================================
+
+network::Result<std::monostate> mpps_scp::handle_n_set(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Verify we have a handler configured
+    if (!set_handler_) {
+#ifdef PACS_WITH_COMMON_SYSTEM
+        return kcenon::common::error_info(
+            std::string("No N-SET handler configured for MPPS SCP"));
+#else
+        return std::string("No N-SET handler configured for MPPS SCP");
+#endif
+    }
+
+    // Verify the SOP Class is MPPS
+    auto sop_class_uid = request.affected_sop_class_uid();
+    if (sop_class_uid.empty()) {
+        // For N-SET, use requested SOP class if affected is empty
+        sop_class_uid = request.command_set().get_string(
+            tag_requested_sop_class_uid);
+    }
+
+    if (sop_class_uid != mpps_sop_class_uid) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            "", status_refused_sop_class_not_supported);
+    }
+
+    // Get the SOP Instance UID (from Requested SOP Instance UID for N-SET)
+    auto sop_instance_uid = request.command_set().get_string(
+        tag_requested_sop_instance_uid);
+
+    if (sop_instance_uid.empty()) {
+        // Try affected SOP instance UID as fallback
+        sop_instance_uid = request.affected_sop_instance_uid();
+    }
+
+    if (sop_instance_uid.empty()) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            "", status_error_missing_attribute);
+    }
+
+    // Verify we have a dataset with modifications
+    if (!request.has_dataset()) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_cannot_understand);
+    }
+
+    const auto& dataset = request.dataset();
+
+    // Extract and validate the new status
+    if (!dataset.contains(mpps_tags::performed_procedure_step_status)) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_missing_attribute);
+    }
+
+    auto status_str = dataset.get_string(mpps_tags::performed_procedure_step_status);
+    auto new_status = parse_mpps_status(status_str);
+
+    if (!new_status.has_value()) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_cannot_understand);
+    }
+
+    // Validate status transition (must be to COMPLETED or DISCONTINUED)
+    if (new_status.value() == mpps_status::in_progress) {
+        // Cannot set back to IN PROGRESS
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_cannot_understand);
+    }
+
+    // Call the handler to update the MPPS instance
+    auto result = set_handler_(sop_instance_uid, dataset, new_status.value());
+    if (result.is_err()) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_unable_to_process);
+    }
+
+    // Update statistics
+    ++sets_processed_;
+    if (new_status.value() == mpps_status::completed) {
+        ++mpps_completed_;
+    } else if (new_status.value() == mpps_status::discontinued) {
+        ++mpps_discontinued_;
+    }
+
+    // Send success response
+    return send_n_set_response(
+        assoc, context_id, request.message_id(),
+        sop_instance_uid, status_success);
+}
+
+// =============================================================================
+// Private Implementation - Response Helpers
+// =============================================================================
+
+network::Result<std::monostate> mpps_scp::send_n_create_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    // Create N-CREATE response message
+    dimse_message response{command_field::n_create_rsp, 0};
+    response.set_message_id_responded_to(message_id);
+    response.set_affected_sop_class_uid(mpps_sop_class_uid);
+    response.set_status(status);
+
+    if (!sop_instance_uid.empty()) {
+        response.set_affected_sop_instance_uid(sop_instance_uid);
+    }
+
+    // Send the response
+    return assoc.send_dimse(context_id, response);
+}
+
+network::Result<std::monostate> mpps_scp::send_n_set_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    // Create N-SET response message
+    dimse_message response{command_field::n_set_rsp, 0};
+    response.set_message_id_responded_to(message_id);
+    response.set_affected_sop_class_uid(mpps_sop_class_uid);
+    response.set_status(status);
+
+    if (!sop_instance_uid.empty()) {
+        response.set_affected_sop_instance_uid(sop_instance_uid);
+    }
+
+    // Send the response
+    return assoc.send_dimse(context_id, response);
+}
+
+}  // namespace pacs::services

--- a/tests/services/mpps_scp_test.cpp
+++ b/tests/services/mpps_scp_test.cpp
@@ -1,0 +1,274 @@
+/**
+ * @file mpps_scp_test.cpp
+ * @brief Unit tests for MPPS (Modality Performed Procedure Step) SCP service
+ */
+
+#include <pacs/services/mpps_scp.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+
+// ============================================================================
+// mpps_scp Construction Tests
+// ============================================================================
+
+TEST_CASE("mpps_scp construction", "[services][mpps]") {
+    mpps_scp scp;
+
+    SECTION("service name is correct") {
+        CHECK(scp.service_name() == "MPPS SCP");
+    }
+
+    SECTION("supports exactly one SOP class") {
+        auto classes = scp.supported_sop_classes();
+        CHECK(classes.size() == 1);
+    }
+
+    SECTION("supports MPPS SOP Class") {
+        auto classes = scp.supported_sop_classes();
+        REQUIRE(classes.size() == 1);
+        CHECK(classes[0] == "1.2.840.10008.3.1.2.3.3");
+    }
+}
+
+// ============================================================================
+// SOP Class Support Tests
+// ============================================================================
+
+TEST_CASE("mpps_scp SOP class support", "[services][mpps]") {
+    mpps_scp scp;
+
+    SECTION("supports MPPS SOP Class UID") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.3.1.2.3.3"));
+        CHECK(scp.supports_sop_class(mpps_sop_class_uid));
+    }
+
+    SECTION("does not support other SOP classes") {
+        // Verification SOP Class
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.1.1"));
+        // CT Image Storage
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.1.1.2"));
+        // Modality Worklist
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.31"));
+        // Empty string
+        CHECK_FALSE(scp.supports_sop_class(""));
+        // Random UID
+        CHECK_FALSE(scp.supports_sop_class("1.2.3.4.5.6.7.8.9"));
+    }
+}
+
+// ============================================================================
+// MPPS SOP Class UID Constant Test
+// ============================================================================
+
+TEST_CASE("mpps_sop_class_uid constant", "[services][mpps]") {
+    CHECK(mpps_sop_class_uid == "1.2.840.10008.3.1.2.3.3");
+}
+
+// ============================================================================
+// mpps_status Enumeration Tests
+// ============================================================================
+
+TEST_CASE("mpps_status to_string conversion", "[services][mpps]") {
+    CHECK(to_string(mpps_status::in_progress) == "IN PROGRESS");
+    CHECK(to_string(mpps_status::completed) == "COMPLETED");
+    CHECK(to_string(mpps_status::discontinued) == "DISCONTINUED");
+}
+
+TEST_CASE("parse_mpps_status conversion", "[services][mpps]") {
+    SECTION("valid status strings") {
+        auto in_progress = parse_mpps_status("IN PROGRESS");
+        REQUIRE(in_progress.has_value());
+        CHECK(in_progress.value() == mpps_status::in_progress);
+
+        auto completed = parse_mpps_status("COMPLETED");
+        REQUIRE(completed.has_value());
+        CHECK(completed.value() == mpps_status::completed);
+
+        auto discontinued = parse_mpps_status("DISCONTINUED");
+        REQUIRE(discontinued.has_value());
+        CHECK(discontinued.value() == mpps_status::discontinued);
+    }
+
+    SECTION("invalid status strings return nullopt") {
+        CHECK_FALSE(parse_mpps_status("").has_value());
+        CHECK_FALSE(parse_mpps_status("INVALID").has_value());
+        CHECK_FALSE(parse_mpps_status("in progress").has_value());  // case sensitive
+        CHECK_FALSE(parse_mpps_status("completed").has_value());    // case sensitive
+        CHECK_FALSE(parse_mpps_status("IN_PROGRESS").has_value());  // wrong format
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("mpps_scp statistics", "[services][mpps]") {
+    mpps_scp scp;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scp.creates_processed() == 0);
+        CHECK(scp.sets_processed() == 0);
+        CHECK(scp.mpps_completed() == 0);
+        CHECK(scp.mpps_discontinued() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        // Note: We can't easily increment these without a full integration test,
+        // but we can verify reset works from zero state
+        scp.reset_statistics();
+        CHECK(scp.creates_processed() == 0);
+        CHECK(scp.sets_processed() == 0);
+        CHECK(scp.mpps_completed() == 0);
+        CHECK(scp.mpps_discontinued() == 0);
+    }
+}
+
+// ============================================================================
+// Handler Configuration Tests
+// ============================================================================
+
+TEST_CASE("mpps_scp handler configuration", "[services][mpps]") {
+    mpps_scp scp;
+
+    SECTION("can set create handler") {
+        bool handler_called = false;
+        scp.set_create_handler([&handler_called](const mpps_instance& /*instance*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+
+        // Handler is stored but not called without a real association
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set set handler") {
+        bool handler_called = false;
+        scp.set_set_handler([&handler_called](
+            const std::string& /*uid*/,
+            const dicom_dataset& /*mods*/,
+            mpps_status /*status*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+
+        // Handler is stored but not called without a real association
+        CHECK_FALSE(handler_called);
+    }
+}
+
+// ============================================================================
+// mpps_instance Structure Tests
+// ============================================================================
+
+TEST_CASE("mpps_instance structure", "[services][mpps]") {
+    mpps_instance instance;
+
+    SECTION("default construction") {
+        CHECK(instance.sop_instance_uid.empty());
+        CHECK(instance.status == mpps_status::in_progress);
+        CHECK(instance.station_ae.empty());
+    }
+
+    SECTION("can be initialized") {
+        instance.sop_instance_uid = "1.2.3.4.5.6";
+        instance.status = mpps_status::in_progress;
+        instance.station_ae = "CT_SCANNER_01";
+
+        CHECK(instance.sop_instance_uid == "1.2.3.4.5.6");
+        CHECK(instance.status == mpps_status::in_progress);
+        CHECK(instance.station_ae == "CT_SCANNER_01");
+    }
+}
+
+// ============================================================================
+// MPPS Tags Tests
+// ============================================================================
+
+TEST_CASE("mpps_tags namespace contains MPPS-specific tags", "[services][mpps]") {
+    using namespace mpps_tags;
+
+    SECTION("performed station tags") {
+        CHECK(performed_station_ae_title == dicom_tag{0x0040, 0x0241});
+        CHECK(performed_station_name == dicom_tag{0x0040, 0x0242});
+        CHECK(performed_location == dicom_tag{0x0040, 0x0243});
+    }
+
+    SECTION("performed procedure step tags") {
+        CHECK(performed_procedure_step_end_date == dicom_tag{0x0040, 0x0250});
+        CHECK(performed_procedure_step_end_time == dicom_tag{0x0040, 0x0251});
+        CHECK(performed_procedure_step_status == dicom_tag{0x0040, 0x0252});
+        CHECK(performed_procedure_step_id == dicom_tag{0x0040, 0x0253});
+    }
+
+    SECTION("sequence tags") {
+        CHECK(performed_series_sequence == dicom_tag{0x0040, 0x0340});
+        CHECK(scheduled_step_attributes_sequence == dicom_tag{0x0040, 0x0270});
+    }
+}
+
+// ============================================================================
+// scp_service Base Class Tests
+// ============================================================================
+
+TEST_CASE("mpps_scp is a scp_service", "[services][mpps]") {
+    // Verify mpps_scp properly inherits from scp_service
+    std::unique_ptr<scp_service> base_ptr = std::make_unique<mpps_scp>();
+
+    CHECK(base_ptr->service_name() == "MPPS SCP");
+    CHECK(base_ptr->supported_sop_classes().size() == 1);
+    CHECK(base_ptr->supports_sop_class("1.2.840.10008.3.1.2.3.3"));
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple mpps_scp instances are independent", "[services][mpps]") {
+    mpps_scp scp1;
+    mpps_scp scp2;
+
+    // Both should have identical behavior
+    CHECK(scp1.service_name() == scp2.service_name());
+    CHECK(scp1.supported_sop_classes() == scp2.supported_sop_classes());
+    CHECK(scp1.supports_sop_class("1.2.840.10008.3.1.2.3.3") ==
+          scp2.supports_sop_class("1.2.840.10008.3.1.2.3.3"));
+
+    // Statistics should be independent
+    scp1.reset_statistics();
+    CHECK(scp1.creates_processed() == scp2.creates_processed());
+}
+
+// ============================================================================
+// Command Field Tests for N-CREATE and N-SET
+// ============================================================================
+
+TEST_CASE("N-CREATE and N-SET command fields", "[services][mpps]") {
+    SECTION("N-CREATE command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_create_rq) == 0x0140);
+        CHECK(static_cast<uint16_t>(command_field::n_create_rsp) == 0x8140);
+        CHECK(is_request(command_field::n_create_rq));
+        CHECK(is_response(command_field::n_create_rsp));
+    }
+
+    SECTION("N-SET command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_set_rq) == 0x0120);
+        CHECK(static_cast<uint16_t>(command_field::n_set_rsp) == 0x8120);
+        CHECK(is_request(command_field::n_set_rq));
+        CHECK(is_response(command_field::n_set_rsp));
+    }
+
+    SECTION("N-CREATE and N-SET are DIMSE-N commands") {
+        CHECK(is_dimse_n(command_field::n_create_rq));
+        CHECK(is_dimse_n(command_field::n_create_rsp));
+        CHECK(is_dimse_n(command_field::n_set_rq));
+        CHECK(is_dimse_n(command_field::n_set_rsp));
+    }
+}


### PR DESCRIPTION
## Summary

- Implement MPPS (Modality Performed Procedure Step) SCP service for tracking exam progress
- Handle N-CREATE requests to create MPPS instances with IN PROGRESS status
- Handle N-SET requests to update MPPS instances to COMPLETED or DISCONTINUED status
- Add MPPS-specific DICOM tags in dedicated namespace

## Changes

### New Files
- `include/pacs/services/mpps_scp.hpp` - MPPS SCP header with class definition and MPPS tags
- `src/services/mpps_scp.cpp` - Implementation of N-CREATE/N-SET handlers
- `tests/services/mpps_scp_test.cpp` - Unit tests (70 assertions, 12 test cases)

### Modified Files
- `CMakeLists.txt` - Added mpps_scp source and test files

## Test Plan

- [x] Unit tests for mpps_scp construction and configuration
- [x] Unit tests for MPPS status string conversion
- [x] Unit tests for handler registration
- [x] Unit tests for MPPS tag constants
- [x] All 504 service tests pass

## Related

Closes #31