### PR TITLE
Add SBOM workflow and CMake presets

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,146 @@
+name: SBOM Generation
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  release:
+    types: [ published ]
+  schedule:
+    # Generate SBOM weekly on Sunday at 3 AM UTC
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  packages: read
+  security-events: write
+
+jobs:
+  generate-sbom:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        submodules: true
+
+    - name: Generate SBOM with Syft (CycloneDX)
+      uses: anchore/sbom-action@v0
+      with:
+        path: .
+        format: cyclonedx-json
+        output-file: sbom-cyclonedx.json
+        artifact-name: sbom-cyclonedx
+
+    - name: Generate SBOM with Syft (SPDX)
+      uses: anchore/sbom-action@v0
+      with:
+        path: .
+        format: spdx-json
+        output-file: sbom-spdx.json
+        artifact-name: sbom-spdx
+
+    - name: Parse vcpkg dependencies
+      run: |
+        if [ -f "vcpkg.json" ]; then
+          echo "# vcpkg Dependencies" > vcpkg-dependencies.md
+          echo "" >> vcpkg-dependencies.md
+          echo "**Generated**: $(date -u)" >> vcpkg-dependencies.md
+          echo "" >> vcpkg-dependencies.md
+          echo "## Direct Dependencies" >> vcpkg-dependencies.md
+          echo "" >> vcpkg-dependencies.md
+
+          python3 << 'EOF'
+        import json
+
+        with open('vcpkg.json', 'r') as f:
+            manifest = json.load(f)
+
+        print(f"**Project**: {manifest.get('name', 'N/A')}")
+        print(f"**Version**: {manifest.get('version', 'N/A')}")
+        print()
+        print("| Package | Features |")
+        print("|---------|----------|")
+
+        deps = manifest.get('dependencies', [])
+        for dep in deps:
+            if isinstance(dep, str):
+                print(f"| {dep} | - |")
+            elif isinstance(dep, dict):
+                name = dep.get('name', 'unknown')
+                features = ', '.join(dep.get('features', [])) or '-'
+                print(f"| {name} | {features} |")
+        EOF
+
+          python3 << 'EOF' >> vcpkg-dependencies.md
+        import json
+
+        with open('vcpkg.json', 'r') as f:
+            manifest = json.load(f)
+
+        print(f"**Project**: {manifest.get('name', 'N/A')}")
+        print(f"**Version**: {manifest.get('version', 'N/A')}")
+        print()
+        print("| Package | Features |")
+        print("|---------|----------|")
+
+        deps = manifest.get('dependencies', [])
+        for dep in deps:
+            if isinstance(dep, str):
+                print(f"| {dep} | - |")
+            elif isinstance(dep, dict):
+                name = dep.get('name', 'unknown')
+                features = ', '.join(dep.get('features', [])) or '-'
+                print(f"| {name} | {features} |")
+        EOF
+        else
+          echo "No vcpkg.json found" > vcpkg-dependencies.md
+        fi
+
+    - name: Create combined SBOM report
+      run: |
+        echo "# Software Bill of Materials (SBOM)" > SBOM_REPORT.md
+        echo "" >> SBOM_REPORT.md
+        echo "**Repository**: ${{ github.repository }}" >> SBOM_REPORT.md
+        echo "**Branch**: ${{ github.ref_name }}" >> SBOM_REPORT.md
+        echo "**Commit**: ${{ github.sha }}" >> SBOM_REPORT.md
+        echo "**Generated**: $(date -u)" >> SBOM_REPORT.md
+        echo "" >> SBOM_REPORT.md
+        echo "## Available Formats" >> SBOM_REPORT.md
+        echo "" >> SBOM_REPORT.md
+        echo "- **CycloneDX**: sbom-cyclonedx.json" >> SBOM_REPORT.md
+        echo "- **SPDX**: sbom-spdx.json" >> SBOM_REPORT.md
+        echo "" >> SBOM_REPORT.md
+        cat vcpkg-dependencies.md >> SBOM_REPORT.md
+
+    - name: Upload SBOM artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: sbom-${{ github.sha }}
+        path: |
+          sbom-cyclonedx.json
+          sbom-spdx.json
+          vcpkg-dependencies.md
+          SBOM_REPORT.md
+        retention-days: 90
+
+    - name: Upload SBOM to release
+      if: github.event_name == 'release'
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          sbom-cyclonedx.json
+          sbom-spdx.json
+          SBOM_REPORT.md
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Submit SBOM to Dependency Graph
+      uses: advanced-security/spdx-dependency-submission-action@v0.1.1
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      continue-on-error: true
+      with:
+        filePath: sbom-spdx.json

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,144 @@
+{
+    "version": 3,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 20,
+        "patch": 0
+    },
+    "configurePresets": [
+        {
+            "name": "default",
+            "displayName": "Default Config",
+            "description": "Default build using local dependencies",
+            "binaryDir": "${sourceDir}/build",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "PACS_BUILD_TESTS": "OFF",
+                "PACS_BUILD_EXAMPLES": "OFF",
+                "PACS_BUILD_BENCHMARKS": "OFF",
+                "PACS_WITH_COMMON_SYSTEM": "ON",
+                "PACS_WITH_CONTAINER_SYSTEM": "ON",
+                "PACS_WITH_NETWORK_SYSTEM": "ON",
+                "PACS_BUILD_STORAGE": "ON"
+            }
+        },
+        {
+            "name": "debug",
+            "displayName": "Debug",
+            "description": "Debug build with tests enabled",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug",
+                "PACS_BUILD_TESTS": "ON",
+                "PACS_BUILD_EXAMPLES": "ON",
+                "ENABLE_COVERAGE": "ON"
+            }
+        },
+        {
+            "name": "release",
+            "displayName": "Release",
+            "description": "Optimized release build",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "PACS_BUILD_TESTS": "OFF",
+                "PACS_BUILD_EXAMPLES": "OFF"
+            }
+        },
+        {
+            "name": "asan",
+            "displayName": "AddressSanitizer",
+            "description": "Build with AddressSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-asan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=address -fno-omit-frame-pointer",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address"
+            }
+        },
+        {
+            "name": "tsan",
+            "displayName": "ThreadSanitizer",
+            "description": "Build with ThreadSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-tsan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=thread",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=thread"
+            }
+        },
+        {
+            "name": "ubsan",
+            "displayName": "UndefinedBehaviorSanitizer",
+            "description": "Build with UndefinedBehaviorSanitizer",
+            "inherits": "debug",
+            "binaryDir": "${sourceDir}/build-ubsan",
+            "cacheVariables": {
+                "CMAKE_CXX_FLAGS": "-fsanitize=undefined",
+                "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=undefined"
+            }
+        },
+        {
+            "name": "ci",
+            "displayName": "CI Build",
+            "description": "Configuration for continuous integration",
+            "inherits": "default",
+            "binaryDir": "${sourceDir}/build-ci",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "RelWithDebInfo",
+                "PACS_BUILD_TESTS": "ON",
+                "PACS_BUILD_EXAMPLES": "ON",
+                "PACS_BUILD_BENCHMARKS": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default"
+        },
+        {
+            "name": "debug",
+            "configurePreset": "debug"
+        },
+        {
+            "name": "release",
+            "configurePreset": "release"
+        },
+        {
+            "name": "asan",
+            "configurePreset": "asan"
+        },
+        {
+            "name": "tsan",
+            "configurePreset": "tsan"
+        },
+        {
+            "name": "ubsan",
+            "configurePreset": "ubsan"
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "default",
+            "configurePreset": "default",
+            "output": {
+                "outputOnFailure": true
+            }
+        },
+        {
+            "name": "ci",
+            "configurePreset": "ci",
+            "output": {
+                "outputOnFailure": true,
+                "verbosity": "verbose"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
Add Software Bill of Materials (SBOM) generation workflow and standardized CMake presets.

## SBOM Generation
- GitHub Actions workflow using Syft
- Generate CycloneDX and SPDX formats
- Parse vcpkg dependencies
- Weekly scheduled generation
- Upload to releases

## CMake Presets
- `default`: Standard release build
- `debug`: Debug build with tests
- `release`: Optimized release build
- `asan`: AddressSanitizer build
- `tsan`: ThreadSanitizer build
- `ubsan`: UndefinedBehaviorSanitizer build
- `ci`: CI-optimized build

## Test plan
- [ ] Verify SBOM workflow triggers correctly
- [ ] Test CMake preset configurations
- [ ] Validate sanitizer builds work properly