### PR TITLE
feat(benchmarks): Add thread performance baseline benchmarks (#154)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -966,6 +966,24 @@ if(PACS_BUILD_EXAMPLES)
 endif()
 
 ##################################################
+# Benchmarks
+##################################################
+
+if(PACS_BUILD_BENCHMARKS)
+    message(STATUS "")
+    message(STATUS "=== Building Benchmarks ===")
+
+    # Thread Performance Benchmarks
+    # @see Issue #154 - Establish performance baseline benchmarks for thread migration
+    if(TARGET pacs_integration AND TARGET Catch2::Catch2WithMain)
+        add_subdirectory(benchmarks/thread_performance)
+        message(STATUS "  [OK] thread_performance_benchmarks: Thread migration baseline")
+    else()
+        message(STATUS "  [--] thread_performance_benchmarks: OFF (requires pacs_integration and Catch2)")
+    endif()
+endif()
+
+##################################################
 # Apply Compiler Warnings to PACS Targets Only
 #
 # This must be done AFTER all pacs_* targets are defined
@@ -1002,6 +1020,13 @@ if(PACS_BUILD_TESTS)
     endif()
     if(TARGET pacs_integration_tests)
         pacs_apply_warnings(pacs_integration_tests)
+    endif()
+endif()
+
+# Benchmark executables
+if(PACS_BUILD_BENCHMARKS)
+    if(TARGET thread_performance_benchmarks)
+        pacs_apply_warnings(thread_performance_benchmarks)
     endif()
 endif()
 

--- a/benchmarks/thread_performance/CMakeLists.txt
+++ b/benchmarks/thread_performance/CMakeLists.txt
@@ -1,0 +1,116 @@
+# Thread Performance Benchmarks
+# Baseline measurements for thread_system migration
+#
+# @see Issue #154 - Establish performance baseline benchmarks for thread migration
+
+##################################################
+# Benchmark Executable
+##################################################
+
+add_executable(thread_performance_benchmarks
+    association_benchmark.cpp
+    throughput_benchmark.cpp
+    concurrent_load_benchmark.cpp
+    shutdown_benchmark.cpp
+)
+
+target_include_directories(thread_performance_benchmarks
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+# Link required PACS libraries
+target_link_libraries(thread_performance_benchmarks
+    PRIVATE
+        pacs_core
+        pacs_encoding
+        pacs_network
+        pacs_services
+        pacs_integration
+        Catch2::Catch2WithMain
+        Threads::Threads
+)
+
+# Set C++20 standard
+target_compile_features(thread_performance_benchmarks PRIVATE cxx_std_20)
+
+# Apply PACS warning flags
+if(COMMAND pacs_apply_warnings)
+    pacs_apply_warnings(thread_performance_benchmarks)
+endif()
+
+##################################################
+# CTest Integration
+##################################################
+
+include(Catch)
+
+# Register benchmark tests with CTest
+# Use longer timeout for benchmark tests
+catch_discover_tests(thread_performance_benchmarks
+    TEST_PREFIX "benchmark::"
+    REPORTER junit
+    OUTPUT_DIR ${CMAKE_BINARY_DIR}/test-results
+    OUTPUT_PREFIX benchmark_
+    OUTPUT_SUFFIX .xml
+    PROPERTIES
+        LABELS "benchmark"
+        TIMEOUT 600
+)
+
+##################################################
+# Custom Targets for Running Benchmarks
+##################################################
+
+# Quick benchmark run (subset of tests)
+add_custom_target(run_quick_benchmarks
+    COMMAND thread_performance_benchmarks
+        "[benchmark][association]"
+        "[benchmark][throughput][echo]"
+        --reporter console
+    DEPENDS thread_performance_benchmarks
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running quick benchmark suite..."
+)
+
+# Full benchmark run
+add_custom_target(run_full_benchmarks
+    COMMAND thread_performance_benchmarks
+        "[benchmark]"
+        --reporter console
+    DEPENDS thread_performance_benchmarks
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running full benchmark suite..."
+)
+
+# Benchmark with JUnit output for CI
+add_custom_target(run_benchmarks_ci
+    COMMAND thread_performance_benchmarks
+        "[benchmark]"
+        --reporter junit
+        --out ${CMAKE_BINARY_DIR}/benchmark_results.xml
+    DEPENDS thread_performance_benchmarks
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    COMMENT "Running benchmarks with JUnit output..."
+)
+
+##################################################
+# Install Target
+##################################################
+
+install(TARGETS thread_performance_benchmarks
+    RUNTIME DESTINATION bin/benchmarks
+)
+
+##################################################
+# Documentation
+##################################################
+
+message(STATUS "")
+message(STATUS "=== Thread Performance Benchmarks ===")
+message(STATUS "  Target: thread_performance_benchmarks")
+message(STATUS "  Run quick: cmake --build . --target run_quick_benchmarks")
+message(STATUS "  Run full:  cmake --build . --target run_full_benchmarks")
+message(STATUS "  Run CI:    cmake --build . --target run_benchmarks_ci")
+message(STATUS "")

--- a/benchmarks/thread_performance/association_benchmark.cpp
+++ b/benchmarks/thread_performance/association_benchmark.cpp
@@ -1,0 +1,282 @@
+/**
+ * @file association_benchmark.cpp
+ * @brief Association establishment latency benchmarks
+ *
+ * Measures the time required to establish DICOM associations,
+ * including TCP connection, A-ASSOCIATE negotiation, and release.
+ *
+ * Key metrics:
+ * - Single association establishment latency
+ * - Association with release latency (full round-trip)
+ * - Repeated association establishment (warm-up effects)
+ *
+ * @see Issue #154 - Establish performance baseline benchmarks for thread migration
+ */
+
+#include "benchmark_common.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+using namespace pacs::benchmark;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::services;
+
+// =============================================================================
+// Association Establishment Benchmarks
+// =============================================================================
+
+TEST_CASE("Association establishment latency baseline", "[benchmark][association]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("Single association establishment") {
+        // Warmup
+        for (int i = 0; i < 3; ++i) {
+            auto config = make_echo_config("BENCH_SCU", server.ae_title());
+            auto result = association::connect("localhost", port, config, default_timeout);
+            if (result.is_ok()) {
+                (void)result.value().release(std::chrono::milliseconds{1000});
+            }
+        }
+
+        // Benchmark
+        constexpr int iterations = 50;
+        benchmark_stats stats;
+
+        for (int i = 0; i < iterations; ++i) {
+            auto config = make_echo_config("BENCH_SCU_" + std::to_string(i), server.ae_title());
+
+            high_resolution_timer timer;
+            timer.start();
+
+            auto result = association::connect("localhost", port, config, default_timeout);
+
+            timer.stop();
+
+            REQUIRE(result.is_ok());
+            stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+
+            (void)result.value().release(std::chrono::milliseconds{1000});
+        }
+
+        // Output results
+        std::cout << "\n=== Association Establishment Latency ===" << std::endl;
+        std::cout << "  Iterations: " << stats.count << std::endl;
+        std::cout << "  Mean: " << stats.mean_ms() << " ms" << std::endl;
+        std::cout << "  Std Dev: " << stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "  Min: " << stats.min_ms << " ms" << std::endl;
+        std::cout << "  Max: " << stats.max_ms << " ms" << std::endl;
+        std::cout << "  Rate: " << stats.throughput_per_second() << " assoc/s" << std::endl;
+
+        // Record baseline requirement: < 100ms mean
+        REQUIRE(stats.mean_ms() < 100.0);
+    }
+
+    SECTION("Full association round-trip (connect + release)") {
+        constexpr int iterations = 30;
+        benchmark_stats stats;
+
+        for (int i = 0; i < iterations; ++i) {
+            auto config = make_echo_config("BENCH_RT_" + std::to_string(i), server.ae_title());
+
+            high_resolution_timer timer;
+            timer.start();
+
+            auto result = association::connect("localhost", port, config, default_timeout);
+            REQUIRE(result.is_ok());
+
+            auto release_result = result.value().release(std::chrono::milliseconds{2000});
+            REQUIRE(release_result.is_ok());
+
+            timer.stop();
+            stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+        }
+
+        std::cout << "\n=== Full Association Round-Trip ===" << std::endl;
+        std::cout << "  Iterations: " << stats.count << std::endl;
+        std::cout << "  Mean: " << stats.mean_ms() << " ms" << std::endl;
+        std::cout << "  Std Dev: " << stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "  Min: " << stats.min_ms << " ms" << std::endl;
+        std::cout << "  Max: " << stats.max_ms << " ms" << std::endl;
+
+        // Record baseline requirement: < 200ms mean for full round-trip
+        REQUIRE(stats.mean_ms() < 200.0);
+    }
+
+    server.stop();
+}
+
+TEST_CASE("Association establishment with C-ECHO", "[benchmark][association][echo]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("Connect + Single C-ECHO + Release") {
+        constexpr int iterations = 30;
+        benchmark_stats connect_stats;
+        benchmark_stats echo_stats;
+        benchmark_stats release_stats;
+        benchmark_stats total_stats;
+
+        for (int i = 0; i < iterations; ++i) {
+            auto config = make_echo_config("BENCH_ECHO_" + std::to_string(i), server.ae_title());
+
+            high_resolution_timer total_timer;
+            high_resolution_timer step_timer;
+
+            total_timer.start();
+
+            // Connect
+            step_timer.start();
+            auto connect_result = association::connect("localhost", port, config, default_timeout);
+            step_timer.stop();
+            REQUIRE(connect_result.is_ok());
+            connect_stats.record(static_cast<double>(step_timer.elapsed_us().count()) / 1000.0);
+
+            auto& assoc = connect_result.value();
+
+            // C-ECHO
+            step_timer.start();
+            auto ctx = assoc.accepted_context_id(verification_sop_class_uid);
+            REQUIRE(ctx.has_value());
+
+            auto echo_rq = make_c_echo_rq(1, verification_sop_class_uid);
+            auto send_result = assoc.send_dimse(*ctx, echo_rq);
+            REQUIRE(send_result.is_ok());
+
+            auto recv_result = assoc.receive_dimse(default_timeout);
+            step_timer.stop();
+            REQUIRE(recv_result.is_ok());
+            REQUIRE(recv_result.value().second.status() == status_success);
+            echo_stats.record(static_cast<double>(step_timer.elapsed_us().count()) / 1000.0);
+
+            // Release
+            step_timer.start();
+            auto release_result = assoc.release(std::chrono::milliseconds{2000});
+            step_timer.stop();
+            REQUIRE(release_result.is_ok());
+            release_stats.record(static_cast<double>(step_timer.elapsed_us().count()) / 1000.0);
+
+            total_timer.stop();
+            total_stats.record(static_cast<double>(total_timer.elapsed_us().count()) / 1000.0);
+        }
+
+        std::cout << "\n=== Association + C-ECHO + Release ===" << std::endl;
+        std::cout << "  Iterations: " << iterations << std::endl;
+        std::cout << "\n  Connect:" << std::endl;
+        std::cout << "    Mean: " << connect_stats.mean_ms() << " ms" << std::endl;
+        std::cout << "    Std Dev: " << connect_stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "\n  C-ECHO:" << std::endl;
+        std::cout << "    Mean: " << echo_stats.mean_ms() << " ms" << std::endl;
+        std::cout << "    Std Dev: " << echo_stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "\n  Release:" << std::endl;
+        std::cout << "    Mean: " << release_stats.mean_ms() << " ms" << std::endl;
+        std::cout << "    Std Dev: " << release_stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "\n  Total:" << std::endl;
+        std::cout << "    Mean: " << total_stats.mean_ms() << " ms" << std::endl;
+        std::cout << "    Min: " << total_stats.min_ms << " ms" << std::endl;
+        std::cout << "    Max: " << total_stats.max_ms << " ms" << std::endl;
+
+        // Baseline requirements
+        REQUIRE(connect_stats.mean_ms() < 100.0);
+        REQUIRE(echo_stats.mean_ms() < 50.0);
+        REQUIRE(release_stats.mean_ms() < 100.0);
+    }
+
+    server.stop();
+}
+
+TEST_CASE("Sequential association establishment", "[benchmark][association][sequential]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("Rapid sequential connections") {
+        constexpr int iterations = 100;
+        benchmark_stats stats;
+
+        high_resolution_timer total_timer;
+        total_timer.start();
+
+        for (int i = 0; i < iterations; ++i) {
+            auto config = make_echo_config("BENCH_SEQ_" + std::to_string(i), server.ae_title());
+
+            high_resolution_timer timer;
+            timer.start();
+
+            auto result = association::connect("localhost", port, config, default_timeout);
+            timer.stop();
+
+            if (result.is_ok()) {
+                stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+                (void)result.value().release(std::chrono::milliseconds{500});
+            }
+        }
+
+        total_timer.stop();
+
+        double total_seconds = total_timer.elapsed_seconds();
+        double connections_per_second = static_cast<double>(stats.count) / total_seconds;
+
+        std::cout << "\n=== Sequential Connection Rate ===" << std::endl;
+        std::cout << "  Successful connections: " << stats.count << "/" << iterations << std::endl;
+        std::cout << "  Total time: " << total_seconds << " s" << std::endl;
+        std::cout << "  Rate: " << connections_per_second << " conn/s" << std::endl;
+        std::cout << "  Mean latency: " << stats.mean_ms() << " ms" << std::endl;
+        std::cout << "  Min latency: " << stats.min_ms << " ms" << std::endl;
+        std::cout << "  Max latency: " << stats.max_ms << " ms" << std::endl;
+
+        // Baseline: at least 90% success rate
+        REQUIRE(stats.count >= iterations * 0.9);
+        // Baseline: at least 10 connections per second
+        REQUIRE(connections_per_second >= 10.0);
+    }
+
+    server.stop();
+}
+
+// =============================================================================
+// Catch2 BENCHMARK macros for micro-benchmarks
+// =============================================================================
+
+TEST_CASE("Association micro-benchmarks", "[.benchmark][association][micro]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    BENCHMARK("Association connect only") {
+        auto config = make_echo_config("BENCH_MICRO", server.ae_title());
+        auto result = association::connect("localhost", port, config, default_timeout);
+        if (result.is_ok()) {
+            // source=0 (service-user), reason=0 (not-specified)
+            (void)result.value().abort(0, 0);
+        }
+        return result.is_ok();
+    };
+
+    BENCHMARK("Association connect + release") {
+        auto config = make_echo_config("BENCH_MICRO", server.ae_title());
+        auto result = association::connect("localhost", port, config, default_timeout);
+        if (result.is_ok()) {
+            (void)result.value().release(std::chrono::milliseconds{1000});
+        }
+        return result.is_ok();
+    };
+
+    server.stop();
+}

--- a/benchmarks/thread_performance/benchmark_common.hpp
+++ b/benchmarks/thread_performance/benchmark_common.hpp
@@ -1,0 +1,346 @@
+/**
+ * @file benchmark_common.hpp
+ * @brief Common utilities and fixtures for thread performance benchmarks
+ *
+ * Provides reusable server fixtures, timing utilities, and DICOM data
+ * generators specifically designed for performance benchmarking.
+ *
+ * @see Issue #154 - Establish performance baseline benchmarks for thread migration
+ */
+
+#ifndef PACS_BENCHMARKS_THREAD_PERFORMANCE_BENCHMARK_COMMON_HPP
+#define PACS_BENCHMARKS_THREAD_PERFORMANCE_BENCHMARK_COMMON_HPP
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/core/dicom_element.hpp"
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/encoding/vr_type.hpp"
+#include "pacs/network/association.hpp"
+#include "pacs/network/dicom_server.hpp"
+#include "pacs/network/dimse/dimse_message.hpp"
+#include "pacs/network/server_config.hpp"
+#include "pacs/services/storage_scp.hpp"
+#include "pacs/services/storage_scu.hpp"
+#include "pacs/services/verification_scp.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <random>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace pacs::benchmark {
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+/// Default benchmark port range start
+constexpr uint16_t default_benchmark_port = 42104;
+
+/// Default timeout for benchmark operations
+constexpr auto default_timeout = std::chrono::milliseconds{10000};
+
+// Note: verification_sop_class_uid is provided by pacs::services::verification_sop_class_uid
+// from verification_scp.hpp to avoid symbol conflicts
+
+/// CT Image Storage SOP Class UID
+constexpr const char* ct_storage_sop_class_uid = "1.2.840.10008.5.1.4.1.1.2";
+
+/// Implicit VR Little Endian Transfer Syntax
+constexpr const char* implicit_vr_le = "1.2.840.10008.1.2";
+
+/// Explicit VR Little Endian Transfer Syntax
+constexpr const char* explicit_vr_le = "1.2.840.10008.1.2.1";
+
+// =============================================================================
+// Timing Utilities
+// =============================================================================
+
+/**
+ * @brief High-resolution timer for precise measurements
+ */
+class high_resolution_timer {
+public:
+    void start() {
+        start_time_ = std::chrono::high_resolution_clock::now();
+    }
+
+    void stop() {
+        end_time_ = std::chrono::high_resolution_clock::now();
+    }
+
+    [[nodiscard]] std::chrono::nanoseconds elapsed_ns() const {
+        return std::chrono::duration_cast<std::chrono::nanoseconds>(
+            end_time_ - start_time_);
+    }
+
+    [[nodiscard]] std::chrono::microseconds elapsed_us() const {
+        return std::chrono::duration_cast<std::chrono::microseconds>(
+            end_time_ - start_time_);
+    }
+
+    [[nodiscard]] std::chrono::milliseconds elapsed_ms() const {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(
+            end_time_ - start_time_);
+    }
+
+    [[nodiscard]] double elapsed_seconds() const {
+        return std::chrono::duration<double>(end_time_ - start_time_).count();
+    }
+
+private:
+    std::chrono::high_resolution_clock::time_point start_time_;
+    std::chrono::high_resolution_clock::time_point end_time_;
+};
+
+/**
+ * @brief Statistics accumulator for benchmark results
+ */
+struct benchmark_stats {
+    size_t count{0};
+    double sum_ms{0.0};
+    double sum_squared_ms{0.0};
+    double min_ms{std::numeric_limits<double>::max()};
+    double max_ms{0.0};
+
+    void record(double duration_ms) {
+        ++count;
+        sum_ms += duration_ms;
+        sum_squared_ms += duration_ms * duration_ms;
+        min_ms = std::min(min_ms, duration_ms);
+        max_ms = std::max(max_ms, duration_ms);
+    }
+
+    [[nodiscard]] double mean_ms() const {
+        return count > 0 ? sum_ms / static_cast<double>(count) : 0.0;
+    }
+
+    [[nodiscard]] double stddev_ms() const {
+        if (count < 2) return 0.0;
+        double mean = mean_ms();
+        double variance = (sum_squared_ms / static_cast<double>(count)) - (mean * mean);
+        return std::sqrt(std::max(0.0, variance));
+    }
+
+    [[nodiscard]] double throughput_per_second() const {
+        return sum_ms > 0.0 ? (static_cast<double>(count) * 1000.0) / sum_ms : 0.0;
+    }
+};
+
+// =============================================================================
+// Port Management
+// =============================================================================
+
+/**
+ * @brief Find an available port for benchmarking
+ * @param start Starting port number
+ * @return Available port number
+ */
+inline uint16_t find_available_port(uint16_t start = default_benchmark_port) {
+    static std::atomic<uint16_t> port_offset{0};
+    return start + (port_offset++ % 100);
+}
+
+// =============================================================================
+// UID Generation
+// =============================================================================
+
+/**
+ * @brief Generate a unique UID for benchmarking
+ * @param root Root UID prefix
+ * @return Unique UID string
+ */
+inline std::string generate_uid(const std::string& root = "1.2.826.0.1.3680043.9.8888") {
+    static std::atomic<uint64_t> counter{0};
+    auto now = std::chrono::system_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now.time_since_epoch()).count();
+    return root + "." + std::to_string(timestamp) + "." + std::to_string(++counter);
+}
+
+// =============================================================================
+// DICOM Dataset Generators
+// =============================================================================
+
+/**
+ * @brief Generate a minimal CT dataset for benchmarking
+ * @param study_uid Study Instance UID (generated if empty)
+ * @return DICOM dataset
+ */
+inline core::dicom_dataset generate_benchmark_dataset(const std::string& study_uid = "") {
+    core::dicom_dataset ds;
+
+    // Patient module
+    ds.set_string(core::tags::patient_name, encoding::vr_type::PN, "BENCHMARK^PATIENT");
+    ds.set_string(core::tags::patient_id, encoding::vr_type::LO, "BENCH001");
+    ds.set_string(core::tags::patient_birth_date, encoding::vr_type::DA, "19800101");
+    ds.set_string(core::tags::patient_sex, encoding::vr_type::CS, "O");
+
+    // Study module
+    ds.set_string(core::tags::study_instance_uid, encoding::vr_type::UI,
+                  study_uid.empty() ? generate_uid() : study_uid);
+    ds.set_string(core::tags::study_date, encoding::vr_type::DA, "20240101");
+    ds.set_string(core::tags::study_time, encoding::vr_type::TM, "120000");
+    ds.set_string(core::tags::accession_number, encoding::vr_type::SH, "BENCH001");
+    ds.set_string(core::tags::study_id, encoding::vr_type::SH, "BENCHSTUDY");
+
+    // Series module
+    ds.set_string(core::tags::series_instance_uid, encoding::vr_type::UI, generate_uid());
+    ds.set_string(core::tags::modality, encoding::vr_type::CS, "CT");
+    ds.set_string(core::tags::series_number, encoding::vr_type::IS, "1");
+
+    // SOP Common module
+    ds.set_string(core::tags::sop_class_uid, encoding::vr_type::UI, ct_storage_sop_class_uid);
+    ds.set_string(core::tags::sop_instance_uid, encoding::vr_type::UI, generate_uid());
+
+    // Image module (minimal 64x64 16-bit image)
+    ds.set_numeric<uint16_t>(core::tags::rows, encoding::vr_type::US, 64);
+    ds.set_numeric<uint16_t>(core::tags::columns, encoding::vr_type::US, 64);
+    ds.set_numeric<uint16_t>(core::tags::bits_allocated, encoding::vr_type::US, 16);
+    ds.set_numeric<uint16_t>(core::tags::bits_stored, encoding::vr_type::US, 12);
+    ds.set_numeric<uint16_t>(core::tags::high_bit, encoding::vr_type::US, 11);
+    ds.set_numeric<uint16_t>(core::tags::pixel_representation, encoding::vr_type::US, 0);
+    ds.set_numeric<uint16_t>(core::tags::samples_per_pixel, encoding::vr_type::US, 1);
+    ds.set_string(core::tags::photometric_interpretation, encoding::vr_type::CS, "MONOCHROME2");
+
+    // Generate minimal pixel data
+    std::vector<uint16_t> pixel_data(64 * 64, 512);
+    core::dicom_element pixel_elem(core::tags::pixel_data, encoding::vr_type::OW);
+    pixel_elem.set_value(std::span<const uint8_t>(
+        reinterpret_cast<const uint8_t*>(pixel_data.data()),
+        pixel_data.size() * sizeof(uint16_t)));
+    ds.insert(std::move(pixel_elem));
+
+    return ds;
+}
+
+// =============================================================================
+// Benchmark Server Fixture
+// =============================================================================
+
+/**
+ * @brief DICOM server fixture for benchmarking
+ *
+ * Provides a lightweight server with configurable services
+ * and counters for measuring performance.
+ */
+class benchmark_server {
+public:
+    explicit benchmark_server(uint16_t port, const std::string& ae_title = "BENCH_SCP")
+        : port_(port)
+        , ae_title_(ae_title) {
+
+        network::server_config config;
+        config.ae_title = ae_title_;
+        config.port = port_;
+        config.max_associations = 100;
+        config.idle_timeout = std::chrono::seconds{60};
+        config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.1";
+        config.implementation_version_name = "BENCH_SCP";
+
+        server_ = std::make_unique<network::dicom_server>(config);
+    }
+
+    /**
+     * @brief Initialize server with verification service only (for echo benchmarks)
+     */
+    bool initialize_echo_only() {
+        server_->register_service(std::make_shared<services::verification_scp>());
+        return true;
+    }
+
+    /**
+     * @brief Initialize server with storage service (for store benchmarks)
+     */
+    bool initialize_with_storage() {
+        server_->register_service(std::make_shared<services::verification_scp>());
+
+        auto storage_scp = std::make_shared<services::storage_scp>();
+        storage_scp->set_handler([this](
+            const core::dicom_dataset& /* dataset */,
+            const std::string& /* calling_ae */,
+            const std::string& /* sop_class_uid */,
+            const std::string& /* sop_instance_uid */) {
+            ++store_count_;
+            return services::storage_status::success;
+        });
+        server_->register_service(storage_scp);
+        return true;
+    }
+
+    bool start() {
+        auto result = server_->start();
+        if (result.is_ok()) {
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+            return true;
+        }
+        return false;
+    }
+
+    void stop() {
+        server_->stop();
+    }
+
+    [[nodiscard]] uint16_t port() const { return port_; }
+    [[nodiscard]] const std::string& ae_title() const { return ae_title_; }
+    [[nodiscard]] size_t store_count() const { return store_count_.load(); }
+    [[nodiscard]] size_t active_associations() const { return server_->active_associations(); }
+
+private:
+    uint16_t port_;
+    std::string ae_title_;
+    std::unique_ptr<network::dicom_server> server_;
+    std::atomic<size_t> store_count_{0};
+};
+
+// =============================================================================
+// Association Configuration Helpers
+// =============================================================================
+
+/**
+ * @brief Create association config for verification (C-ECHO)
+ */
+inline network::association_config make_echo_config(
+    const std::string& calling_ae,
+    const std::string& called_ae) {
+
+    network::association_config config;
+    config.calling_ae_title = calling_ae;
+    config.called_ae_title = called_ae;
+    config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.2";
+    config.proposed_contexts.push_back({
+        1,
+        std::string(services::verification_sop_class_uid),
+        {explicit_vr_le, implicit_vr_le}
+    });
+    return config;
+}
+
+/**
+ * @brief Create association config for storage (C-STORE)
+ */
+inline network::association_config make_store_config(
+    const std::string& calling_ae,
+    const std::string& called_ae) {
+
+    network::association_config config;
+    config.calling_ae_title = calling_ae;
+    config.called_ae_title = called_ae;
+    config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.3";
+    config.proposed_contexts.push_back({
+        1,
+        std::string(ct_storage_sop_class_uid),
+        {explicit_vr_le, implicit_vr_le}
+    });
+    return config;
+}
+
+}  // namespace pacs::benchmark
+
+#endif  // PACS_BENCHMARKS_THREAD_PERFORMANCE_BENCHMARK_COMMON_HPP

--- a/benchmarks/thread_performance/concurrent_load_benchmark.cpp
+++ b/benchmarks/thread_performance/concurrent_load_benchmark.cpp
@@ -1,0 +1,504 @@
+/**
+ * @file concurrent_load_benchmark.cpp
+ * @brief Concurrent connection handling benchmarks
+ *
+ * Measures the server's ability to handle multiple simultaneous
+ * connections and operations.
+ *
+ * Key metrics:
+ * - Maximum concurrent connections
+ * - Throughput under concurrent load
+ * - Latency distribution under load
+ * - Memory usage under concurrent access
+ *
+ * @see Issue #154 - Establish performance baseline benchmarks for thread migration
+ */
+
+#include "benchmark_common.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include <algorithm>
+#include <future>
+#include <iostream>
+#include <latch>
+#include <mutex>
+#include <numeric>
+#include <thread>
+#include <vector>
+
+using namespace pacs::benchmark;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::services;
+
+// =============================================================================
+// Helper Structures
+// =============================================================================
+
+namespace {
+
+/**
+ * @brief Result from a concurrent worker
+ */
+struct worker_result {
+    size_t success_count{0};
+    size_t failure_count{0};
+    std::chrono::milliseconds total_duration{0};
+    benchmark_stats latency_stats;
+    std::string error_message;
+};
+
+/**
+ * @brief Run C-ECHO operations as a concurrent worker
+ */
+worker_result run_echo_worker(
+    uint16_t server_port,
+    const std::string& server_ae,
+    int worker_id,
+    int num_operations,
+    std::latch& start_latch) {
+
+    worker_result result;
+    auto start_time = std::chrono::steady_clock::now();
+
+    // Wait for all workers to be ready
+    start_latch.arrive_and_wait();
+
+    try {
+        auto config = make_echo_config(
+            "ECHO_W" + std::to_string(worker_id), server_ae);
+
+        auto connect_result = association::connect(
+            "localhost", server_port, config,
+            std::chrono::milliseconds{15000});
+
+        if (connect_result.is_err()) {
+            result.error_message = "Connection failed";
+            result.failure_count = num_operations;
+            return result;
+        }
+
+        auto& assoc = connect_result.value();
+        auto ctx = assoc.accepted_context_id(verification_sop_class_uid);
+
+        if (!ctx) {
+            result.error_message = "No accepted context";
+            result.failure_count = num_operations;
+            (void)assoc.release(std::chrono::milliseconds{1000});
+            return result;
+        }
+
+        for (int i = 0; i < num_operations; ++i) {
+            high_resolution_timer timer;
+            timer.start();
+
+            auto echo_rq = make_c_echo_rq(
+                static_cast<uint16_t>(i + 1), verification_sop_class_uid);
+            auto send_result = assoc.send_dimse(*ctx, echo_rq);
+
+            if (send_result.is_err()) {
+                ++result.failure_count;
+                continue;
+            }
+
+            auto recv_result = assoc.receive_dimse(default_timeout);
+            timer.stop();
+
+            if (recv_result.is_ok() && recv_result.value().second.status() == status_success) {
+                ++result.success_count;
+                result.latency_stats.record(
+                    static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+            } else {
+                ++result.failure_count;
+            }
+        }
+
+        (void)assoc.release(std::chrono::milliseconds{2000});
+
+    } catch (const std::exception& e) {
+        result.error_message = e.what();
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    result.total_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    return result;
+}
+
+/**
+ * @brief Run C-STORE operations as a concurrent worker
+ */
+worker_result run_store_worker(
+    uint16_t server_port,
+    const std::string& server_ae,
+    int worker_id,
+    int num_operations,
+    std::latch& start_latch) {
+
+    worker_result result;
+    auto start_time = std::chrono::steady_clock::now();
+
+    start_latch.arrive_and_wait();
+
+    try {
+        auto config = make_store_config(
+            "STORE_W" + std::to_string(worker_id), server_ae);
+
+        auto connect_result = association::connect(
+            "localhost", server_port, config,
+            std::chrono::milliseconds{15000});
+
+        if (connect_result.is_err()) {
+            result.error_message = "Connection failed";
+            result.failure_count = num_operations;
+            return result;
+        }
+
+        auto& assoc = connect_result.value();
+        storage_scu_config scu_config;
+        scu_config.response_timeout = default_timeout;
+        storage_scu scu{scu_config};
+
+        auto study_uid = generate_uid();
+
+        for (int i = 0; i < num_operations; ++i) {
+            auto dataset = generate_benchmark_dataset(study_uid);
+
+            high_resolution_timer timer;
+            timer.start();
+
+            auto store_result = scu.store(assoc, dataset);
+
+            timer.stop();
+
+            if (store_result.is_ok() && store_result.value().is_success()) {
+                ++result.success_count;
+                result.latency_stats.record(
+                    static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+            } else {
+                ++result.failure_count;
+            }
+        }
+
+        (void)assoc.release(std::chrono::milliseconds{2000});
+
+    } catch (const std::exception& e) {
+        result.error_message = e.what();
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    result.total_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    return result;
+}
+
+}  // namespace
+
+// =============================================================================
+// Concurrent Connection Benchmarks
+// =============================================================================
+
+TEST_CASE("Concurrent C-ECHO operations", "[benchmark][concurrent][echo]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("Multiple concurrent connections with C-ECHO") {
+        constexpr int num_workers = 10;
+        constexpr int ops_per_worker = 50;
+
+        std::latch start_latch(num_workers + 1);
+        std::vector<std::future<worker_result>> futures;
+
+        // Launch workers
+        for (int i = 0; i < num_workers; ++i) {
+            futures.push_back(std::async(
+                std::launch::async,
+                run_echo_worker,
+                port,
+                server.ae_title(),
+                i,
+                ops_per_worker,
+                std::ref(start_latch)
+            ));
+        }
+
+        high_resolution_timer total_timer;
+        total_timer.start();
+
+        // Release all workers simultaneously
+        start_latch.arrive_and_wait();
+
+        // Collect results
+        size_t total_success = 0;
+        size_t total_failure = 0;
+        benchmark_stats aggregate_latency;
+        std::chrono::milliseconds max_duration{0};
+
+        for (auto& future : futures) {
+            auto result = future.get();
+            total_success += result.success_count;
+            total_failure += result.failure_count;
+            max_duration = std::max(max_duration, result.total_duration);
+
+            // Aggregate latency stats
+            for (size_t i = 0; i < result.latency_stats.count; ++i) {
+                aggregate_latency.record(result.latency_stats.mean_ms());
+            }
+
+            if (!result.error_message.empty()) {
+                INFO("Worker error: " << result.error_message);
+            }
+        }
+
+        total_timer.stop();
+
+        double total_seconds = total_timer.elapsed_seconds();
+        double throughput = static_cast<double>(total_success) / total_seconds;
+        size_t expected_total = num_workers * ops_per_worker;
+
+        std::cout << "\n=== Concurrent C-ECHO (" << num_workers << " workers) ===" << std::endl;
+        std::cout << "  Expected operations: " << expected_total << std::endl;
+        std::cout << "  Successful: " << total_success << std::endl;
+        std::cout << "  Failed: " << total_failure << std::endl;
+        std::cout << "  Total time: " << total_seconds << " s" << std::endl;
+        std::cout << "  Max worker duration: " << max_duration.count() << " ms" << std::endl;
+        std::cout << "  Aggregate throughput: " << throughput << " echo/s" << std::endl;
+        std::cout << "  Per-worker throughput: " << (throughput / num_workers) << " echo/s" << std::endl;
+        std::cout << "  Success rate: "
+                  << (100.0 * total_success / expected_total) << "%" << std::endl;
+
+        // Baseline requirements
+        REQUIRE(total_success >= expected_total * 0.95);  // 95% success rate
+        REQUIRE(throughput >= 50.0);  // At least 50 echo/s aggregate
+    }
+
+    server.stop();
+}
+
+TEST_CASE("Concurrent C-STORE operations", "[benchmark][concurrent][store]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_with_storage());
+    REQUIRE(server.start());
+
+    SECTION("Multiple concurrent connections with C-STORE") {
+        constexpr int num_workers = 5;
+        constexpr int ops_per_worker = 20;
+
+        std::latch start_latch(num_workers + 1);
+        std::vector<std::future<worker_result>> futures;
+
+        for (int i = 0; i < num_workers; ++i) {
+            futures.push_back(std::async(
+                std::launch::async,
+                run_store_worker,
+                port,
+                server.ae_title(),
+                i,
+                ops_per_worker,
+                std::ref(start_latch)
+            ));
+        }
+
+        high_resolution_timer total_timer;
+        total_timer.start();
+
+        start_latch.arrive_and_wait();
+
+        size_t total_success = 0;
+        size_t total_failure = 0;
+        std::chrono::milliseconds max_duration{0};
+
+        for (auto& future : futures) {
+            auto result = future.get();
+            total_success += result.success_count;
+            total_failure += result.failure_count;
+            max_duration = std::max(max_duration, result.total_duration);
+
+            if (!result.error_message.empty()) {
+                INFO("Worker error: " << result.error_message);
+            }
+        }
+
+        total_timer.stop();
+
+        double total_seconds = total_timer.elapsed_seconds();
+        double throughput = static_cast<double>(total_success) / total_seconds;
+        size_t expected_total = num_workers * ops_per_worker;
+
+        std::cout << "\n=== Concurrent C-STORE (" << num_workers << " workers) ===" << std::endl;
+        std::cout << "  Expected operations: " << expected_total << std::endl;
+        std::cout << "  Successful: " << total_success << std::endl;
+        std::cout << "  Failed: " << total_failure << std::endl;
+        std::cout << "  Server received: " << server.store_count() << std::endl;
+        std::cout << "  Total time: " << total_seconds << " s" << std::endl;
+        std::cout << "  Aggregate throughput: " << throughput << " store/s" << std::endl;
+        std::cout << "  Success rate: "
+                  << (100.0 * total_success / expected_total) << "%" << std::endl;
+
+        REQUIRE(total_success >= expected_total * 0.90);  // 90% success rate
+        REQUIRE(throughput >= 10.0);  // At least 10 store/s aggregate
+    }
+
+    server.stop();
+}
+
+TEST_CASE("Scalability test", "[benchmark][concurrent][scalability]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("Throughput scaling with worker count") {
+        constexpr int ops_per_worker = 30;
+        std::vector<int> worker_counts = {1, 2, 4, 8, 16};
+
+        std::cout << "\n=== Scalability Test ===" << std::endl;
+        std::cout << "  Operations per worker: " << ops_per_worker << std::endl;
+
+        std::vector<double> throughputs;
+
+        for (int num_workers : worker_counts) {
+            std::latch start_latch(num_workers + 1);
+            std::vector<std::future<worker_result>> futures;
+
+            for (int i = 0; i < num_workers; ++i) {
+                futures.push_back(std::async(
+                    std::launch::async,
+                    run_echo_worker,
+                    port,
+                    server.ae_title(),
+                    i,
+                    ops_per_worker,
+                    std::ref(start_latch)
+                ));
+            }
+
+            high_resolution_timer timer;
+            timer.start();
+            start_latch.arrive_and_wait();
+
+            size_t total_success = 0;
+            for (auto& future : futures) {
+                auto result = future.get();
+                total_success += result.success_count;
+            }
+
+            timer.stop();
+
+            double throughput = static_cast<double>(total_success) / timer.elapsed_seconds();
+            throughputs.push_back(throughput);
+
+            std::cout << "\n  " << num_workers << " workers:" << std::endl;
+            std::cout << "    Success: " << total_success << "/" << (num_workers * ops_per_worker) << std::endl;
+            std::cout << "    Throughput: " << throughput << " ops/s" << std::endl;
+
+            // Allow server to recover between tests
+            std::this_thread::sleep_for(std::chrono::milliseconds{500});
+        }
+
+        // Verify reasonable scaling
+        // Throughput should increase (though not linearly) with more workers
+        for (size_t i = 1; i < throughputs.size(); ++i) {
+            double scaling_factor = throughputs[i] / throughputs[0];
+            std::cout << "\n  Scaling factor (" << worker_counts[i]
+                      << " vs 1 worker): " << scaling_factor << "x" << std::endl;
+        }
+
+        // At least some improvement with 2 workers
+        REQUIRE(throughputs[1] >= throughputs[0] * 0.9);
+    }
+
+    server.stop();
+}
+
+TEST_CASE("Connection saturation test", "[benchmark][concurrent][saturation]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("Hold multiple connections simultaneously") {
+        constexpr int num_connections = 20;
+        std::vector<std::optional<association>> connections;
+        size_t successful_connections = 0;
+
+        high_resolution_timer timer;
+        timer.start();
+
+        for (int i = 0; i < num_connections; ++i) {
+            auto config = make_echo_config(
+                "HOLD_" + std::to_string(i), server.ae_title());
+
+            auto result = association::connect(
+                "localhost", port, config, default_timeout);
+
+            if (result.is_ok()) {
+                connections.push_back(std::move(result.value()));
+                ++successful_connections;
+            } else {
+                connections.push_back(std::nullopt);
+            }
+        }
+
+        timer.stop();
+
+        std::cout << "\n=== Connection Saturation Test ===" << std::endl;
+        std::cout << "  Requested connections: " << num_connections << std::endl;
+        std::cout << "  Successful: " << successful_connections << std::endl;
+        std::cout << "  Active (server): " << server.active_associations() << std::endl;
+        std::cout << "  Time to establish all: " << timer.elapsed_ms().count() << " ms" << std::endl;
+
+        // Perform C-ECHO on all held connections
+        size_t echo_success = 0;
+        for (auto& opt_assoc : connections) {
+            if (opt_assoc) {
+                auto ctx = opt_assoc->accepted_context_id(verification_sop_class_uid);
+                if (ctx) {
+                    auto echo_rq = make_c_echo_rq(1, verification_sop_class_uid);
+                    if (opt_assoc->send_dimse(*ctx, echo_rq).is_ok()) {
+                        auto recv = opt_assoc->receive_dimse(default_timeout);
+                        if (recv.is_ok() && recv.value().second.status() == status_success) {
+                            ++echo_success;
+                        }
+                    }
+                }
+            }
+        }
+
+        std::cout << "  C-ECHO success on held connections: " << echo_success << std::endl;
+
+        // Release all connections
+        for (auto& opt_assoc : connections) {
+            if (opt_assoc) {
+                (void)opt_assoc->release(std::chrono::milliseconds{500});
+            }
+        }
+        connections.clear();
+
+        // Verify server can accept new connections after release
+        std::this_thread::sleep_for(std::chrono::milliseconds{200});
+
+        auto new_config = make_echo_config("AFTER_RELEASE", server.ae_title());
+        auto new_result = association::connect("localhost", port, new_config, default_timeout);
+        REQUIRE(new_result.is_ok());
+        (void)new_result.value().release(std::chrono::milliseconds{1000});
+
+        std::cout << "  Post-release connection: SUCCESS" << std::endl;
+
+        REQUIRE(successful_connections >= num_connections * 0.9);
+        REQUIRE(echo_success >= successful_connections * 0.95);
+    }
+
+    server.stop();
+}

--- a/benchmarks/thread_performance/shutdown_benchmark.cpp
+++ b/benchmarks/thread_performance/shutdown_benchmark.cpp
@@ -1,0 +1,427 @@
+/**
+ * @file shutdown_benchmark.cpp
+ * @brief Server shutdown time benchmarks
+ *
+ * Measures the time required to gracefully shut down the DICOM server
+ * under various conditions (idle, with active connections, under load).
+ *
+ * Key metrics:
+ * - Idle server shutdown time
+ * - Shutdown with active associations
+ * - Shutdown under load
+ * - Resource cleanup verification
+ *
+ * @see Issue #154 - Establish performance baseline benchmarks for thread migration
+ */
+
+#include "benchmark_common.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include <atomic>
+#include <future>
+#include <iostream>
+#include <latch>
+#include <thread>
+#include <vector>
+
+using namespace pacs::benchmark;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::services;
+
+// =============================================================================
+// Shutdown Benchmarks
+// =============================================================================
+
+TEST_CASE("Idle server shutdown time", "[benchmark][shutdown][idle]") {
+    SECTION("Immediate shutdown after start") {
+        constexpr int iterations = 10;
+        benchmark_stats stats;
+
+        for (int i = 0; i < iterations; ++i) {
+            auto port = find_available_port();
+
+            server_config config;
+            config.ae_title = "SHUTDOWN_TEST";
+            config.port = port;
+            config.max_associations = 50;
+            config.idle_timeout = std::chrono::seconds{30};
+            config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.5";
+
+            auto server = std::make_unique<dicom_server>(config);
+            server->register_service(std::make_shared<verification_scp>());
+
+            REQUIRE(server->start().is_ok());
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+            high_resolution_timer timer;
+            timer.start();
+
+            server->stop();
+
+            timer.stop();
+            stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+
+            server.reset();
+        }
+
+        std::cout << "\n=== Idle Server Shutdown ===" << std::endl;
+        std::cout << "  Iterations: " << stats.count << std::endl;
+        std::cout << "  Mean: " << stats.mean_ms() << " ms" << std::endl;
+        std::cout << "  Std Dev: " << stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "  Min: " << stats.min_ms << " ms" << std::endl;
+        std::cout << "  Max: " << stats.max_ms << " ms" << std::endl;
+
+        // Baseline: idle shutdown should complete within 1 second
+        REQUIRE(stats.mean_ms() < 1000.0);
+        REQUIRE(stats.max_ms < 2000.0);
+    }
+
+    SECTION("Shutdown after warmup traffic") {
+        constexpr int iterations = 5;
+        benchmark_stats stats;
+
+        for (int i = 0; i < iterations; ++i) {
+            auto port = find_available_port();
+
+            server_config config;
+            config.ae_title = "WARMUP_TEST";
+            config.port = port;
+            config.max_associations = 50;
+            config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.6";
+
+            auto server = std::make_unique<dicom_server>(config);
+            server->register_service(std::make_shared<verification_scp>());
+
+            REQUIRE(server->start().is_ok());
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+            // Perform some warmup operations
+            for (int j = 0; j < 10; ++j) {
+                auto assoc_config = make_echo_config("WARMUP_SCU", "WARMUP_TEST");
+                auto result = association::connect("localhost", port, assoc_config, default_timeout);
+                if (result.is_ok()) {
+                    auto& assoc = result.value();
+                    auto ctx = assoc.accepted_context_id(verification_sop_class_uid);
+                    if (ctx) {
+                        auto echo_rq = make_c_echo_rq(1, verification_sop_class_uid);
+                        (void)assoc.send_dimse(*ctx, echo_rq);
+                        (void)assoc.receive_dimse(default_timeout);
+                    }
+                    (void)assoc.release(std::chrono::milliseconds{500});
+                }
+            }
+
+            // Wait for all connections to close
+            std::this_thread::sleep_for(std::chrono::milliseconds{200});
+
+            high_resolution_timer timer;
+            timer.start();
+
+            server->stop();
+
+            timer.stop();
+            stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+
+            server.reset();
+        }
+
+        std::cout << "\n=== Shutdown After Warmup ===" << std::endl;
+        std::cout << "  Iterations: " << stats.count << std::endl;
+        std::cout << "  Mean: " << stats.mean_ms() << " ms" << std::endl;
+        std::cout << "  Std Dev: " << stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "  Min: " << stats.min_ms << " ms" << std::endl;
+        std::cout << "  Max: " << stats.max_ms << " ms" << std::endl;
+
+        REQUIRE(stats.mean_ms() < 2000.0);
+    }
+}
+
+TEST_CASE("Shutdown with active connections", "[benchmark][shutdown][active]") {
+    SECTION("Shutdown with held connections") {
+        auto port = find_available_port();
+
+        server_config config;
+        config.ae_title = "ACTIVE_TEST";
+        config.port = port;
+        config.max_associations = 50;
+        config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.7";
+
+        auto server = std::make_unique<dicom_server>(config);
+        server->register_service(std::make_shared<verification_scp>());
+
+        REQUIRE(server->start().is_ok());
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+        // Establish and hold multiple connections
+        constexpr int num_connections = 5;
+        std::vector<std::optional<association>> connections;
+
+        for (int i = 0; i < num_connections; ++i) {
+            auto assoc_config = make_echo_config(
+                "HOLD_" + std::to_string(i), "ACTIVE_TEST");
+            auto result = association::connect("localhost", port, assoc_config, default_timeout);
+            if (result.is_ok()) {
+                connections.push_back(std::move(result.value()));
+            }
+        }
+
+        size_t active_before = server->active_associations();
+        std::cout << "\n=== Shutdown With Active Connections ===" << std::endl;
+        std::cout << "  Held connections: " << connections.size() << std::endl;
+        std::cout << "  Active associations (before): " << active_before << std::endl;
+
+        high_resolution_timer timer;
+        timer.start();
+
+        // Shutdown should handle active connections gracefully
+        server->stop();
+
+        timer.stop();
+
+        std::cout << "  Shutdown time: " << timer.elapsed_ms().count() << " ms" << std::endl;
+
+        // Clean up client-side connections (they should be disconnected by now)
+        connections.clear();
+
+        // Baseline: shutdown with active connections should complete within 5 seconds
+        REQUIRE(timer.elapsed_ms().count() < 5000);
+
+        server.reset();
+    }
+}
+
+TEST_CASE("Shutdown under load", "[benchmark][shutdown][load]") {
+    SECTION("Shutdown during active operations") {
+        auto port = find_available_port();
+
+        server_config config;
+        config.ae_title = "LOAD_TEST";
+        config.port = port;
+        config.max_associations = 50;
+        config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.8";
+
+        auto server = std::make_unique<dicom_server>(config);
+        server->register_service(std::make_shared<verification_scp>());
+
+        auto storage_service = std::make_shared<storage_scp>();
+        storage_service->set_handler([](
+            const pacs::core::dicom_dataset& /* dataset */,
+            const std::string& /* calling_ae */,
+            const std::string& /* sop_class_uid */,
+            const std::string& /* sop_instance_uid */) {
+            return storage_status::success;
+        });
+        server->register_service(storage_service);
+
+        REQUIRE(server->start().is_ok());
+        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+        // Start background workers that generate load
+        std::atomic<bool> stop_workers{false};
+        std::atomic<size_t> operations_completed{0};
+
+        auto worker = [&]() {
+            while (!stop_workers.load()) {
+                auto assoc_config = make_echo_config("LOAD_SCU", "LOAD_TEST");
+                auto result = association::connect(
+                    "localhost", port, assoc_config,
+                    std::chrono::milliseconds{2000});
+
+                if (result.is_ok()) {
+                    auto& assoc = result.value();
+                    auto ctx = assoc.accepted_context_id(verification_sop_class_uid);
+                    if (ctx) {
+                        for (int i = 0; i < 5 && !stop_workers.load(); ++i) {
+                            auto echo_rq = make_c_echo_rq(
+                                static_cast<uint16_t>(i + 1), verification_sop_class_uid);
+                            if (assoc.send_dimse(*ctx, echo_rq).is_ok()) {
+                                auto recv = assoc.receive_dimse(std::chrono::milliseconds{2000});
+                                if (recv.is_ok()) {
+                                    ++operations_completed;
+                                }
+                            }
+                        }
+                    }
+                    (void)assoc.release(std::chrono::milliseconds{500});
+                }
+            }
+        };
+
+        constexpr int num_workers = 3;
+        std::vector<std::future<void>> workers;
+        for (int i = 0; i < num_workers; ++i) {
+            workers.push_back(std::async(std::launch::async, worker));
+        }
+
+        // Let workers run for a bit
+        std::this_thread::sleep_for(std::chrono::seconds{2});
+
+        std::cout << "\n=== Shutdown Under Load ===" << std::endl;
+        std::cout << "  Workers: " << num_workers << std::endl;
+        std::cout << "  Operations before shutdown: " << operations_completed.load() << std::endl;
+        std::cout << "  Active associations: " << server->active_associations() << std::endl;
+
+        // Signal workers to stop
+        stop_workers.store(true);
+
+        high_resolution_timer timer;
+        timer.start();
+
+        // Shutdown while workers are still running
+        server->stop();
+
+        timer.stop();
+
+        // Wait for workers to complete
+        for (auto& w : workers) {
+            w.wait();
+        }
+
+        std::cout << "  Operations at shutdown: " << operations_completed.load() << std::endl;
+        std::cout << "  Shutdown time: " << timer.elapsed_ms().count() << " ms" << std::endl;
+
+        // Baseline: shutdown under load should complete within 10 seconds
+        REQUIRE(timer.elapsed_ms().count() < 10000);
+
+        server.reset();
+    }
+}
+
+TEST_CASE("Repeated start-stop cycles", "[benchmark][shutdown][cycles]") {
+    SECTION("Multiple start-stop cycles") {
+        constexpr int cycles = 10;
+        benchmark_stats start_stats;
+        benchmark_stats stop_stats;
+
+        auto port = find_available_port();
+
+        server_config config;
+        config.ae_title = "CYCLE_TEST";
+        config.port = port;
+        config.max_associations = 50;
+        config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.9";
+
+        for (int i = 0; i < cycles; ++i) {
+            auto server = std::make_unique<dicom_server>(config);
+            server->register_service(std::make_shared<verification_scp>());
+
+            high_resolution_timer start_timer;
+            start_timer.start();
+
+            auto result = server->start();
+            REQUIRE(result.is_ok());
+
+            start_timer.stop();
+            start_stats.record(static_cast<double>(start_timer.elapsed_us().count()) / 1000.0);
+
+            // Brief operation
+            std::this_thread::sleep_for(std::chrono::milliseconds{50});
+
+            high_resolution_timer stop_timer;
+            stop_timer.start();
+
+            server->stop();
+
+            stop_timer.stop();
+            stop_stats.record(static_cast<double>(stop_timer.elapsed_us().count()) / 1000.0);
+
+            server.reset();
+
+            // Small delay between cycles
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+        }
+
+        std::cout << "\n=== Start-Stop Cycles ===" << std::endl;
+        std::cout << "  Cycles: " << cycles << std::endl;
+        std::cout << "\n  Start time:" << std::endl;
+        std::cout << "    Mean: " << start_stats.mean_ms() << " ms" << std::endl;
+        std::cout << "    Std Dev: " << start_stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "    Min: " << start_stats.min_ms << " ms" << std::endl;
+        std::cout << "    Max: " << start_stats.max_ms << " ms" << std::endl;
+        std::cout << "\n  Stop time:" << std::endl;
+        std::cout << "    Mean: " << stop_stats.mean_ms() << " ms" << std::endl;
+        std::cout << "    Std Dev: " << stop_stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "    Min: " << stop_stats.min_ms << " ms" << std::endl;
+        std::cout << "    Max: " << stop_stats.max_ms << " ms" << std::endl;
+
+        // Baseline requirements
+        REQUIRE(start_stats.mean_ms() < 500.0);
+        REQUIRE(stop_stats.mean_ms() < 1000.0);
+    }
+}
+
+TEST_CASE("Graceful vs forced shutdown", "[benchmark][shutdown][graceful]") {
+    SECTION("Compare graceful and abort shutdown") {
+        // This test demonstrates the expected behavior for graceful shutdown
+        // After thread_system migration, shutdown should be more controlled
+
+        auto port = find_available_port();
+
+        server_config config;
+        config.ae_title = "GRACEFUL_TEST";
+        config.port = port;
+        config.max_associations = 50;
+        config.implementation_class_uid = "1.2.826.0.1.3680043.9.8888.10";
+
+        // Test 1: Graceful shutdown (no active connections)
+        {
+            auto server = std::make_unique<dicom_server>(config);
+            server->register_service(std::make_shared<verification_scp>());
+            REQUIRE(server->start().is_ok());
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+            high_resolution_timer timer;
+            timer.start();
+            server->stop();  // Default graceful shutdown
+            timer.stop();
+
+            std::cout << "\n=== Graceful Shutdown (no connections) ===" << std::endl;
+            std::cout << "  Time: " << timer.elapsed_ms().count() << " ms" << std::endl;
+
+            REQUIRE(timer.elapsed_ms().count() < 2000);
+        }
+
+        // Allow port to be released
+        std::this_thread::sleep_for(std::chrono::milliseconds{200});
+        port = find_available_port();
+        config.port = port;
+
+        // Test 2: Shutdown with pending connection
+        {
+            auto server = std::make_unique<dicom_server>(config);
+            server->register_service(std::make_shared<verification_scp>());
+            REQUIRE(server->start().is_ok());
+            std::this_thread::sleep_for(std::chrono::milliseconds{100});
+
+            // Establish a connection
+            auto assoc_config = make_echo_config("PENDING_SCU", "GRACEFUL_TEST");
+            auto result = association::connect("localhost", port, assoc_config, default_timeout);
+            REQUIRE(result.is_ok());
+
+            auto& assoc = result.value();
+            // Don't release - leave it pending
+
+            high_resolution_timer timer;
+            timer.start();
+            server->stop();
+            timer.stop();
+
+            std::cout << "\n=== Shutdown (pending connection) ===" << std::endl;
+            std::cout << "  Time: " << timer.elapsed_ms().count() << " ms" << std::endl;
+
+            // Connection should be terminated by server shutdown
+            // Client side cleanup
+            // Note: assoc might already be disconnected, so ignore result
+            // source=0 (service-user), reason=0 (not-specified)
+            (void)assoc.abort(0, 0);
+
+            REQUIRE(timer.elapsed_ms().count() < 5000);
+        }
+
+        std::cout << "\n  [Note: After thread_system migration, graceful shutdown" << std::endl;
+        std::cout << "   should use cancellation_token for cooperative cancellation]" << std::endl;
+    }
+}

--- a/benchmarks/thread_performance/throughput_benchmark.cpp
+++ b/benchmarks/thread_performance/throughput_benchmark.cpp
@@ -1,0 +1,392 @@
+/**
+ * @file throughput_benchmark.cpp
+ * @brief Message throughput benchmarks
+ *
+ * Measures the message processing rate of the DICOM server,
+ * including C-ECHO and C-STORE operations.
+ *
+ * Key metrics:
+ * - C-ECHO messages per second (single connection)
+ * - C-STORE messages per second (single connection)
+ * - Sustained throughput over time
+ *
+ * @see Issue #154 - Establish performance baseline benchmarks for thread migration
+ */
+
+#include "benchmark_common.hpp"
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/benchmark/catch_benchmark.hpp>
+
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+using namespace pacs::benchmark;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::services;
+
+// =============================================================================
+// C-ECHO Throughput Benchmarks
+// =============================================================================
+
+TEST_CASE("C-ECHO throughput baseline", "[benchmark][throughput][echo]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("Single connection C-ECHO throughput") {
+        auto config = make_echo_config("BENCH_ECHO", server.ae_title());
+        auto connect_result = association::connect("localhost", port, config, default_timeout);
+        REQUIRE(connect_result.is_ok());
+
+        auto& assoc = connect_result.value();
+        auto ctx = assoc.accepted_context_id(verification_sop_class_uid);
+        REQUIRE(ctx.has_value());
+
+        // Warmup
+        for (int i = 0; i < 10; ++i) {
+            auto echo_rq = make_c_echo_rq(static_cast<uint16_t>(i + 1), verification_sop_class_uid);
+            (void)assoc.send_dimse(*ctx, echo_rq);
+            (void)assoc.receive_dimse(default_timeout);
+        }
+
+        // Benchmark
+        constexpr int iterations = 500;
+        benchmark_stats stats;
+        size_t success_count = 0;
+
+        high_resolution_timer total_timer;
+        total_timer.start();
+
+        for (int i = 0; i < iterations; ++i) {
+            high_resolution_timer timer;
+            timer.start();
+
+            auto echo_rq = make_c_echo_rq(static_cast<uint16_t>(i + 100), verification_sop_class_uid);
+            auto send_result = assoc.send_dimse(*ctx, echo_rq);
+            if (send_result.is_err()) continue;
+
+            auto recv_result = assoc.receive_dimse(default_timeout);
+            timer.stop();
+
+            if (recv_result.is_ok() && recv_result.value().second.status() == status_success) {
+                ++success_count;
+                stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+            }
+        }
+
+        total_timer.stop();
+
+        double total_seconds = total_timer.elapsed_seconds();
+        double echo_per_second = static_cast<double>(success_count) / total_seconds;
+
+        std::cout << "\n=== C-ECHO Throughput (Single Connection) ===" << std::endl;
+        std::cout << "  Iterations: " << iterations << std::endl;
+        std::cout << "  Successful: " << success_count << std::endl;
+        std::cout << "  Total time: " << total_seconds << " s" << std::endl;
+        std::cout << "  Throughput: " << echo_per_second << " echo/s" << std::endl;
+        std::cout << "  Mean latency: " << stats.mean_ms() << " ms" << std::endl;
+        std::cout << "  Std Dev: " << stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "  Min latency: " << stats.min_ms << " ms" << std::endl;
+        std::cout << "  Max latency: " << stats.max_ms << " ms" << std::endl;
+
+        (void)assoc.release(std::chrono::milliseconds{2000});
+
+        // Baseline requirements
+        REQUIRE(success_count >= iterations * 0.99);  // 99% success rate
+        REQUIRE(echo_per_second >= 100.0);  // At least 100 echo/s
+    }
+
+    server.stop();
+}
+
+TEST_CASE("C-ECHO sustained throughput", "[benchmark][throughput][echo][sustained]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    SECTION("10-second sustained C-ECHO") {
+        auto config = make_echo_config("BENCH_SUSTAINED", server.ae_title());
+        auto connect_result = association::connect("localhost", port, config, default_timeout);
+        REQUIRE(connect_result.is_ok());
+
+        auto& assoc = connect_result.value();
+        auto ctx = assoc.accepted_context_id(verification_sop_class_uid);
+        REQUIRE(ctx.has_value());
+
+        constexpr auto duration = std::chrono::seconds{10};
+        size_t total_messages = 0;
+        size_t failed_messages = 0;
+
+        auto start = std::chrono::steady_clock::now();
+        auto end_time = start + duration;
+
+        while (std::chrono::steady_clock::now() < end_time) {
+            auto echo_rq = make_c_echo_rq(
+                static_cast<uint16_t>((total_messages % 65535) + 1),
+                verification_sop_class_uid);
+
+            auto send_result = assoc.send_dimse(*ctx, echo_rq);
+            if (send_result.is_err()) {
+                ++failed_messages;
+                continue;
+            }
+
+            auto recv_result = assoc.receive_dimse(std::chrono::milliseconds{5000});
+            if (recv_result.is_ok() && recv_result.value().second.status() == status_success) {
+                ++total_messages;
+            } else {
+                ++failed_messages;
+            }
+        }
+
+        auto actual_duration = std::chrono::steady_clock::now() - start;
+        double seconds = std::chrono::duration<double>(actual_duration).count();
+        double throughput = static_cast<double>(total_messages) / seconds;
+
+        std::cout << "\n=== Sustained C-ECHO Throughput (10s) ===" << std::endl;
+        std::cout << "  Duration: " << seconds << " s" << std::endl;
+        std::cout << "  Total messages: " << total_messages << std::endl;
+        std::cout << "  Failed messages: " << failed_messages << std::endl;
+        std::cout << "  Throughput: " << throughput << " msg/s" << std::endl;
+        std::cout << "  Success rate: "
+                  << (100.0 * total_messages / (total_messages + failed_messages)) << "%" << std::endl;
+
+        (void)assoc.release(std::chrono::milliseconds{2000});
+
+        // Baseline: sustained throughput should be at least 80% of burst
+        REQUIRE(throughput >= 80.0);
+    }
+
+    server.stop();
+}
+
+// =============================================================================
+// C-STORE Throughput Benchmarks
+// =============================================================================
+
+TEST_CASE("C-STORE throughput baseline", "[benchmark][throughput][store]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_with_storage());
+    REQUIRE(server.start());
+
+    SECTION("Single connection C-STORE throughput") {
+        auto config = make_store_config("BENCH_STORE", server.ae_title());
+        auto connect_result = association::connect("localhost", port, config, default_timeout);
+        REQUIRE(connect_result.is_ok());
+
+        auto& assoc = connect_result.value();
+        storage_scu_config scu_config;
+        scu_config.response_timeout = default_timeout;
+        storage_scu scu{scu_config};
+
+        // Generate a study UID for all images
+        auto study_uid = generate_uid();
+
+        // Warmup
+        for (int i = 0; i < 5; ++i) {
+            auto dataset = generate_benchmark_dataset(study_uid);
+            (void)scu.store(assoc, dataset);
+        }
+
+        // Reset server counter
+        size_t initial_count = server.store_count();
+
+        // Benchmark
+        constexpr int iterations = 100;
+        benchmark_stats stats;
+        size_t success_count = 0;
+
+        high_resolution_timer total_timer;
+        total_timer.start();
+
+        for (int i = 0; i < iterations; ++i) {
+            auto dataset = generate_benchmark_dataset(study_uid);
+
+            high_resolution_timer timer;
+            timer.start();
+
+            auto result = scu.store(assoc, dataset);
+
+            timer.stop();
+
+            if (result.is_ok() && result.value().is_success()) {
+                ++success_count;
+                stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+            }
+        }
+
+        total_timer.stop();
+
+        double total_seconds = total_timer.elapsed_seconds();
+        double store_per_second = static_cast<double>(success_count) / total_seconds;
+
+        std::cout << "\n=== C-STORE Throughput (Single Connection) ===" << std::endl;
+        std::cout << "  Iterations: " << iterations << std::endl;
+        std::cout << "  Successful: " << success_count << std::endl;
+        std::cout << "  Server received: " << (server.store_count() - initial_count) << std::endl;
+        std::cout << "  Total time: " << total_seconds << " s" << std::endl;
+        std::cout << "  Throughput: " << store_per_second << " store/s" << std::endl;
+        std::cout << "  Mean latency: " << stats.mean_ms() << " ms" << std::endl;
+        std::cout << "  Std Dev: " << stats.stddev_ms() << " ms" << std::endl;
+        std::cout << "  Min latency: " << stats.min_ms << " ms" << std::endl;
+        std::cout << "  Max latency: " << stats.max_ms << " ms" << std::endl;
+
+        // Calculate data throughput (64x64 16-bit = 8KB per image)
+        double bytes_per_image = 64 * 64 * 2;  // 8192 bytes
+        double mb_per_second = (static_cast<double>(success_count) * bytes_per_image)
+                              / (total_seconds * 1024.0 * 1024.0);
+        std::cout << "  Data rate: " << mb_per_second << " MB/s" << std::endl;
+
+        (void)assoc.release(std::chrono::milliseconds{2000});
+
+        // Baseline requirements
+        REQUIRE(success_count >= iterations * 0.95);  // 95% success rate
+        REQUIRE(store_per_second >= 20.0);  // At least 20 store/s for small images
+    }
+
+    server.stop();
+}
+
+TEST_CASE("C-STORE with varying image sizes", "[benchmark][throughput][store][sizes]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_with_storage());
+    REQUIRE(server.start());
+
+    SECTION("Image size impact on throughput") {
+        auto config = make_store_config("BENCH_SIZE", server.ae_title());
+        auto connect_result = association::connect("localhost", port, config, default_timeout);
+        REQUIRE(connect_result.is_ok());
+
+        auto& assoc = connect_result.value();
+        storage_scu_config scu_config;
+        scu_config.response_timeout = std::chrono::milliseconds{30000};
+        storage_scu scu{scu_config};
+
+        // Test different image sizes
+        struct size_test {
+            int rows;
+            int cols;
+            const char* name;
+        };
+
+        std::vector<size_test> sizes = {
+            {64, 64, "64x64 (8KB)"},
+            {128, 128, "128x128 (32KB)"},
+            {256, 256, "256x256 (128KB)"},
+            {512, 512, "512x512 (512KB)"}
+        };
+
+        std::cout << "\n=== C-STORE Throughput by Image Size ===" << std::endl;
+
+        for (const auto& size : sizes) {
+            constexpr int iterations = 20;
+            benchmark_stats stats;
+            size_t success_count = 0;
+
+            high_resolution_timer total_timer;
+            total_timer.start();
+
+            for (int i = 0; i < iterations; ++i) {
+                // Generate dataset with specific size
+                auto dataset = generate_benchmark_dataset();
+
+                // Update image dimensions
+                dataset.set_numeric<uint16_t>(
+                    pacs::core::tags::rows, pacs::encoding::vr_type::US,
+                    static_cast<uint16_t>(size.rows));
+                dataset.set_numeric<uint16_t>(
+                    pacs::core::tags::columns, pacs::encoding::vr_type::US,
+                    static_cast<uint16_t>(size.cols));
+
+                // Generate new pixel data
+                std::vector<uint16_t> pixel_data(size.rows * size.cols, 512);
+                pacs::core::dicom_element pixel_elem(
+                    pacs::core::tags::pixel_data, pacs::encoding::vr_type::OW);
+                pixel_elem.set_value(std::span<const uint8_t>(
+                    reinterpret_cast<const uint8_t*>(pixel_data.data()),
+                    pixel_data.size() * sizeof(uint16_t)));
+
+                // Remove old pixel data and add new
+                dataset.remove(pacs::core::tags::pixel_data);
+                dataset.insert(std::move(pixel_elem));
+
+                // Generate new SOP Instance UID
+                dataset.set_string(pacs::core::tags::sop_instance_uid,
+                                   pacs::encoding::vr_type::UI, generate_uid());
+
+                high_resolution_timer timer;
+                timer.start();
+
+                auto result = scu.store(assoc, dataset);
+
+                timer.stop();
+
+                if (result.is_ok() && result.value().is_success()) {
+                    ++success_count;
+                    stats.record(static_cast<double>(timer.elapsed_us().count()) / 1000.0);
+                }
+            }
+
+            total_timer.stop();
+
+            double total_seconds = total_timer.elapsed_seconds();
+            double store_per_second = static_cast<double>(success_count) / total_seconds;
+            double bytes_per_image = size.rows * size.cols * 2;
+            double mb_per_second = (static_cast<double>(success_count) * bytes_per_image)
+                                  / (total_seconds * 1024.0 * 1024.0);
+
+            std::cout << "\n  " << size.name << ":" << std::endl;
+            std::cout << "    Success: " << success_count << "/" << iterations << std::endl;
+            std::cout << "    Throughput: " << store_per_second << " store/s" << std::endl;
+            std::cout << "    Data rate: " << mb_per_second << " MB/s" << std::endl;
+            std::cout << "    Mean latency: " << stats.mean_ms() << " ms" << std::endl;
+        }
+
+        (void)assoc.release(std::chrono::milliseconds{2000});
+    }
+
+    server.stop();
+}
+
+// =============================================================================
+// Catch2 BENCHMARK macros
+// =============================================================================
+
+TEST_CASE("Throughput micro-benchmarks", "[.benchmark][throughput][micro]") {
+    auto port = find_available_port();
+    benchmark_server server(port);
+
+    REQUIRE(server.initialize_echo_only());
+    REQUIRE(server.start());
+
+    auto config = make_echo_config("BENCH_MICRO", server.ae_title());
+    auto connect_result = association::connect("localhost", port, config, default_timeout);
+    REQUIRE(connect_result.is_ok());
+
+    auto& assoc = connect_result.value();
+    auto ctx = assoc.accepted_context_id(verification_sop_class_uid);
+    REQUIRE(ctx.has_value());
+
+    static uint16_t msg_id = 0;
+
+    BENCHMARK("Single C-ECHO round-trip") {
+        auto echo_rq = make_c_echo_rq(++msg_id, verification_sop_class_uid);
+        (void)assoc.send_dimse(*ctx, echo_rq);
+        auto result = assoc.receive_dimse(default_timeout);
+        return result.is_ok();
+    };
+
+    (void)assoc.release(std::chrono::milliseconds{2000});
+    server.stop();
+}

--- a/docs/PERFORMANCE_BASELINE.md
+++ b/docs/PERFORMANCE_BASELINE.md
@@ -1,0 +1,223 @@
+# Performance Baseline for Thread Migration
+
+**Version:** 1.0.0
+**Date:** 2024-12-04
+**Related Issue:** #154 - Establish performance baseline benchmarks for thread migration
+
+## Overview
+
+This document defines the performance baseline for the PACS system before migrating from direct `std::thread` usage to `thread_system`. These measurements will be used to:
+
+1. Verify migration success (< 5% performance overhead)
+2. Identify performance regressions
+3. Compare thread_system vs direct std::thread overhead
+4. Justify architectural changes
+
+## Benchmark Categories
+
+### 1. Association Establishment Latency
+
+Measures the time to establish DICOM associations.
+
+| Metric | Baseline Target | Description |
+|--------|-----------------|-------------|
+| Single connection | < 100 ms | TCP + A-ASSOCIATE negotiation |
+| Full round-trip | < 200 ms | Connect + Release |
+| Connection + C-ECHO | < 150 ms | Connect + Single echo + Release |
+| Sequential rate | > 10 conn/s | Rapid sequential connections |
+
+### 2. Message Throughput
+
+Measures message processing rate.
+
+| Metric | Baseline Target | Description |
+|--------|-----------------|-------------|
+| C-ECHO (single conn) | > 100 msg/s | Verification messages |
+| C-ECHO (sustained 10s) | > 80 msg/s | Sustained throughput |
+| C-STORE (single conn) | > 20 store/s | Small images (64x64) |
+| Data rate (512x512) | > 5 MB/s | Large image transfer |
+
+### 3. Concurrent Load Handling
+
+Measures multi-connection performance.
+
+| Metric | Baseline Target | Description |
+|--------|-----------------|-------------|
+| Concurrent C-ECHO (10 workers) | > 50 ops/s aggregate | 95% success rate |
+| Concurrent C-STORE (5 workers) | > 10 ops/s aggregate | 90% success rate |
+| Scalability (1→16 workers) | > 0.9x base rate | No significant degradation |
+| Connection saturation (20 held) | > 90% success | Hold + operate |
+
+### 4. Shutdown Time
+
+Measures graceful shutdown performance.
+
+| Metric | Baseline Target | Description |
+|--------|-----------------|-------------|
+| Idle shutdown | < 1000 ms | No active connections |
+| Warmup shutdown | < 2000 ms | After traffic |
+| Active connections | < 5000 ms | With held connections |
+| Under load | < 10000 ms | During active operations |
+| Start-stop cycle | < 500 ms start, < 1000 ms stop | Repeated cycles |
+
+## Running Benchmarks
+
+### Quick Run
+
+```bash
+# Build with benchmarks enabled
+cmake -B build -DPACS_BUILD_BENCHMARKS=ON -DPACS_BUILD_TESTS=ON
+cmake --build build
+
+# Run quick benchmarks (subset)
+cmake --build build --target run_quick_benchmarks
+```
+
+### Full Run
+
+```bash
+# Run all benchmarks
+cmake --build build --target run_full_benchmarks
+```
+
+### CI Integration
+
+```bash
+# Run with JUnit output
+cmake --build build --target run_benchmarks_ci
+
+# Results in: build/benchmark_results.xml
+```
+
+### Manual Execution
+
+```bash
+# Run specific benchmark categories
+./build/bin/thread_performance_benchmarks "[benchmark][association]"
+./build/bin/thread_performance_benchmarks "[benchmark][throughput]"
+./build/bin/thread_performance_benchmarks "[benchmark][concurrent]"
+./build/bin/thread_performance_benchmarks "[benchmark][shutdown]"
+
+# Run with verbose output
+./build/bin/thread_performance_benchmarks -s -d yes
+```
+
+## Baseline Results Template
+
+After running benchmarks, record results in this format:
+
+### Association Establishment
+
+```
+Platform: [e.g., macOS ARM64, Ubuntu x64]
+Date: [YYYY-MM-DD]
+Compiler: [e.g., Apple Clang 15.0, GCC 13.1]
+
+Single connection:     [XX.X] ms (mean), [XX.X] ms (stddev)
+Full round-trip:       [XX.X] ms (mean), [XX.X] ms (stddev)
+Connect + C-ECHO:      [XX.X] ms (mean)
+Sequential rate:       [XX.X] conn/s
+```
+
+### Message Throughput
+
+```
+C-ECHO throughput:     [XXX.X] msg/s (single connection)
+C-ECHO sustained:      [XXX.X] msg/s (10-second test)
+C-STORE throughput:    [XX.X] store/s (64x64 images)
+Data rate (512x512):   [XX.X] MB/s
+```
+
+### Concurrent Load
+
+```
+10 workers C-ECHO:     [XXX.X] ops/s aggregate
+5 workers C-STORE:     [XX.X] ops/s aggregate
+Scalability factor:    [X.XX]x at 16 workers
+```
+
+### Shutdown Time
+
+```
+Idle shutdown:         [XXX] ms
+With 5 connections:    [XXXX] ms
+Under load:            [XXXX] ms
+```
+
+## Post-Migration Comparison
+
+After thread_system migration, run the same benchmarks and compare:
+
+| Metric | Baseline | After Migration | Change |
+|--------|----------|-----------------|--------|
+| Association latency | X ms | Y ms | Z% |
+| C-ECHO throughput | X msg/s | Y msg/s | Z% |
+| C-STORE throughput | X store/s | Y store/s | Z% |
+| Max concurrent | X | Y | Z% |
+| Shutdown time | X ms | Y ms | Z% |
+| Memory usage | X MB | Y MB | Z% |
+
+**Acceptance Criteria:**
+- Performance overhead < 5%
+- No memory leaks (24h test)
+- Graceful shutdown within 5 seconds
+
+## Environment Requirements
+
+### Hardware Recommendations
+
+- CPU: Multi-core (4+ cores recommended for concurrent tests)
+- RAM: 8GB+ (for concurrent load tests)
+- Network: Localhost testing (no network latency)
+
+### Software Requirements
+
+- C++20 compatible compiler
+- CMake 3.20+
+- Catch2 v3.4.0+ (fetched automatically)
+
+### Test Isolation
+
+For consistent results:
+
+1. Close unnecessary applications
+2. Disable power management features
+3. Run multiple iterations for statistical significance
+4. Record system load during tests
+
+## Benchmark Implementation Details
+
+### File Structure
+
+```
+benchmarks/
+└── thread_performance/
+    ├── CMakeLists.txt
+    ├── benchmark_common.hpp       # Common utilities
+    ├── association_benchmark.cpp  # Connection latency tests
+    ├── throughput_benchmark.cpp   # Message rate tests
+    ├── concurrent_load_benchmark.cpp  # Multi-connection tests
+    └── shutdown_benchmark.cpp     # Shutdown time tests
+```
+
+### Key Classes
+
+- `benchmark_stats`: Statistics accumulator (mean, stddev, min, max)
+- `high_resolution_timer`: Precise timing measurements
+- `benchmark_server`: Configurable test server fixture
+
+## Related Issues
+
+- #153 - Epic: Migrate from std::thread to thread_system/network_system
+- #155 - Verify thread_system stability and jthread support
+- #160 - Performance testing and optimization after thread migration
+
+## Version History
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0.0 | 2024-12-04 | Initial baseline document |
+
+---
+
+*This document is part of the thread_system migration project (Phase 1).*


### PR DESCRIPTION
## Summary

Implement comprehensive benchmark suite for measuring DICOM server performance before thread_system migration. This establishes baseline metrics that will be used to verify < 5% performance overhead after migration.

**Parent Epic:** #153

## Changes

### New Files

| File | Description |
|------|-------------|
| `benchmarks/thread_performance/benchmark_common.hpp` | Common utilities: timer, stats, server fixture, DICOM helpers |
| `benchmarks/thread_performance/association_benchmark.cpp` | Association establishment latency tests |
| `benchmarks/thread_performance/throughput_benchmark.cpp` | C-ECHO and C-STORE throughput tests |
| `benchmarks/thread_performance/concurrent_load_benchmark.cpp` | Multi-connection load handling tests |
| `benchmarks/thread_performance/shutdown_benchmark.cpp` | Server shutdown time tests |
| `benchmarks/thread_performance/CMakeLists.txt` | Build configuration with CTest integration |
| `docs/PERFORMANCE_BASELINE.md` | Documentation with baseline targets and usage guide |

### Modified Files

| File | Change |
|------|--------|
| `CMakeLists.txt` | Add benchmarks build section with PACS_BUILD_BENCHMARKS option |

## Benchmark Architecture

```
┌─────────────────────────────────────────────────────────────────┐
│               Thread Performance Benchmark Suite                 │
├─────────────────────────────────────────────────────────────────┤
│                                                                 │
│  ┌────────────────────────────────────────────────────────────┐ │
│  │               benchmark_common.hpp                          │ │
│  │  - high_resolution_timer: Precise timing measurements       │ │
│  │  - benchmark_stats: Mean, stddev, min, max, throughput      │ │
│  │  - benchmark_server: Configurable DICOM server fixture      │ │
│  │  - UID/Dataset generators for test data                     │ │
│  └────────────────────────────────────────────────────────────┘ │
│                           │                                     │
│     ┌─────────────────────┼─────────────────────┐               │
│     │                     │                     │               │
│     ▼                     ▼                     ▼               │
│  ┌──────────┐     ┌──────────────┐     ┌─────────────┐          │
│  │association│     │  throughput  │     │  concurrent │          │
│  │_benchmark │     │  _benchmark  │     │_load_bench  │          │
│  └─────┬────┘     └──────┬───────┘     └──────┬──────┘          │
│        │                 │                    │                 │
│        └─────────────────┼────────────────────┘                 │
│                          │                                      │
│                          ▼                                      │
│                  ┌───────────────┐                              │
│                  │   shutdown    │                              │
│                  │   _benchmark  │                              │
│                  └───────────────┘                              │
│                                                                 │
└─────────────────────────────────────────────────────────────────┘
```

## Baseline Targets

| Category | Metric | Target |
|----------|--------|--------|
| **Association** | Single connection | < 100 ms |
| | Full round-trip | < 200 ms |
| | Sequential rate | > 10 conn/s |
| **Throughput** | C-ECHO (single) | > 100 msg/s |
| | C-ECHO (sustained) | > 80 msg/s |
| | C-STORE (64x64) | > 20 store/s |
| **Concurrent** | 10 workers C-ECHO | > 50 ops/s |
| | 5 workers C-STORE | > 10 ops/s |
| | Scalability | > 0.9x base |
| **Shutdown** | Idle | < 1000 ms |
| | Active connections | < 5000 ms |
| | Under load | < 10000 ms |

## Build and Run

```bash
# Build with benchmarks enabled
cmake -B build -DPACS_BUILD_BENCHMARKS=ON -DPACS_BUILD_TESTS=ON
cmake --build build

# Run benchmark targets
cmake --build build --target run_quick_benchmarks   # Quick subset
cmake --build build --target run_full_benchmarks    # Full suite
cmake --build build --target run_benchmarks_ci      # With JUnit output

# Direct execution with filters
./build/bin/thread_performance_benchmarks "[benchmark][association]"
./build/bin/thread_performance_benchmarks "[benchmark][throughput]"
./build/bin/thread_performance_benchmarks "[benchmark][concurrent]"
./build/bin/thread_performance_benchmarks "[benchmark][shutdown]"
```

## Acceptance Criteria Checklist

- [x] Benchmark suite compiles without errors
- [x] Association latency benchmarks implemented
- [x] Message throughput benchmarks implemented
- [x] Concurrent load benchmarks implemented
- [x] Shutdown time benchmarks implemented
- [x] CMake integration with custom targets
- [x] Documentation with baseline targets and usage guide
- [x] CTest integration for automated discovery

## Test Plan

- [x] Build verification with PACS_BUILD_BENCHMARKS=ON
- [x] Benchmark executable lists all test cases
- [x] CMake custom targets work correctly
- [ ] Run benchmarks on CI (pending CI configuration)

## Notes

- Uses Catch2 v3 testing framework for benchmark infrastructure
- Statistics include mean, standard deviation, min/max, and throughput
- Benchmarks use dynamic port allocation to avoid conflicts
- Server fixtures are automatically configured with verification and storage services

Closes #154