### PR TITLE
feat(monitoring): Implement operation metrics collection (#210)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -602,11 +602,12 @@ else()
     message(STATUS "  [--] pacs_storage: OFF")
 endif()
 
-# Monitoring library (health check endpoint - Issue #211)
+# Monitoring library (health check endpoint - Issue #211, metrics - Issue #210)
 # Requires pacs_storage for file_storage and index_database checks
 if(TARGET pacs_storage)
     add_library(pacs_monitoring
         src/monitoring/health_checker.cpp
+        src/monitoring/pacs_metrics.cpp
     )
     target_include_directories(pacs_monitoring
         PUBLIC
@@ -902,12 +903,13 @@ if(PACS_BUILD_TESTS)
         )
     endif()
 
-    # Monitoring tests (Issue #211 - health check endpoint)
+    # Monitoring tests (Issue #211 - health check endpoint, Issue #210 - metrics)
     if(TARGET pacs_monitoring)
         add_executable(monitoring_tests
             tests/monitoring/health_status_test.cpp
             tests/monitoring/health_checker_test.cpp
             tests/monitoring/health_json_test.cpp
+            tests/monitoring/pacs_metrics_test.cpp
         )
         target_link_libraries(monitoring_tests
             PRIVATE

--- a/include/pacs/monitoring/pacs_metrics.hpp
+++ b/include/pacs/monitoring/pacs_metrics.hpp
@@ -1,0 +1,621 @@
+/**
+ * @file pacs_metrics.hpp
+ * @brief Operation metrics collection for PACS DICOM services
+ *
+ * This file provides the pacs_metrics class that tracks atomic counters and
+ * timing data for DICOM operations to enable performance monitoring with
+ * minimal overhead.
+ *
+ * @see Issue #210 - [Quick Win] feat(monitoring): Implement operation metrics collection
+ * @see DICOM PS3.7 - Message Exchange (DIMSE Services)
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <shared_mutex>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace pacs::monitoring {
+
+/**
+ * @enum dimse_operation
+ * @brief DICOM Message Service Element (DIMSE) operation types
+ *
+ * Represents the different DIMSE operations that can be tracked by the
+ * metrics system. These correspond to the standard DICOM network services.
+ */
+enum class dimse_operation {
+    c_echo,   ///< C-ECHO (Verification Service)
+    c_store,  ///< C-STORE (Storage Service)
+    c_find,   ///< C-FIND (Query Service)
+    c_move,   ///< C-MOVE (Retrieve Service)
+    c_get,    ///< C-GET (Retrieve Service)
+    n_create, ///< N-CREATE (MPPS)
+    n_set,    ///< N-SET (MPPS)
+    n_get,    ///< N-GET
+    n_action, ///< N-ACTION
+    n_event,  ///< N-EVENT-REPORT
+    n_delete  ///< N-DELETE
+};
+
+/**
+ * @brief Convert DIMSE operation to string representation
+ * @param op The DIMSE operation to convert
+ * @return String representation (e.g., "c_echo", "c_store")
+ */
+[[nodiscard]] constexpr std::string_view to_string(dimse_operation op) noexcept {
+    switch (op) {
+        case dimse_operation::c_echo:
+            return "c_echo";
+        case dimse_operation::c_store:
+            return "c_store";
+        case dimse_operation::c_find:
+            return "c_find";
+        case dimse_operation::c_move:
+            return "c_move";
+        case dimse_operation::c_get:
+            return "c_get";
+        case dimse_operation::n_create:
+            return "n_create";
+        case dimse_operation::n_set:
+            return "n_set";
+        case dimse_operation::n_get:
+            return "n_get";
+        case dimse_operation::n_action:
+            return "n_action";
+        case dimse_operation::n_event:
+            return "n_event";
+        case dimse_operation::n_delete:
+            return "n_delete";
+        default:
+            return "unknown";
+    }
+}
+
+/**
+ * @struct operation_counter
+ * @brief Atomic counter for tracking operation success/failure counts
+ *
+ * Thread-safe counters for tracking the number of successful and failed
+ * operations, along with timing statistics.
+ */
+struct operation_counter {
+    std::atomic<std::uint64_t> success_count{0};
+    std::atomic<std::uint64_t> failure_count{0};
+    std::atomic<std::uint64_t> total_duration_us{0};  ///< Total duration in microseconds
+    std::atomic<std::uint64_t> min_duration_us{UINT64_MAX};
+    std::atomic<std::uint64_t> max_duration_us{0};
+
+    /// Get total operation count (success + failure)
+    [[nodiscard]] std::uint64_t total_count() const noexcept {
+        return success_count.load(std::memory_order_relaxed) +
+               failure_count.load(std::memory_order_relaxed);
+    }
+
+    /// Get average duration in microseconds (0 if no operations)
+    [[nodiscard]] std::uint64_t average_duration_us() const noexcept {
+        const auto total = total_count();
+        if (total == 0) {
+            return 0;
+        }
+        return total_duration_us.load(std::memory_order_relaxed) / total;
+    }
+
+    /// Record a successful operation with duration
+    void record_success(std::chrono::microseconds duration) noexcept {
+        success_count.fetch_add(1, std::memory_order_relaxed);
+        const auto duration_us = static_cast<std::uint64_t>(duration.count());
+        total_duration_us.fetch_add(duration_us, std::memory_order_relaxed);
+
+        // Update min/max with CAS loops
+        auto current_min = min_duration_us.load(std::memory_order_relaxed);
+        while (duration_us < current_min &&
+               !min_duration_us.compare_exchange_weak(current_min, duration_us,
+                                                       std::memory_order_relaxed)) {
+            // Loop until successful
+        }
+
+        auto current_max = max_duration_us.load(std::memory_order_relaxed);
+        while (duration_us > current_max &&
+               !max_duration_us.compare_exchange_weak(current_max, duration_us,
+                                                       std::memory_order_relaxed)) {
+            // Loop until successful
+        }
+    }
+
+    /// Record a failed operation with duration
+    void record_failure(std::chrono::microseconds duration) noexcept {
+        failure_count.fetch_add(1, std::memory_order_relaxed);
+        const auto duration_us = static_cast<std::uint64_t>(duration.count());
+        total_duration_us.fetch_add(duration_us, std::memory_order_relaxed);
+
+        // Update min/max with CAS loops
+        auto current_min = min_duration_us.load(std::memory_order_relaxed);
+        while (duration_us < current_min &&
+               !min_duration_us.compare_exchange_weak(current_min, duration_us,
+                                                       std::memory_order_relaxed)) {
+        }
+
+        auto current_max = max_duration_us.load(std::memory_order_relaxed);
+        while (duration_us > current_max &&
+               !max_duration_us.compare_exchange_weak(current_max, duration_us,
+                                                       std::memory_order_relaxed)) {
+        }
+    }
+
+    /// Reset all counters to zero
+    void reset() noexcept {
+        success_count.store(0, std::memory_order_relaxed);
+        failure_count.store(0, std::memory_order_relaxed);
+        total_duration_us.store(0, std::memory_order_relaxed);
+        min_duration_us.store(UINT64_MAX, std::memory_order_relaxed);
+        max_duration_us.store(0, std::memory_order_relaxed);
+    }
+};
+
+/**
+ * @struct data_transfer_metrics
+ * @brief Metrics for tracking data transfer volumes
+ *
+ * Thread-safe counters for tracking bytes sent/received and image counts.
+ */
+struct data_transfer_metrics {
+    std::atomic<std::uint64_t> bytes_sent{0};
+    std::atomic<std::uint64_t> bytes_received{0};
+    std::atomic<std::uint64_t> images_stored{0};
+    std::atomic<std::uint64_t> images_retrieved{0};
+
+    /// Record bytes sent
+    void add_bytes_sent(std::uint64_t bytes) noexcept {
+        bytes_sent.fetch_add(bytes, std::memory_order_relaxed);
+    }
+
+    /// Record bytes received
+    void add_bytes_received(std::uint64_t bytes) noexcept {
+        bytes_received.fetch_add(bytes, std::memory_order_relaxed);
+    }
+
+    /// Record an image stored
+    void increment_images_stored() noexcept {
+        images_stored.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    /// Record an image retrieved
+    void increment_images_retrieved() noexcept {
+        images_retrieved.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    /// Reset all counters to zero
+    void reset() noexcept {
+        bytes_sent.store(0, std::memory_order_relaxed);
+        bytes_received.store(0, std::memory_order_relaxed);
+        images_stored.store(0, std::memory_order_relaxed);
+        images_retrieved.store(0, std::memory_order_relaxed);
+    }
+};
+
+/**
+ * @struct association_counters
+ * @brief Metrics for tracking DICOM association lifecycle
+ *
+ * Thread-safe counters for tracking association establishment, rejection,
+ * and current active count.
+ */
+struct association_counters {
+    std::atomic<std::uint64_t> total_established{0};
+    std::atomic<std::uint64_t> total_rejected{0};
+    std::atomic<std::uint64_t> total_aborted{0};
+    std::atomic<std::uint32_t> current_active{0};
+    std::atomic<std::uint32_t> peak_active{0};
+
+    /// Record an association being established
+    void record_established() noexcept {
+        total_established.fetch_add(1, std::memory_order_relaxed);
+        const auto active = current_active.fetch_add(1, std::memory_order_relaxed) + 1;
+
+        // Update peak with CAS loop
+        auto current_peak = peak_active.load(std::memory_order_relaxed);
+        while (active > current_peak &&
+               !peak_active.compare_exchange_weak(current_peak, active,
+                                                   std::memory_order_relaxed)) {
+        }
+    }
+
+    /// Record an association being released normally
+    void record_released() noexcept {
+        const auto prev = current_active.load(std::memory_order_relaxed);
+        if (prev > 0) {
+            current_active.fetch_sub(1, std::memory_order_relaxed);
+        }
+    }
+
+    /// Record an association being rejected
+    void record_rejected() noexcept {
+        total_rejected.fetch_add(1, std::memory_order_relaxed);
+    }
+
+    /// Record an association being aborted
+    void record_aborted() noexcept {
+        total_aborted.fetch_add(1, std::memory_order_relaxed);
+        const auto prev = current_active.load(std::memory_order_relaxed);
+        if (prev > 0) {
+            current_active.fetch_sub(1, std::memory_order_relaxed);
+        }
+    }
+
+    /// Reset all counters to zero
+    void reset() noexcept {
+        total_established.store(0, std::memory_order_relaxed);
+        total_rejected.store(0, std::memory_order_relaxed);
+        total_aborted.store(0, std::memory_order_relaxed);
+        current_active.store(0, std::memory_order_relaxed);
+        peak_active.store(0, std::memory_order_relaxed);
+    }
+};
+
+/**
+ * @class pacs_metrics
+ * @brief Central metrics collection for PACS DICOM operations
+ *
+ * The pacs_metrics class provides a thread-safe, low-overhead mechanism for
+ * tracking DICOM operation metrics including:
+ * - DIMSE operation counts and timing (C-ECHO, C-STORE, C-FIND, C-MOVE, C-GET)
+ * - Data transfer volumes (bytes sent/received, images stored/retrieved)
+ * - Association lifecycle events (established, rejected, aborted)
+ *
+ * Thread Safety: All public methods are thread-safe using atomic operations.
+ *
+ * @example
+ * @code
+ * // Get global metrics instance
+ * auto& metrics = pacs_metrics::global_metrics();
+ *
+ * // Record a successful C-STORE operation
+ * auto start = std::chrono::steady_clock::now();
+ * // ... perform C-STORE ...
+ * auto end = std::chrono::steady_clock::now();
+ * auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
+ * metrics.record_store(true, duration, 1024 * 1024);  // 1MB image
+ *
+ * // Export metrics
+ * std::string json = metrics.to_json();
+ * std::string prometheus = metrics.to_prometheus();
+ * @endcode
+ */
+class pacs_metrics {
+public:
+    // =========================================================================
+    // Construction and Global Access
+    // =========================================================================
+
+    /**
+     * @brief Default constructor
+     */
+    pacs_metrics() = default;
+
+    /**
+     * @brief Get the global singleton instance
+     * @return Reference to the global metrics instance
+     *
+     * Thread-safe lazy initialization using Meyer's singleton pattern.
+     */
+    [[nodiscard]] static pacs_metrics& global_metrics() noexcept {
+        static pacs_metrics instance;
+        return instance;
+    }
+
+    /// Non-copyable
+    pacs_metrics(const pacs_metrics&) = delete;
+    pacs_metrics& operator=(const pacs_metrics&) = delete;
+
+    /// Non-movable (singleton)
+    pacs_metrics(pacs_metrics&&) = delete;
+    pacs_metrics& operator=(pacs_metrics&&) = delete;
+
+    // =========================================================================
+    // DIMSE Operation Recording
+    // =========================================================================
+
+    /**
+     * @brief Record a C-STORE operation
+     * @param success Whether the operation succeeded
+     * @param duration Operation duration
+     * @param bytes_stored Number of bytes stored (0 if failed)
+     */
+    void record_store(bool success,
+                      std::chrono::microseconds duration,
+                      std::uint64_t bytes_stored = 0) noexcept {
+        if (success) {
+            c_store_.record_success(duration);
+            if (bytes_stored > 0) {
+                transfer_.add_bytes_received(bytes_stored);
+                transfer_.increment_images_stored();
+            }
+        } else {
+            c_store_.record_failure(duration);
+        }
+    }
+
+    /**
+     * @brief Record a C-FIND (query) operation
+     * @param success Whether the operation succeeded
+     * @param duration Operation duration
+     * @param matches Number of matching results
+     */
+    void record_query(bool success,
+                      std::chrono::microseconds duration,
+                      [[maybe_unused]] std::uint32_t matches = 0) noexcept {
+        if (success) {
+            c_find_.record_success(duration);
+        } else {
+            c_find_.record_failure(duration);
+        }
+    }
+
+    /**
+     * @brief Record a C-ECHO (verification) operation
+     * @param success Whether the operation succeeded
+     * @param duration Operation duration
+     */
+    void record_echo(bool success, std::chrono::microseconds duration) noexcept {
+        if (success) {
+            c_echo_.record_success(duration);
+        } else {
+            c_echo_.record_failure(duration);
+        }
+    }
+
+    /**
+     * @brief Record a C-MOVE operation
+     * @param success Whether the operation succeeded
+     * @param duration Operation duration
+     * @param images_moved Number of images moved
+     */
+    void record_move(bool success,
+                     std::chrono::microseconds duration,
+                     std::uint32_t images_moved = 0) noexcept {
+        if (success) {
+            c_move_.record_success(duration);
+            for (std::uint32_t i = 0; i < images_moved; ++i) {
+                transfer_.increment_images_retrieved();
+            }
+        } else {
+            c_move_.record_failure(duration);
+        }
+    }
+
+    /**
+     * @brief Record a C-GET operation
+     * @param success Whether the operation succeeded
+     * @param duration Operation duration
+     * @param images_retrieved Number of images retrieved
+     * @param bytes_retrieved Number of bytes retrieved
+     */
+    void record_get(bool success,
+                    std::chrono::microseconds duration,
+                    std::uint32_t images_retrieved = 0,
+                    std::uint64_t bytes_retrieved = 0) noexcept {
+        if (success) {
+            c_get_.record_success(duration);
+            for (std::uint32_t i = 0; i < images_retrieved; ++i) {
+                transfer_.increment_images_retrieved();
+            }
+            if (bytes_retrieved > 0) {
+                transfer_.add_bytes_sent(bytes_retrieved);
+            }
+        } else {
+            c_get_.record_failure(duration);
+        }
+    }
+
+    /**
+     * @brief Record a generic DIMSE operation
+     * @param op Operation type
+     * @param success Whether the operation succeeded
+     * @param duration Operation duration
+     */
+    void record_operation(dimse_operation op,
+                          bool success,
+                          std::chrono::microseconds duration) noexcept {
+        auto& counter = get_counter(op);
+        if (success) {
+            counter.record_success(duration);
+        } else {
+            counter.record_failure(duration);
+        }
+    }
+
+    // =========================================================================
+    // Data Transfer Recording
+    // =========================================================================
+
+    /**
+     * @brief Record bytes sent over the network
+     * @param bytes Number of bytes sent
+     */
+    void record_bytes_sent(std::uint64_t bytes) noexcept {
+        transfer_.add_bytes_sent(bytes);
+    }
+
+    /**
+     * @brief Record bytes received from the network
+     * @param bytes Number of bytes received
+     */
+    void record_bytes_received(std::uint64_t bytes) noexcept {
+        transfer_.add_bytes_received(bytes);
+    }
+
+    // =========================================================================
+    // Association Recording
+    // =========================================================================
+
+    /**
+     * @brief Record an association being established
+     */
+    void record_association_established() noexcept {
+        associations_.record_established();
+    }
+
+    /**
+     * @brief Record an association being released
+     */
+    void record_association_released() noexcept {
+        associations_.record_released();
+    }
+
+    /**
+     * @brief Record an association being rejected
+     */
+    void record_association_rejected() noexcept {
+        associations_.record_rejected();
+    }
+
+    /**
+     * @brief Record an association being aborted
+     */
+    void record_association_aborted() noexcept {
+        associations_.record_aborted();
+    }
+
+    // =========================================================================
+    // Metric Access
+    // =========================================================================
+
+    /**
+     * @brief Get operation counter for a specific DIMSE operation
+     * @param op The DIMSE operation type
+     * @return Const reference to the operation counter
+     */
+    [[nodiscard]] const operation_counter& get_counter(dimse_operation op) const noexcept {
+        switch (op) {
+            case dimse_operation::c_echo:
+                return c_echo_;
+            case dimse_operation::c_store:
+                return c_store_;
+            case dimse_operation::c_find:
+                return c_find_;
+            case dimse_operation::c_move:
+                return c_move_;
+            case dimse_operation::c_get:
+                return c_get_;
+            case dimse_operation::n_create:
+                return n_create_;
+            case dimse_operation::n_set:
+                return n_set_;
+            case dimse_operation::n_get:
+                return n_get_;
+            case dimse_operation::n_action:
+                return n_action_;
+            case dimse_operation::n_event:
+                return n_event_;
+            case dimse_operation::n_delete:
+                return n_delete_;
+            default:
+                return c_echo_;  // Should never happen
+        }
+    }
+
+    /**
+     * @brief Get mutable operation counter for a specific DIMSE operation
+     * @param op The DIMSE operation type
+     * @return Reference to the operation counter
+     */
+    [[nodiscard]] operation_counter& get_counter(dimse_operation op) noexcept {
+        return const_cast<operation_counter&>(
+            static_cast<const pacs_metrics*>(this)->get_counter(op));
+    }
+
+    /**
+     * @brief Get data transfer metrics
+     * @return Const reference to transfer metrics
+     */
+    [[nodiscard]] const data_transfer_metrics& transfer() const noexcept {
+        return transfer_;
+    }
+
+    /**
+     * @brief Get association counters
+     * @return Const reference to association counters
+     */
+    [[nodiscard]] const association_counters& associations() const noexcept {
+        return associations_;
+    }
+
+    // =========================================================================
+    // Export Methods
+    // =========================================================================
+
+    /**
+     * @brief Export metrics as JSON string
+     * @return JSON representation of all metrics
+     *
+     * The JSON format is suitable for REST API responses and integration
+     * with monitoring systems like Grafana.
+     */
+    [[nodiscard]] std::string to_json() const;
+
+    /**
+     * @brief Export metrics in Prometheus text format
+     * @param prefix Metric name prefix (default: "pacs")
+     * @return Prometheus exposition format text
+     *
+     * The output follows the Prometheus text-based format specification
+     * suitable for scraping by Prometheus servers.
+     */
+    [[nodiscard]] std::string to_prometheus(std::string_view prefix = "pacs") const;
+
+    // =========================================================================
+    // Reset
+    // =========================================================================
+
+    /**
+     * @brief Reset all metrics to zero
+     *
+     * Thread-safe reset of all counters. Useful for testing or periodic
+     * metric collection windows.
+     */
+    void reset() noexcept {
+        c_echo_.reset();
+        c_store_.reset();
+        c_find_.reset();
+        c_move_.reset();
+        c_get_.reset();
+        n_create_.reset();
+        n_set_.reset();
+        n_get_.reset();
+        n_action_.reset();
+        n_event_.reset();
+        n_delete_.reset();
+        transfer_.reset();
+        associations_.reset();
+    }
+
+private:
+    // DIMSE operation counters
+    operation_counter c_echo_;
+    operation_counter c_store_;
+    operation_counter c_find_;
+    operation_counter c_move_;
+    operation_counter c_get_;
+    operation_counter n_create_;
+    operation_counter n_set_;
+    operation_counter n_get_;
+    operation_counter n_action_;
+    operation_counter n_event_;
+    operation_counter n_delete_;
+
+    // Data transfer metrics
+    data_transfer_metrics transfer_;
+
+    // Association lifecycle counters
+    association_counters associations_;
+};
+
+}  // namespace pacs::monitoring

--- a/src/monitoring/pacs_metrics.cpp
+++ b/src/monitoring/pacs_metrics.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file pacs_metrics.cpp
+ * @brief Implementation of operation metrics collection for PACS DICOM services
+ *
+ * @see Issue #210 - [Quick Win] feat(monitoring): Implement operation metrics collection
+ */
+
+#include "pacs/monitoring/pacs_metrics.hpp"
+
+#include <iomanip>
+#include <sstream>
+
+namespace pacs::monitoring {
+
+namespace {
+
+/**
+ * @brief Helper to format a single operation counter as JSON object
+ * @param counter The operation counter to format
+ * @return JSON object string for the counter
+ */
+std::string counter_to_json(const operation_counter& counter) {
+    std::ostringstream oss;
+    const auto total = counter.total_count();
+    const auto success = counter.success_count.load(std::memory_order_relaxed);
+    const auto failure = counter.failure_count.load(std::memory_order_relaxed);
+    const auto avg_us = counter.average_duration_us();
+    const auto min_us = counter.min_duration_us.load(std::memory_order_relaxed);
+    const auto max_us = counter.max_duration_us.load(std::memory_order_relaxed);
+
+    oss << "{"
+        << R"("total":)" << total
+        << R"(,"success":)" << success
+        << R"(,"failure":)" << failure
+        << R"(,"avg_duration_us":)" << avg_us;
+
+    // Only include min/max if there were operations
+    if (total > 0) {
+        oss << R"(,"min_duration_us":)" << min_us
+            << R"(,"max_duration_us":)" << max_us;
+    }
+
+    oss << "}";
+    return oss.str();
+}
+
+/**
+ * @brief Helper to format Prometheus metrics for an operation counter
+ * @param oss Output stream
+ * @param prefix Metric prefix
+ * @param op_name Operation name
+ * @param counter The operation counter
+ */
+void counter_to_prometheus(std::ostringstream& oss,
+                            std::string_view prefix,
+                            std::string_view op_name,
+                            const operation_counter& counter) {
+    const auto success = counter.success_count.load(std::memory_order_relaxed);
+    const auto failure = counter.failure_count.load(std::memory_order_relaxed);
+    const auto total = counter.total_count();
+    const auto total_duration = counter.total_duration_us.load(std::memory_order_relaxed);
+
+    // Total operations counter
+    oss << "# HELP " << prefix << "_dimse_" << op_name << "_total "
+        << "Total " << op_name << " operations\n"
+        << "# TYPE " << prefix << "_dimse_" << op_name << "_total counter\n"
+        << prefix << "_dimse_" << op_name << "_total " << total << "\n";
+
+    // Success counter
+    oss << "# HELP " << prefix << "_dimse_" << op_name << "_success_total "
+        << "Successful " << op_name << " operations\n"
+        << "# TYPE " << prefix << "_dimse_" << op_name << "_success_total counter\n"
+        << prefix << "_dimse_" << op_name << "_success_total " << success << "\n";
+
+    // Failure counter
+    oss << "# HELP " << prefix << "_dimse_" << op_name << "_failure_total "
+        << "Failed " << op_name << " operations\n"
+        << "# TYPE " << prefix << "_dimse_" << op_name << "_failure_total counter\n"
+        << prefix << "_dimse_" << op_name << "_failure_total " << failure << "\n";
+
+    // Duration sum (for calculating averages)
+    oss << "# HELP " << prefix << "_dimse_" << op_name << "_duration_microseconds_sum "
+        << "Total duration of " << op_name << " operations in microseconds\n"
+        << "# TYPE " << prefix << "_dimse_" << op_name << "_duration_microseconds_sum counter\n"
+        << prefix << "_dimse_" << op_name << "_duration_microseconds_sum " << total_duration << "\n";
+
+    // Duration min/max (only if there were operations)
+    if (total > 0) {
+        const auto min_us = counter.min_duration_us.load(std::memory_order_relaxed);
+        const auto max_us = counter.max_duration_us.load(std::memory_order_relaxed);
+
+        oss << "# HELP " << prefix << "_dimse_" << op_name << "_duration_microseconds_min "
+            << "Minimum duration of " << op_name << " operations in microseconds\n"
+            << "# TYPE " << prefix << "_dimse_" << op_name << "_duration_microseconds_min gauge\n"
+            << prefix << "_dimse_" << op_name << "_duration_microseconds_min " << min_us << "\n";
+
+        oss << "# HELP " << prefix << "_dimse_" << op_name << "_duration_microseconds_max "
+            << "Maximum duration of " << op_name << " operations in microseconds\n"
+            << "# TYPE " << prefix << "_dimse_" << op_name << "_duration_microseconds_max gauge\n"
+            << prefix << "_dimse_" << op_name << "_duration_microseconds_max " << max_us << "\n";
+    }
+}
+
+}  // namespace
+
+std::string pacs_metrics::to_json() const {
+    std::ostringstream oss;
+    oss << "{";
+
+    // DIMSE operations section
+    oss << R"("dimse_operations":{)"
+        << R"("c_echo":)" << counter_to_json(c_echo_)
+        << R"(,"c_store":)" << counter_to_json(c_store_)
+        << R"(,"c_find":)" << counter_to_json(c_find_)
+        << R"(,"c_move":)" << counter_to_json(c_move_)
+        << R"(,"c_get":)" << counter_to_json(c_get_)
+        << R"(,"n_create":)" << counter_to_json(n_create_)
+        << R"(,"n_set":)" << counter_to_json(n_set_)
+        << R"(,"n_get":)" << counter_to_json(n_get_)
+        << R"(,"n_action":)" << counter_to_json(n_action_)
+        << R"(,"n_event":)" << counter_to_json(n_event_)
+        << R"(,"n_delete":)" << counter_to_json(n_delete_)
+        << "}";
+
+    // Data transfer section
+    oss << R"(,"data_transfer":{)"
+        << R"("bytes_sent":)" << transfer_.bytes_sent.load(std::memory_order_relaxed)
+        << R"(,"bytes_received":)" << transfer_.bytes_received.load(std::memory_order_relaxed)
+        << R"(,"images_stored":)" << transfer_.images_stored.load(std::memory_order_relaxed)
+        << R"(,"images_retrieved":)" << transfer_.images_retrieved.load(std::memory_order_relaxed)
+        << "}";
+
+    // Associations section
+    oss << R"(,"associations":{)"
+        << R"("total_established":)" << associations_.total_established.load(std::memory_order_relaxed)
+        << R"(,"total_rejected":)" << associations_.total_rejected.load(std::memory_order_relaxed)
+        << R"(,"total_aborted":)" << associations_.total_aborted.load(std::memory_order_relaxed)
+        << R"(,"current_active":)" << associations_.current_active.load(std::memory_order_relaxed)
+        << R"(,"peak_active":)" << associations_.peak_active.load(std::memory_order_relaxed)
+        << "}";
+
+    oss << "}";
+    return oss.str();
+}
+
+std::string pacs_metrics::to_prometheus(std::string_view prefix) const {
+    std::ostringstream oss;
+
+    // DIMSE operation metrics
+    counter_to_prometheus(oss, prefix, "c_echo", c_echo_);
+    counter_to_prometheus(oss, prefix, "c_store", c_store_);
+    counter_to_prometheus(oss, prefix, "c_find", c_find_);
+    counter_to_prometheus(oss, prefix, "c_move", c_move_);
+    counter_to_prometheus(oss, prefix, "c_get", c_get_);
+    counter_to_prometheus(oss, prefix, "n_create", n_create_);
+    counter_to_prometheus(oss, prefix, "n_set", n_set_);
+    counter_to_prometheus(oss, prefix, "n_get", n_get_);
+    counter_to_prometheus(oss, prefix, "n_action", n_action_);
+    counter_to_prometheus(oss, prefix, "n_event", n_event_);
+    counter_to_prometheus(oss, prefix, "n_delete", n_delete_);
+
+    // Data transfer metrics
+    oss << "# HELP " << prefix << "_bytes_sent_total Total bytes sent over network\n"
+        << "# TYPE " << prefix << "_bytes_sent_total counter\n"
+        << prefix << "_bytes_sent_total " << transfer_.bytes_sent.load(std::memory_order_relaxed) << "\n";
+
+    oss << "# HELP " << prefix << "_bytes_received_total Total bytes received from network\n"
+        << "# TYPE " << prefix << "_bytes_received_total counter\n"
+        << prefix << "_bytes_received_total " << transfer_.bytes_received.load(std::memory_order_relaxed) << "\n";
+
+    oss << "# HELP " << prefix << "_images_stored_total Total DICOM images stored\n"
+        << "# TYPE " << prefix << "_images_stored_total counter\n"
+        << prefix << "_images_stored_total " << transfer_.images_stored.load(std::memory_order_relaxed) << "\n";
+
+    oss << "# HELP " << prefix << "_images_retrieved_total Total DICOM images retrieved\n"
+        << "# TYPE " << prefix << "_images_retrieved_total counter\n"
+        << prefix << "_images_retrieved_total " << transfer_.images_retrieved.load(std::memory_order_relaxed) << "\n";
+
+    // Association metrics
+    oss << "# HELP " << prefix << "_associations_established_total Total associations established\n"
+        << "# TYPE " << prefix << "_associations_established_total counter\n"
+        << prefix << "_associations_established_total " << associations_.total_established.load(std::memory_order_relaxed) << "\n";
+
+    oss << "# HELP " << prefix << "_associations_rejected_total Total associations rejected\n"
+        << "# TYPE " << prefix << "_associations_rejected_total counter\n"
+        << prefix << "_associations_rejected_total " << associations_.total_rejected.load(std::memory_order_relaxed) << "\n";
+
+    oss << "# HELP " << prefix << "_associations_aborted_total Total associations aborted\n"
+        << "# TYPE " << prefix << "_associations_aborted_total counter\n"
+        << prefix << "_associations_aborted_total " << associations_.total_aborted.load(std::memory_order_relaxed) << "\n";
+
+    oss << "# HELP " << prefix << "_associations_active Current active associations\n"
+        << "# TYPE " << prefix << "_associations_active gauge\n"
+        << prefix << "_associations_active " << associations_.current_active.load(std::memory_order_relaxed) << "\n";
+
+    oss << "# HELP " << prefix << "_associations_peak_active Peak concurrent associations\n"
+        << "# TYPE " << prefix << "_associations_peak_active gauge\n"
+        << prefix << "_associations_peak_active " << associations_.peak_active.load(std::memory_order_relaxed) << "\n";
+
+    return oss.str();
+}
+
+}  // namespace pacs::monitoring

--- a/tests/monitoring/pacs_metrics_test.cpp
+++ b/tests/monitoring/pacs_metrics_test.cpp
@@ -1,0 +1,525 @@
+/**
+ * @file pacs_metrics_test.cpp
+ * @brief Unit tests for pacs_metrics operation metrics collection
+ *
+ * @see Issue #210 - [Quick Win] feat(monitoring): Implement operation metrics collection
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "pacs/monitoring/pacs_metrics.hpp"
+
+#include <chrono>
+#include <string>
+#include <thread>
+#include <vector>
+
+using namespace pacs::monitoring;
+using namespace std::chrono_literals;
+
+// =============================================================================
+// dimse_operation enum tests
+// =============================================================================
+
+TEST_CASE("dimse_operation to_string conversion", "[monitoring][metrics]") {
+    SECTION("C-DIMSE operations") {
+        CHECK(to_string(dimse_operation::c_echo) == "c_echo");
+        CHECK(to_string(dimse_operation::c_store) == "c_store");
+        CHECK(to_string(dimse_operation::c_find) == "c_find");
+        CHECK(to_string(dimse_operation::c_move) == "c_move");
+        CHECK(to_string(dimse_operation::c_get) == "c_get");
+    }
+
+    SECTION("N-DIMSE operations") {
+        CHECK(to_string(dimse_operation::n_create) == "n_create");
+        CHECK(to_string(dimse_operation::n_set) == "n_set");
+        CHECK(to_string(dimse_operation::n_get) == "n_get");
+        CHECK(to_string(dimse_operation::n_action) == "n_action");
+        CHECK(to_string(dimse_operation::n_event) == "n_event");
+        CHECK(to_string(dimse_operation::n_delete) == "n_delete");
+    }
+}
+
+// =============================================================================
+// operation_counter tests
+// =============================================================================
+
+TEST_CASE("operation_counter basic functionality", "[monitoring][metrics]") {
+    operation_counter counter;
+
+    SECTION("Initial state is zero") {
+        CHECK(counter.success_count.load() == 0);
+        CHECK(counter.failure_count.load() == 0);
+        CHECK(counter.total_count() == 0);
+        CHECK(counter.average_duration_us() == 0);
+    }
+
+    SECTION("Record success updates counters") {
+        counter.record_success(100us);
+
+        CHECK(counter.success_count.load() == 1);
+        CHECK(counter.failure_count.load() == 0);
+        CHECK(counter.total_count() == 1);
+        CHECK(counter.total_duration_us.load() == 100);
+        CHECK(counter.min_duration_us.load() == 100);
+        CHECK(counter.max_duration_us.load() == 100);
+        CHECK(counter.average_duration_us() == 100);
+    }
+
+    SECTION("Record failure updates counters") {
+        counter.record_failure(200us);
+
+        CHECK(counter.success_count.load() == 0);
+        CHECK(counter.failure_count.load() == 1);
+        CHECK(counter.total_count() == 1);
+        CHECK(counter.total_duration_us.load() == 200);
+    }
+
+    SECTION("Multiple operations track min/max correctly") {
+        counter.record_success(50us);
+        counter.record_success(100us);
+        counter.record_success(75us);
+
+        CHECK(counter.total_count() == 3);
+        CHECK(counter.min_duration_us.load() == 50);
+        CHECK(counter.max_duration_us.load() == 100);
+        CHECK(counter.average_duration_us() == 75);  // (50 + 100 + 75) / 3 = 75
+    }
+
+    SECTION("Reset clears all counters") {
+        counter.record_success(100us);
+        counter.record_failure(200us);
+        counter.reset();
+
+        CHECK(counter.success_count.load() == 0);
+        CHECK(counter.failure_count.load() == 0);
+        CHECK(counter.total_count() == 0);
+        CHECK(counter.total_duration_us.load() == 0);
+        CHECK(counter.min_duration_us.load() == UINT64_MAX);
+        CHECK(counter.max_duration_us.load() == 0);
+    }
+}
+
+// =============================================================================
+// data_transfer_metrics tests
+// =============================================================================
+
+TEST_CASE("data_transfer_metrics functionality", "[monitoring][metrics]") {
+    data_transfer_metrics transfer;
+
+    SECTION("Initial state is zero") {
+        CHECK(transfer.bytes_sent.load() == 0);
+        CHECK(transfer.bytes_received.load() == 0);
+        CHECK(transfer.images_stored.load() == 0);
+        CHECK(transfer.images_retrieved.load() == 0);
+    }
+
+    SECTION("Bytes tracking works correctly") {
+        transfer.add_bytes_sent(1024);
+        transfer.add_bytes_received(2048);
+
+        CHECK(transfer.bytes_sent.load() == 1024);
+        CHECK(transfer.bytes_received.load() == 2048);
+
+        transfer.add_bytes_sent(512);
+        CHECK(transfer.bytes_sent.load() == 1536);
+    }
+
+    SECTION("Image counts work correctly") {
+        transfer.increment_images_stored();
+        transfer.increment_images_stored();
+        transfer.increment_images_retrieved();
+
+        CHECK(transfer.images_stored.load() == 2);
+        CHECK(transfer.images_retrieved.load() == 1);
+    }
+
+    SECTION("Reset clears all values") {
+        transfer.add_bytes_sent(1024);
+        transfer.increment_images_stored();
+        transfer.reset();
+
+        CHECK(transfer.bytes_sent.load() == 0);
+        CHECK(transfer.images_stored.load() == 0);
+    }
+}
+
+// =============================================================================
+// association_counters tests
+// =============================================================================
+
+TEST_CASE("association_counters functionality", "[monitoring][metrics]") {
+    association_counters assoc;
+
+    SECTION("Initial state is zero") {
+        CHECK(assoc.total_established.load() == 0);
+        CHECK(assoc.total_rejected.load() == 0);
+        CHECK(assoc.total_aborted.load() == 0);
+        CHECK(assoc.current_active.load() == 0);
+        CHECK(assoc.peak_active.load() == 0);
+    }
+
+    SECTION("Establish and release tracking") {
+        assoc.record_established();
+        CHECK(assoc.total_established.load() == 1);
+        CHECK(assoc.current_active.load() == 1);
+        CHECK(assoc.peak_active.load() == 1);
+
+        assoc.record_established();
+        CHECK(assoc.current_active.load() == 2);
+        CHECK(assoc.peak_active.load() == 2);
+
+        assoc.record_released();
+        CHECK(assoc.current_active.load() == 1);
+        CHECK(assoc.peak_active.load() == 2);  // Peak remains at 2
+    }
+
+    SECTION("Rejection tracking") {
+        assoc.record_rejected();
+        CHECK(assoc.total_rejected.load() == 1);
+        CHECK(assoc.current_active.load() == 0);  // Rejections don't affect active
+    }
+
+    SECTION("Abort tracking") {
+        assoc.record_established();
+        assoc.record_aborted();
+
+        CHECK(assoc.total_aborted.load() == 1);
+        CHECK(assoc.current_active.load() == 0);
+    }
+
+    SECTION("Peak tracking across multiple associations") {
+        for (int i = 0; i < 5; ++i) {
+            assoc.record_established();
+        }
+        CHECK(assoc.peak_active.load() == 5);
+
+        for (int i = 0; i < 3; ++i) {
+            assoc.record_released();
+        }
+        CHECK(assoc.current_active.load() == 2);
+        CHECK(assoc.peak_active.load() == 5);  // Peak unchanged
+    }
+}
+
+// =============================================================================
+// pacs_metrics tests
+// =============================================================================
+
+TEST_CASE("pacs_metrics singleton access", "[monitoring][metrics]") {
+    SECTION("Global metrics returns same instance") {
+        auto& m1 = pacs_metrics::global_metrics();
+        auto& m2 = pacs_metrics::global_metrics();
+        CHECK(&m1 == &m2);
+    }
+}
+
+TEST_CASE("pacs_metrics DIMSE operation recording", "[monitoring][metrics]") {
+    pacs_metrics metrics;
+
+    SECTION("record_store updates C-STORE counter") {
+        metrics.record_store(true, 1000us, 1024);
+
+        const auto& counter = metrics.get_counter(dimse_operation::c_store);
+        CHECK(counter.success_count.load() == 1);
+        CHECK(counter.total_duration_us.load() == 1000);
+
+        const auto& transfer = metrics.transfer();
+        CHECK(transfer.bytes_received.load() == 1024);
+        CHECK(transfer.images_stored.load() == 1);
+    }
+
+    SECTION("record_store failure does not update transfer") {
+        metrics.record_store(false, 500us, 0);
+
+        const auto& counter = metrics.get_counter(dimse_operation::c_store);
+        CHECK(counter.failure_count.load() == 1);
+
+        const auto& transfer = metrics.transfer();
+        CHECK(transfer.images_stored.load() == 0);
+    }
+
+    SECTION("record_query updates C-FIND counter") {
+        metrics.record_query(true, 200us, 10);
+
+        const auto& counter = metrics.get_counter(dimse_operation::c_find);
+        CHECK(counter.success_count.load() == 1);
+    }
+
+    SECTION("record_echo updates C-ECHO counter") {
+        metrics.record_echo(true, 50us);
+
+        const auto& counter = metrics.get_counter(dimse_operation::c_echo);
+        CHECK(counter.success_count.load() == 1);
+    }
+
+    SECTION("record_move updates C-MOVE counter and images retrieved") {
+        metrics.record_move(true, 5000us, 3);
+
+        const auto& counter = metrics.get_counter(dimse_operation::c_move);
+        CHECK(counter.success_count.load() == 1);
+
+        const auto& transfer = metrics.transfer();
+        CHECK(transfer.images_retrieved.load() == 3);
+    }
+
+    SECTION("record_get updates C-GET counter and transfer") {
+        metrics.record_get(true, 3000us, 2, 2048);
+
+        const auto& counter = metrics.get_counter(dimse_operation::c_get);
+        CHECK(counter.success_count.load() == 1);
+
+        const auto& transfer = metrics.transfer();
+        CHECK(transfer.images_retrieved.load() == 2);
+        CHECK(transfer.bytes_sent.load() == 2048);
+    }
+
+    SECTION("record_operation works for all types") {
+        metrics.record_operation(dimse_operation::n_create, true, 100us);
+        metrics.record_operation(dimse_operation::n_set, true, 150us);
+
+        CHECK(metrics.get_counter(dimse_operation::n_create).success_count.load() == 1);
+        CHECK(metrics.get_counter(dimse_operation::n_set).success_count.load() == 1);
+    }
+}
+
+TEST_CASE("pacs_metrics association tracking", "[monitoring][metrics]") {
+    pacs_metrics metrics;
+
+    SECTION("Association lifecycle events") {
+        metrics.record_association_established();
+        metrics.record_association_established();
+
+        const auto& assoc = metrics.associations();
+        CHECK(assoc.total_established.load() == 2);
+        CHECK(assoc.current_active.load() == 2);
+
+        metrics.record_association_released();
+        CHECK(assoc.current_active.load() == 1);
+
+        metrics.record_association_rejected();
+        CHECK(assoc.total_rejected.load() == 1);
+
+        metrics.record_association_aborted();
+        CHECK(assoc.total_aborted.load() == 1);
+    }
+}
+
+TEST_CASE("pacs_metrics byte recording", "[monitoring][metrics]") {
+    pacs_metrics metrics;
+
+    metrics.record_bytes_sent(1024);
+    metrics.record_bytes_received(2048);
+
+    const auto& transfer = metrics.transfer();
+    CHECK(transfer.bytes_sent.load() == 1024);
+    CHECK(transfer.bytes_received.load() == 2048);
+}
+
+TEST_CASE("pacs_metrics reset", "[monitoring][metrics]") {
+    pacs_metrics metrics;
+
+    // Record various operations
+    metrics.record_store(true, 1000us, 1024);
+    metrics.record_echo(true, 50us);
+    metrics.record_association_established();
+    metrics.record_bytes_sent(512);
+
+    // Reset all
+    metrics.reset();
+
+    // Verify all reset
+    CHECK(metrics.get_counter(dimse_operation::c_store).total_count() == 0);
+    CHECK(metrics.get_counter(dimse_operation::c_echo).total_count() == 0);
+    CHECK(metrics.transfer().bytes_sent.load() == 0);
+    CHECK(metrics.associations().total_established.load() == 0);
+}
+
+// =============================================================================
+// JSON export tests
+// =============================================================================
+
+TEST_CASE("pacs_metrics to_json export", "[monitoring][metrics][json]") {
+    pacs_metrics metrics;
+
+    SECTION("Empty metrics produces valid JSON") {
+        std::string json = metrics.to_json();
+
+        CHECK_THAT(json, Catch::Matchers::StartsWith("{"));
+        CHECK_THAT(json, Catch::Matchers::EndsWith("}"));
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"dimse_operations\""));
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"data_transfer\""));
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"associations\""));
+    }
+
+    SECTION("JSON contains operation data") {
+        metrics.record_store(true, 1000us, 2048);
+        metrics.record_echo(true, 50us);
+
+        std::string json = metrics.to_json();
+
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"c_store\""));
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"c_echo\""));
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"success\":1"));
+    }
+
+    SECTION("JSON contains transfer data") {
+        metrics.record_bytes_sent(1024);
+        metrics.record_bytes_received(2048);
+
+        std::string json = metrics.to_json();
+
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"bytes_sent\":1024"));
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"bytes_received\":2048"));
+    }
+
+    SECTION("JSON contains association data") {
+        metrics.record_association_established();
+        metrics.record_association_established();
+        metrics.record_association_released();
+
+        std::string json = metrics.to_json();
+
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"total_established\":2"));
+        CHECK_THAT(json, Catch::Matchers::ContainsSubstring("\"current_active\":1"));
+    }
+}
+
+// =============================================================================
+// Prometheus export tests
+// =============================================================================
+
+TEST_CASE("pacs_metrics to_prometheus export", "[monitoring][metrics][prometheus]") {
+    pacs_metrics metrics;
+
+    SECTION("Empty metrics produces valid Prometheus format") {
+        std::string prom = metrics.to_prometheus();
+
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("# HELP"));
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("# TYPE"));
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("pacs_dimse_c_echo_total"));
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("pacs_dimse_c_store_total"));
+    }
+
+    SECTION("Custom prefix is used") {
+        std::string prom = metrics.to_prometheus("myprefix");
+
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("myprefix_dimse_c_echo_total"));
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("myprefix_bytes_sent_total"));
+    }
+
+    SECTION("Prometheus contains counter types") {
+        std::string prom = metrics.to_prometheus();
+
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("# TYPE pacs_dimse_c_store_total counter"));
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("# TYPE pacs_bytes_sent_total counter"));
+    }
+
+    SECTION("Prometheus contains gauge types for active associations") {
+        std::string prom = metrics.to_prometheus();
+
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("# TYPE pacs_associations_active gauge"));
+    }
+
+    SECTION("Prometheus contains operation values") {
+        metrics.record_store(true, 1000us, 2048);
+
+        std::string prom = metrics.to_prometheus();
+
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("pacs_dimse_c_store_success_total 1"));
+        CHECK_THAT(prom, Catch::Matchers::ContainsSubstring("pacs_images_stored_total 1"));
+    }
+}
+
+// =============================================================================
+// Thread safety tests
+// =============================================================================
+
+TEST_CASE("pacs_metrics thread safety", "[monitoring][metrics][threading]") {
+    pacs_metrics metrics;
+    constexpr int num_threads = 4;
+    constexpr int ops_per_thread = 1000;
+
+    SECTION("Concurrent C-STORE recording is thread-safe") {
+        std::vector<std::thread> threads;
+        threads.reserve(num_threads);
+
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&metrics]() {
+                for (int i = 0; i < ops_per_thread; ++i) {
+                    metrics.record_store(true, 100us, 1024);
+                }
+            });
+        }
+
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        const auto& counter = metrics.get_counter(dimse_operation::c_store);
+        CHECK(counter.success_count.load() == num_threads * ops_per_thread);
+        CHECK(counter.total_duration_us.load() == num_threads * ops_per_thread * 100);
+    }
+
+    SECTION("Concurrent association tracking is thread-safe") {
+        std::vector<std::thread> threads;
+        threads.reserve(num_threads);
+
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&metrics]() {
+                for (int i = 0; i < ops_per_thread; ++i) {
+                    metrics.record_association_established();
+                    metrics.record_association_released();
+                }
+            });
+        }
+
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        const auto& assoc = metrics.associations();
+        CHECK(assoc.total_established.load() == num_threads * ops_per_thread);
+        // current_active may not be exactly 0 due to race between establish/release
+        // but it should be close to 0
+        CHECK(assoc.current_active.load() <= static_cast<std::uint32_t>(num_threads));
+    }
+
+    SECTION("Concurrent mixed operations are thread-safe") {
+        std::vector<std::thread> threads;
+        threads.reserve(num_threads);
+
+        for (int t = 0; t < num_threads; ++t) {
+            threads.emplace_back([&metrics, t]() {
+                for (int i = 0; i < ops_per_thread; ++i) {
+                    switch (t % 4) {
+                        case 0:
+                            metrics.record_store(true, 100us, 1024);
+                            break;
+                        case 1:
+                            metrics.record_echo(true, 50us);
+                            break;
+                        case 2:
+                            metrics.record_query(true, 200us, 5);
+                            break;
+                        case 3:
+                            metrics.record_bytes_sent(512);
+                            metrics.record_bytes_received(256);
+                            break;
+                    }
+                }
+            });
+        }
+
+        for (auto& t : threads) {
+            t.join();
+        }
+
+        // Verify each operation type has expected count
+        CHECK(metrics.get_counter(dimse_operation::c_store).success_count.load() == ops_per_thread);
+        CHECK(metrics.get_counter(dimse_operation::c_echo).success_count.load() == ops_per_thread);
+        CHECK(metrics.get_counter(dimse_operation::c_find).success_count.load() == ops_per_thread);
+        CHECK(metrics.transfer().bytes_sent.load() == ops_per_thread * 512);
+    }
+}


### PR DESCRIPTION
## Summary

This PR implements thread-safe operation metrics collection for PACS DICOM services, addressing Issue #210.

### Key Features

- **DIMSE Operation Tracking**: Atomic counters for all C-DIMSE (C-ECHO, C-STORE, C-FIND, C-MOVE, C-GET) and N-DIMSE (N-CREATE, N-SET, etc.) operations
- **Timing Statistics**: Per-operation timing with min/max/average duration tracking in microseconds
- **Data Transfer Metrics**: Bytes sent/received and images stored/retrieved counters
- **Association Lifecycle**: Track established/rejected/aborted associations with current and peak active counts
- **Export Formats**: JSON for REST APIs and Prometheus exposition format for monitoring systems
- **Thread Safety**: Lock-free atomic operations with CAS-based min/max updates

### Implementation Details

| Component | Description |
|-----------|-------------|
| `pacs_metrics` | Singleton class with global_metrics() accessor |
| `operation_counter` | Atomic success/failure counts with duration tracking |
| `data_transfer_metrics` | Bytes and image count tracking |
| `association_counters` | Connection lifecycle metrics |

### Files Changed

- `include/pacs/monitoring/pacs_metrics.hpp` - Header with all metric structures
- `src/monitoring/pacs_metrics.cpp` - JSON and Prometheus export implementation
- `tests/monitoring/pacs_metrics_test.cpp` - Comprehensive unit tests including thread safety
- `CMakeLists.txt` - Added pacs_metrics.cpp to pacs_monitoring library
- `docs/API_REFERENCE.md` - Added Monitoring Module documentation
- `docs/API_REFERENCE_KO.md` - Added Korean Monitoring Module documentation

### Usage Example

```cpp
#include <pacs/monitoring/pacs_metrics.hpp>
using namespace pacs::monitoring;

// Get global metrics
auto& metrics = pacs_metrics::global_metrics();

// Record a C-STORE operation
auto start = std::chrono::steady_clock::now();
// ... perform C-STORE ...
auto end = std::chrono::steady_clock::now();
auto duration = std::chrono::duration_cast<std::chrono::microseconds>(end - start);
metrics.record_store(true, duration, 1024 * 1024);

// Export for monitoring
std::string json = metrics.to_json();
std::string prom = metrics.to_prometheus();
```

## Test Plan

- [x] All 283 assertions pass in 62 test cases
- [x] Thread safety verified with concurrent operation tests (4 threads, 1000 ops each)
- [x] JSON format validation tests
- [x] Prometheus exposition format tests
- [x] Build succeeds with CMake

```bash
# Run tests
cmake --build build --target monitoring_tests
./build/bin/monitoring_tests
```

## Related Issues

Closes #210

---

**Reviewer Notes:**
- The implementation uses `std::memory_order_relaxed` for counters to minimize overhead
- CAS loops are used for lock-free min/max updates
- Meyer's singleton pattern ensures thread-safe lazy initialization