### PR TITLE
feat(storage): Implement S3-compatible storage backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -714,6 +714,7 @@ if(PACS_BUILD_STORAGE AND SQLITE3_FOUND)
     add_library(pacs_storage
         src/storage/storage_interface.cpp
         src/storage/file_storage.cpp
+        src/storage/s3_storage.cpp
         src/storage/migration_runner.cpp
         src/storage/index_database.cpp
     )
@@ -1046,6 +1047,7 @@ if(PACS_BUILD_TESTS)
         add_executable(storage_tests
             tests/storage/storage_interface_test.cpp
             tests/storage/file_storage_test.cpp
+            tests/storage/s3_storage_test.cpp
             tests/storage/migration_runner_test.cpp
             tests/storage/index_database_test.cpp
             tests/storage/mpps_test.cpp

--- a/include/pacs/storage/s3_storage.hpp
+++ b/include/pacs/storage/s3_storage.hpp
@@ -1,0 +1,394 @@
+/**
+ * @file s3_storage.hpp
+ * @brief S3-compatible DICOM storage backend for cloud storage support
+ *
+ * This file provides the s3_storage class which implements storage_interface
+ * using S3-compatible object storage (AWS S3, MinIO, etc.).
+ *
+ * @see SRS-STOR-003, FR-4.2 (Cloud Storage Backend)
+ */
+
+#pragma once
+
+#include "storage_interface.hpp"
+
+#include <pacs/core/dicom_dataset.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <shared_mutex>
+#include <string>
+#include <unordered_map>
+
+namespace pacs::storage {
+
+/**
+ * @brief Configuration for S3-compatible cloud storage
+ *
+ * Contains all settings needed to connect to an S3-compatible storage service.
+ * Supports AWS S3, MinIO, and other S3-compatible services via endpoint_url.
+ */
+struct cloud_storage_config {
+  /// S3 bucket name for storing DICOM files
+  std::string bucket_name;
+
+  /// AWS region (e.g., "us-east-1", "eu-west-1")
+  std::string region{"us-east-1"};
+
+  /// AWS access key ID for authentication
+  std::string access_key_id;
+
+  /// AWS secret access key for authentication
+  std::string secret_access_key;
+
+  /// Optional custom endpoint URL for MinIO or S3-compatible services
+  /// If empty, uses the default AWS S3 endpoint
+  std::optional<std::string> endpoint_url;
+
+  /// Threshold for multipart upload in bytes (default: 100MB)
+  /// Files larger than this will use multipart upload
+  std::size_t multipart_threshold = 100 * 1024 * 1024;
+
+  /// Part size for multipart upload in bytes (default: 10MB)
+  std::size_t part_size = 10 * 1024 * 1024;
+
+  /// Maximum number of concurrent upload connections
+  std::size_t max_connections = 25;
+
+  /// Connection timeout in milliseconds
+  std::uint32_t connect_timeout_ms = 3000;
+
+  /// Request timeout in milliseconds
+  std::uint32_t request_timeout_ms = 30000;
+
+  /// Enable server-side encryption (SSE-S3)
+  bool enable_encryption = false;
+
+  /// Storage class for S3 objects (STANDARD, INTELLIGENT_TIERING, etc.)
+  std::string storage_class{"STANDARD"};
+};
+
+/**
+ * @brief Information about an S3 object
+ */
+struct s3_object_info {
+  /// S3 object key (path within bucket)
+  std::string key;
+
+  /// SOP Instance UID from DICOM metadata
+  std::string sop_instance_uid;
+
+  /// Study Instance UID
+  std::string study_instance_uid;
+
+  /// Series Instance UID
+  std::string series_instance_uid;
+
+  /// Object size in bytes
+  std::size_t size_bytes{0};
+
+  /// ETag for integrity verification
+  std::string etag;
+
+  /// Content type
+  std::string content_type{"application/dicom"};
+};
+
+/**
+ * @brief Callback type for upload/download progress tracking
+ *
+ * Parameters:
+ * - bytes_transferred: Number of bytes transferred so far
+ * - total_bytes: Total number of bytes to transfer
+ * - Returns: true to continue, false to abort
+ */
+using progress_callback =
+    std::function<bool(std::size_t bytes_transferred, std::size_t total_bytes)>;
+
+/**
+ * @brief S3-compatible storage backend for DICOM files
+ *
+ * Implements storage_interface using S3-compatible object storage.
+ * Supports AWS S3 and S3-compatible services (MinIO, etc.).
+ *
+ * Object Key Structure:
+ * @code
+ * {bucket}/
+ *   +-- {StudyUID}/
+ *       +-- {SeriesUID}/
+ *           +-- {SOPUID}.dcm
+ * @endcode
+ *
+ * Thread Safety:
+ * - All methods are thread-safe
+ * - Concurrent reads are allowed (shared lock)
+ * - Writes require exclusive lock for index updates
+ * - S3 operations themselves are thread-safe
+ *
+ * @example
+ * @code
+ * cloud_storage_config config;
+ * config.bucket_name = "my-dicom-bucket";
+ * config.region = "us-east-1";
+ * config.access_key_id = "AKIAIOSFODNN7EXAMPLE";
+ * config.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
+ *
+ * // For MinIO local testing
+ * config.endpoint_url = "http://localhost:9000";
+ *
+ * s3_storage storage{config};
+ *
+ * // Store a DICOM dataset
+ * core::dicom_dataset ds;
+ * // ... populate dataset ...
+ * auto result = storage.store(ds);
+ *
+ * // Retrieve by SOP Instance UID
+ * auto retrieved = storage.retrieve("1.2.3.4.5.6.7.8.9");
+ * @endcode
+ *
+ * @note This implementation currently uses mock S3 operations for testing.
+ *       Full AWS SDK integration will be added in a future update.
+ */
+class s3_storage : public storage_interface {
+public:
+  // =========================================================================
+  // Construction
+  // =========================================================================
+
+  /**
+   * @brief Construct S3 storage with configuration
+   * @param config Cloud storage configuration
+   */
+  explicit s3_storage(const cloud_storage_config &config);
+
+  /**
+   * @brief Destructor
+   */
+  ~s3_storage() override;
+
+  /// Non-copyable (contains mutex)
+  s3_storage(const s3_storage &) = delete;
+  s3_storage &operator=(const s3_storage &) = delete;
+
+  /// Non-movable (contains mutex)
+  s3_storage(s3_storage &&) = delete;
+  s3_storage &operator=(s3_storage &&) = delete;
+
+  // =========================================================================
+  // storage_interface Implementation
+  // =========================================================================
+
+  /**
+   * @brief Store a DICOM dataset to S3
+   *
+   * Serializes the dataset to DICOM Part 10 format and uploads to S3.
+   * Uses multipart upload for files exceeding multipart_threshold.
+   *
+   * @param dataset The DICOM dataset to store
+   * @return VoidResult Success or error information
+   *
+   * @note Requires Study, Series, and SOP Instance UIDs in the dataset
+   */
+  [[nodiscard]] auto store(const core::dicom_dataset &dataset)
+      -> VoidResult override;
+
+  /**
+   * @brief Retrieve a DICOM dataset by SOP Instance UID
+   *
+   * Downloads the object from S3 and deserializes to dicom_dataset.
+   *
+   * @param sop_instance_uid The unique identifier for the instance
+   * @return Result containing the dataset or error information
+   */
+  [[nodiscard]] auto retrieve(std::string_view sop_instance_uid)
+      -> Result<core::dicom_dataset> override;
+
+  /**
+   * @brief Remove a DICOM object from S3
+   *
+   * @param sop_instance_uid The unique identifier for the instance to remove
+   * @return VoidResult Success or error information
+   */
+  [[nodiscard]] auto remove(std::string_view sop_instance_uid)
+      -> VoidResult override;
+
+  /**
+   * @brief Check if a DICOM instance exists in S3
+   *
+   * Uses S3 HeadObject to check existence without downloading.
+   *
+   * @param sop_instance_uid The unique identifier to check
+   * @return true if the object exists, false otherwise
+   */
+  [[nodiscard]] auto exists(std::string_view sop_instance_uid) const
+      -> bool override;
+
+  /**
+   * @brief Find DICOM datasets matching query criteria
+   *
+   * This operation requires scanning the local index. For large buckets,
+   * consider using the index_database instead.
+   *
+   * @param query The query dataset containing search criteria
+   * @return Result containing matching datasets or error information
+   *
+   * @note This operation can be slow for large storage
+   */
+  [[nodiscard]] auto find(const core::dicom_dataset &query)
+      -> Result<std::vector<core::dicom_dataset>> override;
+
+  /**
+   * @brief Get storage statistics
+   *
+   * @return Storage statistics structure
+   */
+  [[nodiscard]] auto get_statistics() const -> storage_statistics override;
+
+  /**
+   * @brief Verify storage integrity
+   *
+   * Checks that all indexed objects exist in S3 and have valid ETags.
+   *
+   * @return VoidResult Success if integrity is verified, error otherwise
+   */
+  [[nodiscard]] auto verify_integrity() -> VoidResult override;
+
+  // =========================================================================
+  // S3-specific Operations
+  // =========================================================================
+
+  /**
+   * @brief Store with progress tracking
+   *
+   * @param dataset The DICOM dataset to store
+   * @param callback Progress callback function
+   * @return VoidResult Success or error information
+   */
+  [[nodiscard]] auto store_with_progress(const core::dicom_dataset &dataset,
+                                         progress_callback callback)
+      -> VoidResult;
+
+  /**
+   * @brief Retrieve with progress tracking
+   *
+   * @param sop_instance_uid The SOP Instance UID
+   * @param callback Progress callback function
+   * @return Result containing the dataset or error information
+   */
+  [[nodiscard]] auto retrieve_with_progress(std::string_view sop_instance_uid,
+                                            progress_callback callback)
+      -> Result<core::dicom_dataset>;
+
+  /**
+   * @brief Get the S3 object key for a SOP Instance UID
+   *
+   * @param sop_instance_uid The SOP Instance UID
+   * @return The S3 object key (may be empty if not found)
+   */
+  [[nodiscard]] auto get_object_key(std::string_view sop_instance_uid) const
+      -> std::string;
+
+  /**
+   * @brief Get the bucket name
+   *
+   * @return The configured bucket name
+   */
+  [[nodiscard]] auto bucket_name() const -> const std::string &;
+
+  /**
+   * @brief Rebuild the local index from S3
+   *
+   * Lists all objects in the bucket and rebuilds the SOP UID mapping.
+   *
+   * @return VoidResult Success or error information
+   *
+   * @note This operation can be slow for buckets with many objects
+   */
+  [[nodiscard]] auto rebuild_index() -> VoidResult;
+
+  /**
+   * @brief Check S3 connectivity
+   *
+   * @return true if S3 is reachable, false otherwise
+   */
+  [[nodiscard]] auto is_connected() const -> bool;
+
+private:
+  // =========================================================================
+  // Internal Types
+  // =========================================================================
+
+  /**
+   * @brief Mock S3 client interface for testing
+   *
+   * This will be replaced with AWS SDK S3Client when integrated.
+   */
+  class mock_s3_client;
+
+  // =========================================================================
+  // Internal Helper Methods
+  // =========================================================================
+
+  /**
+   * @brief Build S3 object key for a dataset
+   * @param study_uid Study Instance UID
+   * @param series_uid Series Instance UID
+   * @param sop_uid SOP Instance UID
+   * @return The constructed object key
+   */
+  [[nodiscard]] auto build_object_key(std::string_view study_uid,
+                                      std::string_view series_uid,
+                                      std::string_view sop_uid) const
+      -> std::string;
+
+  /**
+   * @brief Sanitize UID for use in S3 object key
+   * @param uid The UID to sanitize
+   * @return Sanitized string safe for S3 key use
+   */
+  [[nodiscard]] static auto sanitize_uid(std::string_view uid) -> std::string;
+
+  /**
+   * @brief Execute multipart upload for large files
+   * @param key S3 object key
+   * @param data Data to upload
+   * @param callback Optional progress callback
+   * @return VoidResult Success or error information
+   */
+  [[nodiscard]] auto upload_multipart(const std::string &key,
+                                      const std::vector<std::uint8_t> &data,
+                                      progress_callback callback) -> VoidResult;
+
+  /**
+   * @brief Check if dataset matches query criteria
+   * @param dataset The dataset to check
+   * @param query The query criteria
+   * @return true if dataset matches query
+   */
+  [[nodiscard]] static auto matches_query(const core::dicom_dataset &dataset,
+                                          const core::dicom_dataset &query)
+      -> bool;
+
+  // =========================================================================
+  // Member Variables
+  // =========================================================================
+
+  /// Storage configuration
+  cloud_storage_config config_;
+
+  /// Mock S3 client for testing (will be replaced with AWS SDK client)
+  std::unique_ptr<mock_s3_client> client_;
+
+  /// Mapping from SOP Instance UID to S3 object info
+  std::unordered_map<std::string, s3_object_info> index_;
+
+  /// Mutex for thread-safe access
+  mutable std::shared_mutex mutex_;
+};
+
+} // namespace pacs::storage

--- a/src/storage/s3_storage.cpp
+++ b/src/storage/s3_storage.cpp
@@ -1,0 +1,563 @@
+/**
+ * @file s3_storage.cpp
+ * @brief Implementation of S3-compatible DICOM storage backend
+ *
+ * This file implements the s3_storage class for cloud storage support.
+ * Currently uses a mock S3 client for testing and API validation.
+ * Full AWS SDK integration will be added in a future update.
+ */
+
+#include <pacs/storage/s3_storage.hpp>
+
+#include <pacs/core/dicom_file.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/transfer_syntax.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <algorithm>
+#include <set>
+#include <sstream>
+
+namespace pacs::storage {
+
+using kcenon::common::make_error;
+using kcenon::common::ok;
+
+namespace {
+
+/// Error codes for S3 storage operations
+constexpr int kMissingRequiredUid = -1;
+constexpr int kObjectNotFound = -2;
+constexpr int kUploadError = -3;
+constexpr int kDownloadError = -4;
+constexpr int kConnectionError = -6;
+constexpr int kIntegrityError = -7;
+constexpr int kSerializationError = -8;
+
+} // namespace
+
+// ============================================================================
+// Mock S3 Client Implementation
+// ============================================================================
+
+/**
+ * @brief Mock S3 client for testing without AWS SDK dependency
+ *
+ * This class simulates S3 operations using an in-memory storage.
+ * It will be replaced with AWS SDK S3Client when integrated.
+ */
+class s3_storage::mock_s3_client {
+public:
+  explicit mock_s3_client(const cloud_storage_config & /*config*/)
+      : connected_(true) {}
+
+  /**
+   * @brief Simulate S3 PutObject operation
+   */
+  [[nodiscard]] auto put_object(const std::string &key,
+                                const std::vector<std::uint8_t> &data)
+      -> VoidResult {
+    if (!connected_) {
+      return make_error<std::monostate>(
+          kConnectionError, "S3 client not connected", "s3_storage");
+    }
+
+    objects_[key] = data;
+    return ok();
+  }
+
+  /**
+   * @brief Simulate S3 GetObject operation
+   */
+  [[nodiscard]] auto get_object(const std::string &key)
+      -> Result<std::vector<std::uint8_t>> {
+    if (!connected_) {
+      return make_error<std::vector<std::uint8_t>>(
+          kConnectionError, "S3 client not connected", "s3_storage");
+    }
+
+    auto it = objects_.find(key);
+    if (it == objects_.end()) {
+      return make_error<std::vector<std::uint8_t>>(
+          kObjectNotFound, "Object not found: " + key, "s3_storage");
+    }
+
+    return it->second;
+  }
+
+  /**
+   * @brief Simulate S3 DeleteObject operation
+   */
+  [[nodiscard]] auto delete_object(const std::string &key) -> VoidResult {
+    if (!connected_) {
+      return make_error<std::monostate>(
+          kConnectionError, "S3 client not connected", "s3_storage");
+    }
+
+    objects_.erase(key);
+    return ok();
+  }
+
+  /**
+   * @brief Simulate S3 HeadObject operation
+   */
+  [[nodiscard]] auto head_object(const std::string &key) const -> bool {
+    if (!connected_) {
+      return false;
+    }
+    return objects_.contains(key);
+  }
+
+  /**
+   * @brief Get object size
+   */
+  [[nodiscard]] auto get_object_size(const std::string &key) const
+      -> std::size_t {
+    auto it = objects_.find(key);
+    if (it != objects_.end()) {
+      return it->second.size();
+    }
+    return 0;
+  }
+
+  /**
+   * @brief List all object keys
+   */
+  [[nodiscard]] auto list_objects() const -> std::vector<std::string> {
+    std::vector<std::string> keys;
+    keys.reserve(objects_.size());
+    for (const auto &[key, data] : objects_) {
+      keys.push_back(key);
+    }
+    return keys;
+  }
+
+  /**
+   * @brief Check connection status
+   */
+  [[nodiscard]] auto is_connected() const -> bool { return connected_; }
+
+  /**
+   * @brief Set connection status (for testing)
+   */
+  void set_connected(bool connected) { connected_ = connected; }
+
+private:
+  std::unordered_map<std::string, std::vector<std::uint8_t>> objects_;
+  bool connected_;
+};
+
+// ============================================================================
+// Construction
+// ============================================================================
+
+s3_storage::s3_storage(const cloud_storage_config &config)
+    : config_(config), client_(std::make_unique<mock_s3_client>(config)) {}
+
+s3_storage::~s3_storage() = default;
+
+// ============================================================================
+// storage_interface Implementation
+// ============================================================================
+
+auto s3_storage::store(const core::dicom_dataset &dataset) -> VoidResult {
+  return store_with_progress(dataset, nullptr);
+}
+
+auto s3_storage::store_with_progress(const core::dicom_dataset &dataset,
+                                     progress_callback callback) -> VoidResult {
+  // Extract required UIDs
+  auto study_uid = dataset.get_string(core::tags::study_instance_uid);
+  auto series_uid = dataset.get_string(core::tags::series_instance_uid);
+  auto sop_uid = dataset.get_string(core::tags::sop_instance_uid);
+
+  if (study_uid.empty() || series_uid.empty() || sop_uid.empty()) {
+    return make_error<std::monostate>(
+        kMissingRequiredUid,
+        "Missing required UID (Study, Series, or SOP Instance UID)",
+        "s3_storage");
+  }
+
+  // Build S3 object key
+  auto object_key = build_object_key(study_uid, series_uid, sop_uid);
+
+  // Create DICOM file and serialize to bytes
+  auto dicom_file = core::dicom_file::create(
+      dataset, encoding::transfer_syntax::explicit_vr_little_endian);
+
+  auto data = dicom_file.to_bytes();
+  if (data.empty()) {
+    return make_error<std::monostate>(
+        kSerializationError, "Failed to serialize DICOM dataset", "s3_storage");
+  }
+
+  // Report initial progress
+  if (callback && !callback(0, data.size())) {
+    return make_error<std::monostate>(kUploadError, "Upload cancelled by user",
+                                      "s3_storage");
+  }
+
+  // Upload to S3 (use multipart for large files)
+  VoidResult upload_result = ok();
+  if (data.size() > config_.multipart_threshold) {
+    upload_result = upload_multipart(object_key, data, callback);
+  } else {
+    upload_result = client_->put_object(object_key, data);
+
+    // Report completion progress
+    if (callback) {
+      callback(data.size(), data.size());
+    }
+  }
+
+  if (upload_result.is_err()) {
+    return upload_result;
+  }
+
+  // Update local index
+  {
+    std::unique_lock lock(mutex_);
+    s3_object_info info;
+    info.key = object_key;
+    info.sop_instance_uid = sop_uid;
+    info.study_instance_uid = study_uid;
+    info.series_instance_uid = series_uid;
+    info.size_bytes = data.size();
+    index_[sop_uid] = std::move(info);
+  }
+
+  return ok();
+}
+
+auto s3_storage::retrieve(std::string_view sop_instance_uid)
+    -> Result<core::dicom_dataset> {
+  return retrieve_with_progress(sop_instance_uid, nullptr);
+}
+
+auto s3_storage::retrieve_with_progress(std::string_view sop_instance_uid,
+                                        progress_callback callback)
+    -> Result<core::dicom_dataset> {
+  std::string object_key;
+
+  {
+    std::shared_lock lock(mutex_);
+    auto it = index_.find(std::string{sop_instance_uid});
+    if (it == index_.end()) {
+      return make_error<core::dicom_dataset>(
+          kObjectNotFound,
+          "Instance not found: " + std::string{sop_instance_uid}, "s3_storage");
+    }
+    object_key = it->second.key;
+  }
+
+  // Download from S3
+  auto download_result = client_->get_object(object_key);
+  if (download_result.is_err()) {
+    return make_error<core::dicom_dataset>(
+        kDownloadError, "Failed to download from S3", "s3_storage");
+  }
+
+  const auto &data = download_result.value();
+
+  // Report progress (download complete)
+  if (callback) {
+    callback(data.size(), data.size());
+  }
+
+  // Deserialize DICOM data
+  auto parse_result = core::dicom_file::from_bytes(data);
+  if (!parse_result.has_value()) {
+    return make_error<core::dicom_dataset>(
+        kSerializationError,
+        "Failed to parse DICOM data: " + core::to_string(parse_result.error()),
+        "s3_storage");
+  }
+
+  return parse_result->dataset();
+}
+
+auto s3_storage::remove(std::string_view sop_instance_uid) -> VoidResult {
+  std::string object_key;
+
+  {
+    std::unique_lock lock(mutex_);
+    auto it = index_.find(std::string{sop_instance_uid});
+    if (it == index_.end()) {
+      // Not found is not an error for remove
+      return ok();
+    }
+    object_key = it->second.key;
+    index_.erase(it);
+  }
+
+  // Delete from S3
+  auto delete_result = client_->delete_object(object_key);
+  // Ignore delete errors - object might have been deleted externally
+
+  return ok();
+}
+
+auto s3_storage::exists(std::string_view sop_instance_uid) const -> bool {
+  std::shared_lock lock(mutex_);
+  return index_.contains(std::string{sop_instance_uid});
+}
+
+auto s3_storage::find(const core::dicom_dataset &query)
+    -> Result<std::vector<core::dicom_dataset>> {
+  std::vector<core::dicom_dataset> results;
+
+  std::vector<std::string> keys_to_retrieve;
+  {
+    std::shared_lock lock(mutex_);
+    keys_to_retrieve.reserve(index_.size());
+    for (const auto &[uid, info] : index_) {
+      keys_to_retrieve.push_back(info.key);
+    }
+  }
+
+  for (const auto &key : keys_to_retrieve) {
+    auto download_result = client_->get_object(key);
+    if (download_result.is_err()) {
+      continue; // Skip objects that can't be downloaded
+    }
+
+    auto parse_result = core::dicom_file::from_bytes(download_result.value());
+    if (!parse_result.has_value()) {
+      continue; // Skip invalid DICOM files
+    }
+
+    const auto &dataset = parse_result->dataset();
+    if (matches_query(dataset, query)) {
+      results.push_back(dataset);
+    }
+  }
+
+  return results;
+}
+
+auto s3_storage::get_statistics() const -> storage_statistics {
+  storage_statistics stats;
+
+  std::set<std::string> studies;
+  std::set<std::string> series;
+  std::set<std::string> patients;
+
+  {
+    std::shared_lock lock(mutex_);
+    stats.total_instances = index_.size();
+
+    for (const auto &[uid, info] : index_) {
+      stats.total_bytes += info.size_bytes;
+
+      if (!info.study_instance_uid.empty()) {
+        studies.insert(info.study_instance_uid);
+      }
+      if (!info.series_instance_uid.empty()) {
+        series.insert(info.series_instance_uid);
+      }
+    }
+  }
+
+  stats.studies_count = studies.size();
+  stats.series_count = series.size();
+  // Note: patient_count requires downloading datasets to extract PatientID
+
+  return stats;
+}
+
+auto s3_storage::verify_integrity() -> VoidResult {
+  std::vector<std::pair<std::string, std::string>> entries;
+  {
+    std::shared_lock lock(mutex_);
+    entries.reserve(index_.size());
+    for (const auto &[uid, info] : index_) {
+      entries.emplace_back(uid, info.key);
+    }
+  }
+
+  std::vector<std::string> invalid_entries;
+
+  for (const auto &[uid, key] : entries) {
+    if (!client_->head_object(key)) {
+      invalid_entries.push_back(uid + " (object missing)");
+    }
+  }
+
+  if (!invalid_entries.empty()) {
+    std::string message = "Integrity check failed for " +
+                          std::to_string(invalid_entries.size()) + " entries";
+    return make_error<std::monostate>(kIntegrityError, message, "s3_storage");
+  }
+
+  return ok();
+}
+
+// ============================================================================
+// S3-specific Operations
+// ============================================================================
+
+auto s3_storage::get_object_key(std::string_view sop_instance_uid) const
+    -> std::string {
+  std::shared_lock lock(mutex_);
+  auto it = index_.find(std::string{sop_instance_uid});
+  if (it != index_.end()) {
+    return it->second.key;
+  }
+  return {};
+}
+
+auto s3_storage::bucket_name() const -> const std::string & {
+  return config_.bucket_name;
+}
+
+auto s3_storage::rebuild_index() -> VoidResult {
+  std::unique_lock lock(mutex_);
+  index_.clear();
+
+  // List all objects from S3
+  auto keys = client_->list_objects();
+
+  for (const auto &key : keys) {
+    // Download and parse each object to rebuild index
+    auto download_result = client_->get_object(key);
+    if (download_result.is_err()) {
+      continue;
+    }
+
+    auto parse_result = core::dicom_file::from_bytes(download_result.value());
+    if (!parse_result.has_value()) {
+      continue;
+    }
+
+    const auto &dataset = parse_result->dataset();
+    auto sop_uid = dataset.get_string(core::tags::sop_instance_uid);
+    auto study_uid = dataset.get_string(core::tags::study_instance_uid);
+    auto series_uid = dataset.get_string(core::tags::series_instance_uid);
+
+    if (!sop_uid.empty()) {
+      s3_object_info info;
+      info.key = key;
+      info.sop_instance_uid = sop_uid;
+      info.study_instance_uid = study_uid;
+      info.series_instance_uid = series_uid;
+      info.size_bytes = client_->get_object_size(key);
+      index_[sop_uid] = std::move(info);
+    }
+  }
+
+  return ok();
+}
+
+auto s3_storage::is_connected() const -> bool {
+  return client_ && client_->is_connected();
+}
+
+// ============================================================================
+// Internal Helper Methods
+// ============================================================================
+
+auto s3_storage::build_object_key(std::string_view study_uid,
+                                  std::string_view series_uid,
+                                  std::string_view sop_uid) const
+    -> std::string {
+  std::ostringstream oss;
+  oss << sanitize_uid(study_uid) << "/" << sanitize_uid(series_uid) << "/"
+      << sanitize_uid(sop_uid) << ".dcm";
+  return oss.str();
+}
+
+auto s3_storage::sanitize_uid(std::string_view uid) -> std::string {
+  std::string result;
+  result.reserve(uid.length());
+
+  for (char c : uid) {
+    // UIDs contain digits and dots, which are safe for S3 keys
+    // Replace any other characters with underscore
+    if (std::isalnum(static_cast<unsigned char>(c)) || c == '.') {
+      result += c;
+    } else {
+      result += '_';
+    }
+  }
+
+  return result;
+}
+
+auto s3_storage::upload_multipart(const std::string &key,
+                                  const std::vector<std::uint8_t> &data,
+                                  progress_callback callback) -> VoidResult {
+  // For mock implementation, just use regular put_object
+  // Real implementation would use S3 multipart upload API
+
+  std::size_t total_bytes = data.size();
+  std::size_t bytes_uploaded = 0;
+
+  // Simulate multipart upload with progress
+  while (bytes_uploaded < total_bytes) {
+    std::size_t part_size =
+        std::min(config_.part_size, total_bytes - bytes_uploaded);
+    bytes_uploaded += part_size;
+
+    if (callback && !callback(bytes_uploaded, total_bytes)) {
+      return make_error<std::monostate>(
+          kUploadError, "Upload cancelled by user", "s3_storage");
+    }
+  }
+
+  // Actually store the data
+  return client_->put_object(key, data);
+}
+
+auto s3_storage::matches_query(const core::dicom_dataset &dataset,
+                               const core::dicom_dataset &query) -> bool {
+  // If query is empty, match all
+  if (query.empty()) {
+    return true;
+  }
+
+  // Check each query element
+  for (const auto &[tag, element] : query) {
+    auto query_value = element.as_string();
+    if (query_value.empty()) {
+      continue; // Empty value acts as wildcard
+    }
+
+    auto dataset_value = dataset.get_string(tag);
+
+    // Support basic wildcard matching (* and ?)
+    if (query_value.find('*') != std::string::npos ||
+        query_value.find('?') != std::string::npos) {
+      // Simple pattern matching
+      if (query_value.front() == '*' && query_value.back() == '*') {
+        // Contains
+        auto inner = query_value.substr(1, query_value.length() - 2);
+        if (dataset_value.find(inner) == std::string::npos) {
+          return false;
+        }
+      } else if (query_value.front() == '*') {
+        // Ends with
+        auto suffix = query_value.substr(1);
+        if (dataset_value.length() < suffix.length() ||
+            dataset_value.substr(dataset_value.length() - suffix.length()) !=
+                suffix) {
+          return false;
+        }
+      } else if (query_value.back() == '*') {
+        // Starts with
+        auto prefix = query_value.substr(0, query_value.length() - 1);
+        if (dataset_value.substr(0, prefix.length()) != prefix) {
+          return false;
+        }
+      }
+    } else {
+      // Exact match
+      if (dataset_value != query_value) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+} // namespace pacs::storage

--- a/tests/storage/s3_storage_test.cpp
+++ b/tests/storage/s3_storage_test.cpp
@@ -1,0 +1,457 @@
+/**
+ * @file s3_storage_test.cpp
+ * @brief Unit tests for s3_storage class
+ *
+ * Tests the s3_storage implementation for S3-compatible DICOM storage.
+ * Uses the mock S3 client for testing without AWS SDK dependency.
+ */
+
+#include <pacs/storage/s3_storage.hpp>
+
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <atomic>
+
+using namespace pacs::storage;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+namespace {
+
+/**
+ * @brief Helper to create a test dataset with required UIDs
+ */
+auto create_test_dataset(const std::string &study_uid,
+                         const std::string &series_uid,
+                         const std::string &sop_uid,
+                         const std::string &patient_id = "P001",
+                         const std::string &patient_name = "TEST^PATIENT")
+    -> dicom_dataset {
+  dicom_dataset ds;
+  ds.set_string(tags::study_instance_uid, vr_type::UI, study_uid);
+  ds.set_string(tags::series_instance_uid, vr_type::UI, series_uid);
+  ds.set_string(tags::sop_instance_uid, vr_type::UI, sop_uid);
+  ds.set_string(tags::sop_class_uid, vr_type::UI, "1.2.840.10008.5.1.4.1.1.2");
+  ds.set_string(tags::patient_id, vr_type::LO, patient_id);
+  ds.set_string(tags::patient_name, vr_type::PN, patient_name);
+  ds.set_string(tags::modality, vr_type::CS, "CT");
+  return ds;
+}
+
+/**
+ * @brief Helper to create a default cloud storage config for testing
+ */
+auto create_test_config() -> cloud_storage_config {
+  cloud_storage_config config;
+  config.bucket_name = "test-dicom-bucket";
+  config.region = "us-east-1";
+  config.access_key_id = "test-access-key";
+  config.secret_access_key = "test-secret-key";
+  config.endpoint_url = "http://localhost:9000"; // MinIO endpoint
+  return config;
+}
+
+} // namespace
+
+// ============================================================================
+// Construction Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: construction with config", "[storage][s3_storage]") {
+  auto config = create_test_config();
+
+  REQUIRE_NOTHROW(s3_storage{config});
+}
+
+TEST_CASE("s3_storage: bucket_name accessor", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  CHECK(storage.bucket_name() == "test-dicom-bucket");
+}
+
+TEST_CASE("s3_storage: is_connected returns true", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  CHECK(storage.is_connected());
+}
+
+// ============================================================================
+// Store and Retrieve Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: store and retrieve", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto dataset = create_test_dataset("1.2.3.100", "1.2.3.100.1",
+                                     "1.2.3.100.1.1", "PAT001", "DOE^JOHN");
+
+  SECTION("store returns success") {
+    auto result = storage.store(dataset);
+    REQUIRE(result.is_ok());
+  }
+
+  SECTION("retrieve after store returns dataset") {
+    REQUIRE(storage.store(dataset).is_ok());
+
+    auto result = storage.retrieve("1.2.3.100.1.1");
+    REQUIRE(result.is_ok());
+    CHECK(result.value().get_string(tags::patient_id) == "PAT001");
+    CHECK(result.value().get_string(tags::patient_name) == "DOE^JOHN");
+  }
+
+  SECTION("retrieve non-existent returns error") {
+    auto result = storage.retrieve("nonexistent.uid");
+    REQUIRE(result.is_err());
+  }
+}
+
+TEST_CASE("s3_storage: store requires UIDs", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  SECTION("missing study UID") {
+    dicom_dataset ds;
+    ds.set_string(tags::series_instance_uid, vr_type::UI, "1.2.3.4");
+    ds.set_string(tags::sop_instance_uid, vr_type::UI, "1.2.3.4.5");
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  "1.2.840.10008.5.1.4.1.1.2");
+
+    auto result = storage.store(ds);
+    CHECK(result.is_err());
+  }
+
+  SECTION("missing series UID") {
+    dicom_dataset ds;
+    ds.set_string(tags::study_instance_uid, vr_type::UI, "1.2.3");
+    ds.set_string(tags::sop_instance_uid, vr_type::UI, "1.2.3.4.5");
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  "1.2.840.10008.5.1.4.1.1.2");
+
+    auto result = storage.store(ds);
+    CHECK(result.is_err());
+  }
+
+  SECTION("missing SOP Instance UID") {
+    dicom_dataset ds;
+    ds.set_string(tags::study_instance_uid, vr_type::UI, "1.2.3");
+    ds.set_string(tags::series_instance_uid, vr_type::UI, "1.2.3.4");
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  "1.2.840.10008.5.1.4.1.1.2");
+
+    auto result = storage.store(ds);
+    CHECK(result.is_err());
+  }
+}
+
+// ============================================================================
+// Exists Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: exists check", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto dataset = create_test_dataset("1.2.3", "1.2.3.4", "1.2.3.4.5");
+
+  CHECK_FALSE(storage.exists("1.2.3.4.5"));
+
+  REQUIRE(storage.store(dataset).is_ok());
+
+  CHECK(storage.exists("1.2.3.4.5"));
+  CHECK_FALSE(storage.exists("nonexistent"));
+}
+
+// ============================================================================
+// Remove Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: remove", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto dataset = create_test_dataset("1.2.3", "1.2.3.4", "1.2.3.4.5");
+  REQUIRE(storage.store(dataset).is_ok());
+  CHECK(storage.exists("1.2.3.4.5"));
+
+  auto result = storage.remove("1.2.3.4.5");
+  REQUIRE(result.is_ok());
+  CHECK_FALSE(storage.exists("1.2.3.4.5"));
+
+  // Remove non-existent should not error
+  result = storage.remove("nonexistent");
+  CHECK(result.is_ok());
+}
+
+// ============================================================================
+// Find Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: find", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto ds1 = create_test_dataset("1.2.3.1", "1.2.3.1.1", "1.2.3.1.1.1",
+                                 "PAT001", "SMITH^JOHN");
+  auto ds2 = create_test_dataset("1.2.3.2", "1.2.3.2.1", "1.2.3.2.1.1",
+                                 "PAT001", "SMITH^JANE");
+  auto ds3 = create_test_dataset("1.2.3.3", "1.2.3.3.1", "1.2.3.3.1.1",
+                                 "PAT002", "DOE^JOHN");
+
+  REQUIRE(storage.store(ds1).is_ok());
+  REQUIRE(storage.store(ds2).is_ok());
+  REQUIRE(storage.store(ds3).is_ok());
+
+  SECTION("find all") {
+    dicom_dataset empty_query;
+    auto result = storage.find(empty_query);
+
+    REQUIRE(result.is_ok());
+    CHECK(result.value().size() == 3);
+  }
+
+  SECTION("find by patient ID") {
+    dicom_dataset query;
+    query.set_string(tags::patient_id, vr_type::LO, "PAT001");
+
+    auto result = storage.find(query);
+
+    REQUIRE(result.is_ok());
+    CHECK(result.value().size() == 2);
+  }
+
+  SECTION("find with wildcard") {
+    dicom_dataset query;
+    query.set_string(tags::patient_name, vr_type::PN, "SMITH*");
+
+    auto result = storage.find(query);
+
+    REQUIRE(result.is_ok());
+    CHECK(result.value().size() == 2);
+  }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: get_statistics", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto stats = storage.get_statistics();
+  CHECK(stats.total_instances == 0);
+
+  auto ds1 =
+      create_test_dataset("1.2.3.1", "1.2.3.1.1", "1.2.3.1.1.1", "PAT001");
+  auto ds2 =
+      create_test_dataset("1.2.3.1", "1.2.3.1.2", "1.2.3.1.2.1", "PAT001");
+  auto ds3 =
+      create_test_dataset("1.2.3.2", "1.2.3.2.1", "1.2.3.2.1.1", "PAT002");
+
+  REQUIRE(storage.store(ds1).is_ok());
+  REQUIRE(storage.store(ds2).is_ok());
+  REQUIRE(storage.store(ds3).is_ok());
+
+  stats = storage.get_statistics();
+  CHECK(stats.total_instances == 3);
+  CHECK(stats.studies_count == 2);
+  CHECK(stats.series_count == 3);
+  CHECK(stats.total_bytes > 0);
+}
+
+// ============================================================================
+// Integrity Verification Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: verify_integrity", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto dataset = create_test_dataset("1.2.3", "1.2.3.4", "1.2.3.4.5");
+  REQUIRE(storage.store(dataset).is_ok());
+
+  auto result = storage.verify_integrity();
+  CHECK(result.is_ok());
+}
+
+// ============================================================================
+// Object Key Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: get_object_key", "[storage][s3_storage]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  // Non-existent returns empty string
+  auto key = storage.get_object_key("nonexistent");
+  CHECK(key.empty());
+
+  // After store, returns actual key
+  auto dataset = create_test_dataset("1.2.3", "1.2.3.4", "1.2.3.4.5");
+  REQUIRE(storage.store(dataset).is_ok());
+
+  key = storage.get_object_key("1.2.3.4.5");
+  CHECK(!key.empty());
+  CHECK(key.find("1.2.3") != std::string::npos);     // Contains study UID
+  CHECK(key.find("1.2.3.4") != std::string::npos);   // Contains series UID
+  CHECK(key.find("1.2.3.4.5") != std::string::npos); // Contains SOP UID
+  CHECK(key.ends_with(".dcm"));
+}
+
+// ============================================================================
+// Rebuild Index Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: rebuild_index", "[storage][s3_storage]") {
+  auto config = create_test_config();
+
+  // First, store some data
+  {
+    s3_storage storage1{config};
+
+    auto ds1 = create_test_dataset("1.2.3.1", "1.2.3.1.1", "1.2.3.1.1.1");
+    auto ds2 = create_test_dataset("1.2.3.2", "1.2.3.2.1", "1.2.3.2.1.1");
+
+    REQUIRE(storage1.store(ds1).is_ok());
+    REQUIRE(storage1.store(ds2).is_ok());
+
+    // Rebuild index should preserve data
+    REQUIRE(storage1.rebuild_index().is_ok());
+
+    CHECK(storage1.exists("1.2.3.1.1.1"));
+    CHECK(storage1.exists("1.2.3.2.1.1"));
+  }
+}
+
+// ============================================================================
+// Batch Operation Tests (inherited from storage_interface)
+// ============================================================================
+
+TEST_CASE("s3_storage: store_batch", "[storage][s3_storage][batch]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  std::vector<dicom_dataset> datasets;
+  datasets.push_back(
+      create_test_dataset("1.2.3.1", "1.2.3.1.1", "1.2.3.1.1.1"));
+  datasets.push_back(
+      create_test_dataset("1.2.3.2", "1.2.3.2.1", "1.2.3.2.1.1"));
+  datasets.push_back(
+      create_test_dataset("1.2.3.3", "1.2.3.3.1", "1.2.3.3.1.1"));
+
+  auto result = storage.store_batch(datasets);
+
+  REQUIRE(result.is_ok());
+  CHECK(storage.exists("1.2.3.1.1.1"));
+  CHECK(storage.exists("1.2.3.2.1.1"));
+  CHECK(storage.exists("1.2.3.3.1.1"));
+}
+
+TEST_CASE("s3_storage: retrieve_batch", "[storage][s3_storage][batch]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  REQUIRE(
+      storage.store(create_test_dataset("1.2.3.1", "1.2.3.1.1", "1.2.3.1.1.1"))
+          .is_ok());
+  REQUIRE(
+      storage.store(create_test_dataset("1.2.3.2", "1.2.3.2.1", "1.2.3.2.1.1"))
+          .is_ok());
+
+  SECTION("retrieve existing instances") {
+    std::vector<std::string> uids{"1.2.3.1.1.1", "1.2.3.2.1.1"};
+    auto result = storage.retrieve_batch(uids);
+
+    REQUIRE(result.is_ok());
+    CHECK(result.value().size() == 2);
+  }
+
+  SECTION("retrieve with some missing") {
+    std::vector<std::string> uids{"1.2.3.1.1.1", "nonexistent", "1.2.3.2.1.1"};
+    auto result = storage.retrieve_batch(uids);
+
+    REQUIRE(result.is_ok());
+    CHECK(result.value().size() == 2);
+  }
+}
+
+// ============================================================================
+// Progress Callback Tests
+// ============================================================================
+
+TEST_CASE("s3_storage: store_with_progress",
+          "[storage][s3_storage][progress]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto dataset = create_test_dataset("1.2.3", "1.2.3.4", "1.2.3.4.5");
+
+  std::atomic<std::size_t> last_bytes{0};
+  std::atomic<int> callback_count{0};
+
+  auto callback = [&](std::size_t bytes_transferred,
+                      std::size_t total_bytes) -> bool {
+    (void)total_bytes; // Suppress unused parameter warning
+    last_bytes = bytes_transferred;
+    callback_count++;
+    return true; // Continue upload
+  };
+
+  auto result = storage.store_with_progress(dataset, callback);
+
+  REQUIRE(result.is_ok());
+  CHECK(callback_count > 0);
+  CHECK(last_bytes > 0);
+}
+
+TEST_CASE("s3_storage: retrieve_with_progress",
+          "[storage][s3_storage][progress]") {
+  auto config = create_test_config();
+  s3_storage storage{config};
+
+  auto dataset = create_test_dataset("1.2.3", "1.2.3.4", "1.2.3.4.5");
+  REQUIRE(storage.store(dataset).is_ok());
+
+  std::atomic<std::size_t> last_bytes{0};
+  std::atomic<int> callback_count{0};
+
+  auto callback = [&](std::size_t bytes_transferred,
+                      std::size_t total_bytes) -> bool {
+    (void)total_bytes; // Suppress unused parameter warning
+    last_bytes = bytes_transferred;
+    callback_count++;
+    return true; // Continue download
+  };
+
+  auto result = storage.retrieve_with_progress("1.2.3.4.5", callback);
+
+  REQUIRE(result.is_ok());
+  CHECK(callback_count > 0);
+}
+
+// ============================================================================
+// Cloud Storage Config Tests
+// ============================================================================
+
+TEST_CASE("cloud_storage_config: default values", "[storage][s3_storage]") {
+  cloud_storage_config config;
+
+  CHECK(config.bucket_name.empty());
+  CHECK(config.region == "us-east-1");
+  CHECK(config.access_key_id.empty());
+  CHECK(config.secret_access_key.empty());
+  CHECK_FALSE(config.endpoint_url.has_value());
+  CHECK(config.multipart_threshold == 100 * 1024 * 1024); // 100MB
+  CHECK(config.part_size == 10 * 1024 * 1024);            // 10MB
+  CHECK(config.max_connections == 25);
+  CHECK(config.connect_timeout_ms == 3000);
+  CHECK(config.request_timeout_ms == 30000);
+  CHECK_FALSE(config.enable_encryption);
+  CHECK(config.storage_class == "STANDARD");
+}


### PR DESCRIPTION
## Summary
This PR implements an S3-compatible storage backend for PACS cloud storage support (Issue #198).

## Changes

### New Files
- `include/pacs/storage/s3_storage.hpp` - Header defining `cloud_storage_config` struct and `s3_storage` class implementing `storage_interface`
- `src/storage/s3_storage.cpp` - Implementation with mock S3 client for testing and API validation
- `tests/storage/s3_storage_test.cpp` - Comprehensive unit tests (17 test cases, 88 assertions)

### Modified Files
- `CMakeLists.txt` - Added s3_storage.cpp to pacs_storage library and s3_storage_test.cpp to storage_tests executable
- `docs/FEATURES.md` - Added S3 Cloud Storage documentation section with configuration examples and usage patterns

## Features Implemented
- `cloud_storage_config` struct with bucket, region, credentials, multipart settings
- `s3_storage` class inheriting from `storage_interface`
- All CRUD operations (store, retrieve, remove, exists)
- Query functionality (find)
- Statistics and integrity verification
- Progress callbacks for upload/download monitoring
- Multipart upload structure (stub for future AWS SDK integration)
- Thread-safe operations with shared_mutex
- Hierarchical S3 object key structure (Study/Series/SOP)

## Testing
- 17 test cases covering all functionality
- 88 assertions verifying correct behavior
- All tests passing

## API Example
```cpp
cloud_storage_config config;
config.bucket_name = "my-dicom-bucket";
config.region = "us-east-1";
config.endpoint_url = "http://localhost:9000";  // For MinIO

s3_storage storage{config};

// Store/retrieve DICOM datasets by SOP Instance UID
auto result = storage.store(dataset);
auto retrieved = storage.retrieve("1.2.3.4.5.6.7.8.9");
```

## Note
This is a mock implementation for API validation and testing. Full AWS SDK C++ integration planned for a future release.

Closes #198