### PR TITLE
refactor(logger): deprecate legacy source location API for v3.0.0 migration

### DIFF
--- a/include/pacs/integration/logger_adapter.hpp
+++ b/include/pacs/integration/logger_adapter.hpp
@@ -290,7 +290,14 @@ public:
      * @param file Source file name
      * @param line Line number
      * @param function Function name
+     *
+     * @deprecated Use log(log_level, const std::string&) instead.
+     *             Source location is now auto-captured by the underlying logger.
+     *             This overload will be removed in v3.0.0.
+     * @see https://github.com/kcenon/common_system/blob/main/docs/DEPRECATION.md
      */
+    [[deprecated("Use log(log_level, const std::string&) instead. "
+                 "Source location is auto-captured. Will be removed in v3.0.0.")]]
     static void log(log_level level,
                     const std::string& message,
                     const std::string& file,

--- a/src/integration/logger_adapter.cpp
+++ b/src/integration/logger_adapter.cpp
@@ -111,18 +111,13 @@ public:
 
     void log(log_level level,
              const std::string& message,
-             const std::string& file,
-             int line,
-             const std::string& function) {
-        if (!initialized_ || !logger_) {
-            return;
-        }
-
-        if (!is_level_enabled(level)) {
-            return;
-        }
-
-        logger_->log(convert_log_level(level), message, file, line, function);
+             [[maybe_unused]] const std::string& file,
+             [[maybe_unused]] int line,
+             [[maybe_unused]] const std::string& function) {
+        // Delegate to the simple log method.
+        // Source location is now auto-captured by the underlying logger.
+        // The file, line, and function parameters are ignored.
+        log(level, message);
     }
 
     [[nodiscard]] auto is_level_enabled(log_level level) const noexcept -> bool {
@@ -297,6 +292,16 @@ void logger_adapter::log(log_level level, const std::string& message) {
     pimpl_->log(level, message);
 }
 
+// Suppress deprecation warning for deprecated method implementation
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
 void logger_adapter::log(log_level level,
                          const std::string& message,
                          const std::string& file,
@@ -304,6 +309,13 @@ void logger_adapter::log(log_level level,
                          const std::string& function) {
     pimpl_->log(level, message, file, line, function);
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
 
 auto logger_adapter::is_level_enabled(log_level level) noexcept -> bool {
     return pimpl_->is_level_enabled(level);

--- a/tests/integration/logger_adapter_test.cpp
+++ b/tests/integration/logger_adapter_test.cpp
@@ -176,9 +176,33 @@ TEST_CASE("logger_adapter standard logging", "[logger_adapter][logging]") {
         REQUIRE(logger_adapter::is_level_enabled(log_level::fatal));
     }
 
-    SECTION("Log with source location") {
+    SECTION("Log with source location (deprecated API - tests backward compatibility)") {
+        // Suppress deprecation warning for backward compatibility test
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4996)
+#endif
+
         logger_adapter::log(log_level::info, "Test message with location",
                            __FILE__, __LINE__, __FUNCTION__);
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic pop
+#endif
+
+        logger_adapter::flush();
+    }
+
+    SECTION("Log without source location (recommended API)") {
+        // This is the recommended way to log - source location is auto-captured
+        logger_adapter::log(log_level::info, "Test message without explicit location");
         logger_adapter::flush();
     }
 }


### PR DESCRIPTION
## Summary

- Mark `log(level, message, file, line, function)` as deprecated with `[[deprecated]]` attribute
- Update implementation to delegate to the simple `log(level, message)` method (source location is auto-captured)
- Add backward compatibility tests with appropriate warning suppression
- Add new test case for the recommended API usage pattern

## Changes

| File | Change |
|------|--------|
| `include/pacs/integration/logger_adapter.hpp` | Add `[[deprecated]]` attribute with migration message |
| `src/integration/logger_adapter.cpp` | Delegate deprecated call to simple API, add warning suppression pragmas |
| `tests/integration/logger_adapter_test.cpp` | Add warning suppression for backward compatibility test, add recommended API test |

## Migration Guide

**Before (Deprecated)**
```cpp
logger_adapter::log(log_level::info, "message", __FILE__, __LINE__, __func__);
```

**After (Recommended)**
```cpp
logger_adapter::log(log_level::info, "message");  // source_location auto-captured
```

## Test Plan

- [x] Build succeeds without deprecation warnings in production code
- [x] All logger_adapter tests pass (58 assertions in 8 test cases)
- [x] All ILogger tests pass (63 assertions in 16 test cases)
- [x] Backward compatibility test verifies deprecated API still works
- [x] New test verifies recommended API pattern

## Related Issues

Closes #397

## References

- [common_system DEPRECATION.md](https://github.com/kcenon/common_system/blob/main/docs/DEPRECATION.md)
- Parent Issue: kcenon/common_system#216