### PR TITLE
deprecation(logger): remove deprecated log method with source location

### DIFF
--- a/include/pacs/integration/logger_adapter.hpp
+++ b/include/pacs/integration/logger_adapter.hpp
@@ -284,27 +284,6 @@ public:
     static void log(log_level level, const std::string& message);
 
     /**
-     * @brief Log a message with source location
-     * @param level Log severity level
-     * @param message The message to log
-     * @param file Source file name
-     * @param line Line number
-     * @param function Function name
-     *
-     * @deprecated Use log(log_level, const std::string&) instead.
-     *             Source location is now auto-captured by the underlying logger.
-     *             This overload will be removed in v3.0.0.
-     * @see https://github.com/kcenon/common_system/blob/main/docs/DEPRECATION.md
-     */
-    [[deprecated("Use log(log_level, const std::string&) instead. "
-                 "Source location is auto-captured. Will be removed in v3.0.0.")]]
-    static void log(log_level level,
-                    const std::string& message,
-                    const std::string& file,
-                    int line,
-                    const std::string& function);
-
-    /**
      * @brief Check if a log level is enabled
      * @param level The level to check
      * @return true if messages at this level will be logged

--- a/src/integration/logger_adapter.cpp
+++ b/src/integration/logger_adapter.cpp
@@ -109,16 +109,6 @@ public:
         logger_->log(convert_log_level(level), message);
     }
 
-    void log(log_level level,
-             const std::string& message,
-             [[maybe_unused]] const std::string& file,
-             [[maybe_unused]] int line,
-             [[maybe_unused]] const std::string& function) {
-        // Delegate to the simple log method.
-        // Source location is now auto-captured by the underlying logger.
-        // The file, line, and function parameters are ignored.
-        log(level, message);
-    }
 
     [[nodiscard]] auto is_level_enabled(log_level level) const noexcept -> bool {
         return static_cast<int>(level) >= static_cast<int>(min_level_.load());
@@ -291,31 +281,6 @@ auto logger_adapter::is_initialized() noexcept -> bool {
 void logger_adapter::log(log_level level, const std::string& message) {
     pimpl_->log(level, message);
 }
-
-// Suppress deprecation warning for deprecated method implementation
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-
-void logger_adapter::log(log_level level,
-                         const std::string& message,
-                         const std::string& file,
-                         int line,
-                         const std::string& function) {
-    pimpl_->log(level, message, file, line, function);
-}
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
 
 auto logger_adapter::is_level_enabled(log_level level) noexcept -> bool {
     return pimpl_->is_level_enabled(level);

--- a/tests/integration/logger_adapter_test.cpp
+++ b/tests/integration/logger_adapter_test.cpp
@@ -176,31 +176,7 @@ TEST_CASE("logger_adapter standard logging", "[logger_adapter][logging]") {
         REQUIRE(logger_adapter::is_level_enabled(log_level::fatal));
     }
 
-    SECTION("Log with source location (deprecated API - tests backward compatibility)") {
-        // Suppress deprecation warning for backward compatibility test
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-#endif
-#if defined(_MSC_VER)
-#pragma warning(push)
-#pragma warning(disable : 4996)
-#endif
-
-        logger_adapter::log(log_level::info, "Test message with location",
-                           __FILE__, __LINE__, __FUNCTION__);
-
-#if defined(_MSC_VER)
-#pragma warning(pop)
-#endif
-#if defined(__GNUC__) || defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-        logger_adapter::flush();
-    }
-
-    SECTION("Log without source location (recommended API)") {
+    SECTION("Log with auto-captured source location") {
         // This is the recommended way to log - source location is auto-captured
         logger_adapter::log(log_level::info, "Test message without explicit location");
         logger_adapter::flush();


### PR DESCRIPTION
## Summary

- Remove deprecated `log(level, message, file, line, function)` method from `logger_adapter`
- Update tests to use the recommended `log(level, message)` API
- The underlying common_system logger now auto-captures source location

## Changes

### Removed APIs
- `logger_adapter::log(log_level, const std::string&, const std::string&, int, const std::string&)`

### Migration
Users should use the simpler API:
```cpp
// Before (deprecated)
logger_adapter::log(log_level::info, "message", __FILE__, __LINE__, __FUNCTION__);

// After (recommended)
logger_adapter::log(log_level::info, "message");
// or use convenience methods
logger_adapter::info("message with {} formatting", arg);
```

## Test Plan

- [x] Build completes without errors
- [x] All logger_adapter tests pass (58 assertions in 8 test cases)
- [x] No pacs_system deprecation warnings in build

## Related Issues

Resolves #399