### PR TITLE
feat(storage): migrate migration_runner to database_system

### DIFF
--- a/include/pacs/storage/migration_runner.hpp
+++ b/include/pacs/storage/migration_runner.hpp
@@ -5,7 +5,12 @@
  * This file provides the migration_runner class for managing database
  * schema evolution through versioned migrations.
  *
+ * When compiled with PACS_WITH_DATABASE_SYSTEM, uses database_system's
+ * database_manager for consistent database abstraction. Otherwise, uses
+ * direct SQLite prepared statements.
+ *
  * @see SRS-STOR-003
+ * @see Issue #422 - Migrate migration_runner.cpp to database_system
  */
 
 #pragma once
@@ -15,9 +20,30 @@
 #include <kcenon/common/patterns/result.h>
 
 #include <functional>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+// Suppress deprecated warnings from database_system headers
+// database_base is deprecated in favor of database_backend
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#elif defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#include <database/database_manager.h>
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#elif defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
+#endif
 
 // Forward declaration of SQLite handle
 struct sqlite3;
@@ -28,7 +54,7 @@ namespace pacs::storage {
 using VoidResult = kcenon::common::VoidResult;
 
 /**
- * @brief Function type for migration implementations
+ * @brief Function type for migration implementations (SQLite)
  *
  * Each migration function receives a database handle and should execute
  * the necessary SQL to upgrade the schema to its target version.
@@ -37,6 +63,20 @@ using VoidResult = kcenon::common::VoidResult;
  * @return VoidResult Success or error information
  */
 using migration_function = std::function<VoidResult(sqlite3* db)>;
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+/**
+ * @brief Function type for migration implementations (database_system)
+ *
+ * Each migration function receives a database manager and should execute
+ * the necessary SQL to upgrade the schema to its target version.
+ *
+ * @param db The database_system manager
+ * @return VoidResult Success or error information
+ */
+using db_system_migration_function =
+    std::function<VoidResult(std::shared_ptr<database::database_manager>)>;
+#endif
 
 /**
  * @brief Manages database schema migrations
@@ -112,6 +152,66 @@ public:
      */
     [[nodiscard]] auto run_migrations_to(sqlite3* db, int target_version)
         -> VoidResult;
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    // ========================================================================
+    // Migration Operations (database_system)
+    // ========================================================================
+
+    /**
+     * @brief Run all pending migrations using database_system
+     *
+     * Executes all migrations from the current version up to LATEST_VERSION.
+     * Each migration is run within a transaction for atomicity.
+     *
+     * @param db_manager The database_system manager
+     * @return VoidResult Success or error information
+     *
+     * @note If any migration fails, the database will be rolled back to its
+     *       state before that migration started.
+     */
+    [[nodiscard]] auto run_migrations(
+        std::shared_ptr<database::database_manager> db_manager) -> VoidResult;
+
+    /**
+     * @brief Run migrations up to a specific version using database_system
+     *
+     * @param db_manager The database_system manager
+     * @param target_version The version to migrate to
+     * @return VoidResult Success or error information
+     */
+    [[nodiscard]] auto run_migrations_to(
+        std::shared_ptr<database::database_manager> db_manager,
+        int target_version) -> VoidResult;
+
+    /**
+     * @brief Get the current schema version using database_system
+     *
+     * @param db_manager The database_system manager
+     * @return Current schema version number
+     */
+    [[nodiscard]] auto get_current_version(
+        std::shared_ptr<database::database_manager> db_manager) const -> int;
+
+    /**
+     * @brief Check if migration is needed using database_system
+     *
+     * @param db_manager The database_system manager
+     * @return true if current version is less than LATEST_VERSION
+     */
+    [[nodiscard]] auto needs_migration(
+        std::shared_ptr<database::database_manager> db_manager) const -> bool;
+
+    /**
+     * @brief Get the migration history using database_system
+     *
+     * @param db_manager The database_system manager
+     * @return Vector of migration records
+     */
+    [[nodiscard]] auto get_history(
+        std::shared_ptr<database::database_manager> db_manager) const
+        -> std::vector<migration_record>;
+#endif
 
     // ========================================================================
     // Version Information
@@ -202,9 +302,68 @@ private:
     [[nodiscard]] auto execute_sql(sqlite3* db, std::string_view sql)
         -> VoidResult;
 
-    // Migration implementations
+    // Migration implementations (SQLite)
     [[nodiscard]] auto migrate_v1(sqlite3* db) -> VoidResult;
     [[nodiscard]] auto migrate_v2(sqlite3* db) -> VoidResult;
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    // ========================================================================
+    // Internal Implementation (database_system)
+    // ========================================================================
+
+    /**
+     * @brief Create the schema_version table if it doesn't exist
+     *
+     * @param db_manager The database_system manager
+     * @return VoidResult Success or error information
+     */
+    [[nodiscard]] auto ensure_schema_version_table(
+        std::shared_ptr<database::database_manager> db_manager) -> VoidResult;
+
+    /**
+     * @brief Apply a single migration using database_system
+     *
+     * @param db_manager The database_system manager
+     * @param version The migration version to apply
+     * @return VoidResult Success or error information
+     */
+    [[nodiscard]] auto apply_migration(
+        std::shared_ptr<database::database_manager> db_manager,
+        int version) -> VoidResult;
+
+    /**
+     * @brief Record a migration in the schema_version table
+     *
+     * @param db_manager The database_system manager
+     * @param version The version that was applied
+     * @param description Description of the migration
+     * @return VoidResult Success or error information
+     */
+    [[nodiscard]] auto record_migration(
+        std::shared_ptr<database::database_manager> db_manager,
+        int version,
+        std::string_view description) -> VoidResult;
+
+    /**
+     * @brief Execute SQL statement using database_system
+     *
+     * @param db_manager The database_system manager
+     * @param sql The SQL statement to execute
+     * @return VoidResult Success or error information
+     */
+    [[nodiscard]] auto execute_sql(
+        std::shared_ptr<database::database_manager> db_manager,
+        std::string_view sql) -> VoidResult;
+
+    // Migration implementations (database_system)
+    [[nodiscard]] auto migrate_v1(
+        std::shared_ptr<database::database_manager> db_manager) -> VoidResult;
+    [[nodiscard]] auto migrate_v2(
+        std::shared_ptr<database::database_manager> db_manager) -> VoidResult;
+
+    /// Migration function registry (database_system)
+    std::vector<std::pair<int, db_system_migration_function>> db_system_migrations_;
+#endif
 
     /// Latest schema version (increment when adding migrations)
     static constexpr int LATEST_VERSION = 2;

--- a/src/storage/migration_runner.cpp
+++ b/src/storage/migration_runner.cpp
@@ -1,6 +1,12 @@
 /**
  * @file migration_runner.cpp
  * @brief Implementation of database schema migration runner
+ *
+ * When compiled with PACS_WITH_DATABASE_SYSTEM, uses database_system's
+ * database_manager for consistent database abstraction. Otherwise, uses
+ * direct SQLite prepared statements.
+ *
+ * @see Issue #422 - Migrate migration_runner.cpp to database_system
  */
 
 #include <pacs/storage/migration_runner.hpp>
@@ -20,9 +26,21 @@ using kcenon::common::make_error;
 // ============================================================================
 
 migration_runner::migration_runner() {
-    // Register all migrations
+    // Register all migrations (SQLite version)
     migrations_.push_back({1, [this](sqlite3* db) { return migrate_v1(db); }});
     migrations_.push_back({2, [this](sqlite3* db) { return migrate_v2(db); }});
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    // Register all migrations (database_system version)
+    db_system_migrations_.push_back(
+        {1, [this](std::shared_ptr<database::database_manager> db) {
+            return migrate_v1(db);
+        }});
+    db_system_migrations_.push_back(
+        {2, [this](std::shared_ptr<database::database_manager> db) {
+            return migrate_v2(db);
+        }});
+#endif
 }
 
 // ============================================================================
@@ -514,5 +532,526 @@ auto migration_runner::migrate_v2(sqlite3* db) -> VoidResult {
 
     return record_migration(db, 2, "Add audit_log table");
 }
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+// ============================================================================
+// Migration Operations (database_system)
+// ============================================================================
+
+auto migration_runner::run_migrations(
+    std::shared_ptr<database::database_manager> db_manager) -> VoidResult {
+    return run_migrations_to(db_manager, LATEST_VERSION);
+}
+
+auto migration_runner::run_migrations_to(
+    std::shared_ptr<database::database_manager> db_manager,
+    int target_version) -> VoidResult {
+    if (!db_manager) {
+        return make_error<std::monostate>(
+            -1, "Database manager is null", "storage");
+    }
+
+    if (target_version > LATEST_VERSION) {
+        return make_error<std::monostate>(
+            -1,
+            pacs::compat::format("Target version {} exceeds latest version {}",
+                                 target_version, LATEST_VERSION),
+            "storage");
+    }
+
+    // Ensure schema_version table exists
+    auto ensure_result = ensure_schema_version_table(db_manager);
+    if (ensure_result.is_err()) {
+        return ensure_result;
+    }
+
+    auto current_version = get_current_version(db_manager);
+
+    // Nothing to do if already at or past target
+    if (current_version >= target_version) {
+        return ok();
+    }
+
+    // Apply each migration in a transaction
+    while (current_version < target_version) {
+        auto next_version = current_version + 1;
+
+        // Begin transaction
+        auto begin_result = db_manager->begin_transaction();
+        if (begin_result.is_err()) {
+            return make_error<std::monostate>(
+                begin_result.error().code,
+                pacs::compat::format("Failed to begin transaction: {}",
+                                     begin_result.error().message),
+                "storage");
+        }
+
+        // Apply migration
+        auto migration_result = apply_migration(db_manager, next_version);
+        if (migration_result.is_err()) {
+            // Rollback on failure
+            (void)db_manager->rollback_transaction();
+            return migration_result;
+        }
+
+        // Commit transaction
+        auto commit_result = db_manager->commit_transaction();
+        if (commit_result.is_err()) {
+            (void)db_manager->rollback_transaction();
+            return make_error<std::monostate>(
+                commit_result.error().code,
+                pacs::compat::format("Failed to commit transaction: {}",
+                                     commit_result.error().message),
+                "storage");
+        }
+
+        current_version = next_version;
+    }
+
+    return ok();
+}
+
+// ============================================================================
+// Version Information (database_system)
+// ============================================================================
+
+auto migration_runner::get_current_version(
+    std::shared_ptr<database::database_manager> db_manager) const -> int {
+    if (!db_manager) {
+        return 0;
+    }
+
+    // Check if schema_version table exists by querying sqlite_master
+    const std::string check_sql =
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='schema_version';";
+
+    auto check_result = db_manager->select_query_result(check_sql);
+    if (check_result.is_err() || check_result.value().empty()) {
+        // Table doesn't exist
+        return 0;
+    }
+
+    // Get max version from table
+    const std::string version_sql = "SELECT MAX(version) AS max_ver FROM schema_version;";
+    auto version_result = db_manager->select_query_result(version_sql);
+    if (version_result.is_err() || version_result.value().empty()) {
+        return 0;
+    }
+
+    const auto& row = version_result.value()[0];
+    auto it = row.find("max_ver");
+    if (it == row.end()) {
+        // Try alternative column names
+        it = row.find("MAX(version)");
+        if (it == row.end()) {
+            it = row.find("max(version)");
+        }
+    }
+
+    if (it != row.end()) {
+        if (std::holds_alternative<int64_t>(it->second)) {
+            return static_cast<int>(std::get<int64_t>(it->second));
+        }
+    }
+
+    return 0;
+}
+
+auto migration_runner::needs_migration(
+    std::shared_ptr<database::database_manager> db_manager) const -> bool {
+    return get_current_version(db_manager) < LATEST_VERSION;
+}
+
+// ============================================================================
+// Migration History (database_system)
+// ============================================================================
+
+auto migration_runner::get_history(
+    std::shared_ptr<database::database_manager> db_manager) const
+    -> std::vector<migration_record> {
+    std::vector<migration_record> history;
+
+    if (!db_manager) {
+        return history;
+    }
+
+    const std::string sql =
+        "SELECT version, description, applied_at FROM schema_version ORDER BY version;";
+
+    auto result = db_manager->select_query_result(sql);
+    if (result.is_err()) {
+        return history;
+    }
+
+    for (const auto& row : result.value()) {
+        migration_record record;
+
+        // Get version
+        if (auto it = row.find("version"); it != row.end()) {
+            if (std::holds_alternative<int64_t>(it->second)) {
+                record.version = static_cast<int>(std::get<int64_t>(it->second));
+            }
+        }
+
+        // Get description
+        if (auto it = row.find("description"); it != row.end()) {
+            if (std::holds_alternative<std::string>(it->second)) {
+                record.description = std::get<std::string>(it->second);
+            }
+        }
+
+        // Get applied_at
+        if (auto it = row.find("applied_at"); it != row.end()) {
+            if (std::holds_alternative<std::string>(it->second)) {
+                record.applied_at = std::get<std::string>(it->second);
+            }
+        }
+
+        history.push_back(std::move(record));
+    }
+
+    return history;
+}
+
+// ============================================================================
+// Internal Implementation (database_system)
+// ============================================================================
+
+auto migration_runner::ensure_schema_version_table(
+    std::shared_ptr<database::database_manager> db_manager) -> VoidResult {
+    const std::string sql = R"(
+        CREATE TABLE IF NOT EXISTS schema_version (
+            version     INTEGER PRIMARY KEY,
+            description TEXT NOT NULL,
+            applied_at  TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+    )";
+
+    return execute_sql(db_manager, sql);
+}
+
+auto migration_runner::apply_migration(
+    std::shared_ptr<database::database_manager> db_manager,
+    int version) -> VoidResult {
+    // Find the migration function
+    for (const auto& [ver, func] : db_system_migrations_) {
+        if (ver == version) {
+            return func(db_manager);
+        }
+    }
+
+    return make_error<std::monostate>(
+        -1,
+        pacs::compat::format("Migration for version {} not found", version),
+        "storage");
+}
+
+auto migration_runner::record_migration(
+    std::shared_ptr<database::database_manager> db_manager,
+    int version,
+    std::string_view description) -> VoidResult {
+    // Use raw SQL for INSERT (simpler and more reliable for migrations)
+    // Note: description is sanitized by the caller and controlled internally
+    const std::string sql = pacs::compat::format(
+        "INSERT INTO schema_version (version, description) VALUES ({}, '{}');",
+        version, description);
+
+    auto result = db_manager->insert_query_result(sql);
+    if (result.is_err()) {
+        return make_error<std::monostate>(
+            result.error().code,
+            pacs::compat::format("Failed to record migration: {}",
+                                 result.error().message),
+            "storage");
+    }
+
+    return ok();
+}
+
+auto migration_runner::execute_sql(
+    std::shared_ptr<database::database_manager> db_manager,
+    std::string_view sql) -> VoidResult {
+    auto result = db_manager->execute_query_result(std::string(sql));
+
+    if (result.is_err()) {
+        return make_error<std::monostate>(
+            result.error().code,
+            pacs::compat::format("SQL execution failed: {}",
+                                 result.error().message),
+            "storage");
+    }
+
+    return ok();
+}
+
+// ============================================================================
+// Migration Implementations (database_system)
+// ============================================================================
+
+auto migration_runner::migrate_v1(
+    std::shared_ptr<database::database_manager> db_manager) -> VoidResult {
+    // V1: Initial schema - Create all base tables
+    // Note: Same DDL as SQLite version since database_system supports raw SQL
+    const std::string sql = R"(
+        -- =====================================================================
+        -- PATIENTS TABLE
+        -- =====================================================================
+        CREATE TABLE IF NOT EXISTS patients (
+            patient_pk      INTEGER PRIMARY KEY AUTOINCREMENT,
+            patient_id      TEXT NOT NULL UNIQUE,
+            patient_name    TEXT,
+            birth_date      TEXT,
+            sex             TEXT,
+            other_ids       TEXT,
+            ethnic_group    TEXT,
+            comments        TEXT,
+            created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at      TEXT NOT NULL DEFAULT (datetime('now')),
+            CHECK (length(patient_id) <= 64)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_patients_name ON patients(patient_name);
+        CREATE INDEX IF NOT EXISTS idx_patients_birth ON patients(birth_date);
+
+        -- =====================================================================
+        -- STUDIES TABLE
+        -- =====================================================================
+        CREATE TABLE IF NOT EXISTS studies (
+            study_pk            INTEGER PRIMARY KEY AUTOINCREMENT,
+            patient_pk          INTEGER NOT NULL REFERENCES patients(patient_pk)
+                                ON DELETE CASCADE,
+            study_uid           TEXT NOT NULL UNIQUE,
+            study_id            TEXT,
+            study_date          TEXT,
+            study_time          TEXT,
+            accession_number    TEXT,
+            referring_physician TEXT,
+            study_description   TEXT,
+            modalities_in_study TEXT,
+            num_series          INTEGER DEFAULT 0,
+            num_instances       INTEGER DEFAULT 0,
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            CHECK (length(study_uid) <= 64)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_studies_patient ON studies(patient_pk);
+        CREATE INDEX IF NOT EXISTS idx_studies_date ON studies(study_date);
+        CREATE INDEX IF NOT EXISTS idx_studies_accession ON studies(accession_number);
+
+        -- =====================================================================
+        -- SERIES TABLE
+        -- =====================================================================
+        CREATE TABLE IF NOT EXISTS series (
+            series_pk           INTEGER PRIMARY KEY AUTOINCREMENT,
+            study_pk            INTEGER NOT NULL REFERENCES studies(study_pk)
+                                ON DELETE CASCADE,
+            series_uid          TEXT NOT NULL UNIQUE,
+            series_number       INTEGER,
+            modality            TEXT,
+            series_description  TEXT,
+            body_part_examined  TEXT,
+            station_name        TEXT,
+            num_instances       INTEGER DEFAULT 0,
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            CHECK (length(series_uid) <= 64)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_series_study ON series(study_pk);
+        CREATE INDEX IF NOT EXISTS idx_series_modality ON series(modality);
+
+        -- =====================================================================
+        -- INSTANCES TABLE
+        -- =====================================================================
+        CREATE TABLE IF NOT EXISTS instances (
+            instance_pk     INTEGER PRIMARY KEY AUTOINCREMENT,
+            series_pk       INTEGER NOT NULL REFERENCES series(series_pk)
+                            ON DELETE CASCADE,
+            sop_uid         TEXT NOT NULL UNIQUE,
+            sop_class_uid   TEXT NOT NULL,
+            instance_number INTEGER,
+            transfer_syntax TEXT,
+            content_date    TEXT,
+            content_time    TEXT,
+            rows            INTEGER,
+            columns         INTEGER,
+            bits_allocated  INTEGER,
+            number_of_frames INTEGER,
+            file_path       TEXT NOT NULL,
+            file_size       INTEGER NOT NULL,
+            file_hash       TEXT,
+            created_at      TEXT NOT NULL DEFAULT (datetime('now')),
+            CHECK (length(sop_uid) <= 64),
+            CHECK (file_size >= 0)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_instances_series ON instances(series_pk);
+        CREATE INDEX IF NOT EXISTS idx_instances_sop_class ON instances(sop_class_uid);
+        CREATE INDEX IF NOT EXISTS idx_instances_number ON instances(instance_number);
+        CREATE INDEX IF NOT EXISTS idx_instances_created ON instances(created_at);
+
+        -- =====================================================================
+        -- MPPS TABLE (Modality Performed Procedure Step)
+        -- =====================================================================
+        CREATE TABLE IF NOT EXISTS mpps (
+            mpps_pk             INTEGER PRIMARY KEY AUTOINCREMENT,
+            mpps_uid            TEXT NOT NULL UNIQUE,
+            status              TEXT NOT NULL,
+            start_datetime      TEXT,
+            end_datetime        TEXT,
+            station_ae          TEXT,
+            station_name        TEXT,
+            modality            TEXT,
+            study_uid           TEXT,
+            accession_no        TEXT,
+            scheduled_step_id   TEXT,
+            requested_proc_id   TEXT,
+            performed_series    TEXT,
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            CHECK (status IN ('IN PROGRESS', 'COMPLETED', 'DISCONTINUED'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_mpps_status ON mpps(status);
+        CREATE INDEX IF NOT EXISTS idx_mpps_station ON mpps(station_ae);
+        CREATE INDEX IF NOT EXISTS idx_mpps_study ON mpps(study_uid);
+        CREATE INDEX IF NOT EXISTS idx_mpps_date ON mpps(start_datetime);
+
+        -- =====================================================================
+        -- WORKLIST TABLE (Modality Worklist)
+        -- =====================================================================
+        CREATE TABLE IF NOT EXISTS worklist (
+            worklist_pk         INTEGER PRIMARY KEY AUTOINCREMENT,
+            step_id             TEXT NOT NULL,
+            step_status         TEXT DEFAULT 'SCHEDULED',
+            patient_id          TEXT NOT NULL,
+            patient_name        TEXT,
+            birth_date          TEXT,
+            sex                 TEXT,
+            accession_no        TEXT,
+            requested_proc_id   TEXT,
+            study_uid           TEXT,
+            scheduled_datetime  TEXT NOT NULL,
+            station_ae          TEXT,
+            station_name        TEXT,
+            modality            TEXT NOT NULL,
+            procedure_desc      TEXT,
+            protocol_code       TEXT,
+            referring_phys      TEXT,
+            referring_phys_id   TEXT,
+            created_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            updated_at          TEXT NOT NULL DEFAULT (datetime('now')),
+            UNIQUE (step_id, accession_no)
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_worklist_station ON worklist(station_ae);
+        CREATE INDEX IF NOT EXISTS idx_worklist_modality ON worklist(modality);
+        CREATE INDEX IF NOT EXISTS idx_worklist_scheduled ON worklist(scheduled_datetime);
+        CREATE INDEX IF NOT EXISTS idx_worklist_patient ON worklist(patient_id);
+        CREATE INDEX IF NOT EXISTS idx_worklist_accession ON worklist(accession_no);
+        CREATE INDEX IF NOT EXISTS idx_worklist_status ON worklist(step_status);
+        CREATE INDEX IF NOT EXISTS idx_worklist_station_date_mod
+            ON worklist(station_ae, scheduled_datetime, modality);
+
+        -- =====================================================================
+        -- TRIGGERS FOR PARENT COUNT UPDATES
+        -- =====================================================================
+        CREATE TRIGGER IF NOT EXISTS trg_instances_insert
+        AFTER INSERT ON instances
+        BEGIN
+            UPDATE series
+            SET num_instances = num_instances + 1,
+                updated_at = datetime('now')
+            WHERE series_pk = NEW.series_pk;
+
+            UPDATE studies
+            SET num_instances = num_instances + 1,
+                updated_at = datetime('now')
+            WHERE study_pk = (SELECT study_pk FROM series WHERE series_pk = NEW.series_pk);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_instances_delete
+        AFTER DELETE ON instances
+        BEGIN
+            UPDATE series
+            SET num_instances = num_instances - 1,
+                updated_at = datetime('now')
+            WHERE series_pk = OLD.series_pk;
+
+            UPDATE studies
+            SET num_instances = num_instances - 1,
+                updated_at = datetime('now')
+            WHERE study_pk = (SELECT study_pk FROM series WHERE series_pk = OLD.series_pk);
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_series_insert
+        AFTER INSERT ON series
+        BEGIN
+            UPDATE studies
+            SET num_series = num_series + 1,
+                updated_at = datetime('now')
+            WHERE study_pk = NEW.study_pk;
+        END;
+
+        CREATE TRIGGER IF NOT EXISTS trg_series_delete
+        AFTER DELETE ON series
+        BEGIN
+            UPDATE studies
+            SET num_series = num_series - 1,
+                updated_at = datetime('now')
+            WHERE study_pk = OLD.study_pk;
+        END;
+    )";
+
+    auto result = execute_sql(db_manager, sql);
+    if (result.is_err()) {
+        return result;
+    }
+
+    return record_migration(db_manager, 1, "Initial schema creation");
+}
+
+auto migration_runner::migrate_v2(
+    std::shared_ptr<database::database_manager> db_manager) -> VoidResult {
+    // V2: Add audit_log table for REST API audit endpoints
+    const std::string sql = R"(
+        -- =====================================================================
+        -- AUDIT_LOG TABLE (for REST API and HIPAA compliance)
+        -- =====================================================================
+        CREATE TABLE IF NOT EXISTS audit_log (
+            audit_pk        INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_type      TEXT NOT NULL,
+            outcome         TEXT DEFAULT 'SUCCESS',
+            timestamp       TEXT NOT NULL DEFAULT (datetime('now')),
+            user_id         TEXT,
+            source_ae       TEXT,
+            target_ae       TEXT,
+            source_ip       TEXT,
+            patient_id      TEXT,
+            study_uid       TEXT,
+            message         TEXT,
+            details         TEXT,
+            CHECK (outcome IN ('SUCCESS', 'FAILURE', 'WARNING'))
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_audit_event_type ON audit_log(event_type);
+        CREATE INDEX IF NOT EXISTS idx_audit_timestamp ON audit_log(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_audit_user ON audit_log(user_id);
+        CREATE INDEX IF NOT EXISTS idx_audit_source_ae ON audit_log(source_ae);
+        CREATE INDEX IF NOT EXISTS idx_audit_patient ON audit_log(patient_id);
+        CREATE INDEX IF NOT EXISTS idx_audit_study ON audit_log(study_uid);
+        CREATE INDEX IF NOT EXISTS idx_audit_outcome ON audit_log(outcome);
+    )";
+
+    auto result = execute_sql(db_manager, sql);
+    if (result.is_err()) {
+        return result;
+    }
+
+    return record_migration(db_manager, 2, "Add audit_log table");
+}
+
+#endif  // PACS_WITH_DATABASE_SYSTEM
 
 }  // namespace pacs::storage


### PR DESCRIPTION
## Summary

Adds `database_system` support to `migration_runner` with conditional compilation (`PACS_WITH_DATABASE_SYSTEM`). This allows the migration runner to leverage the unified database abstraction layer for consistent database operations.

### Changes

- **Header updates** (`migration_runner.hpp`):
  - Added `database_system` includes with deprecation warning suppression
  - Added `db_system_migration_function` type alias for database_manager-based migrations
  - Added overloaded methods for database_system: `run_migrations()`, `run_migrations_to()`, `get_current_version()`, `needs_migration()`, `get_history()`
  - Added internal helper methods for database_system operations

- **Implementation updates** (`migration_runner.cpp`):
  - Extended constructor to register migrations for both SQLite and database_system
  - Implemented all database_system overloads using `select_query_result()` and `insert_query_result()`
  - Added transaction management via `begin_transaction()`, `commit_transaction()`, `rollback_transaction()`
  - Preserved original SQLite implementation for backward compatibility

### API Usage

When `PACS_WITH_DATABASE_SYSTEM` is defined:
```cpp
auto db_manager = std::make_shared<database::database_manager>(context);
migration_runner runner;

// Check if migration needed
if (runner.needs_migration(db_manager)) {
    auto result = runner.run_migrations(db_manager);
    if (result.is_err()) {
        // Handle error
    }
}

// Get migration history
auto history = runner.get_history(db_manager);
```

## Test Plan

- [x] Build `pacs_storage` target with `PACS_WITH_DATABASE_SYSTEM` enabled
- [x] Verify conditional compilation works correctly
- [ ] Integration test with existing index_database usage

## Related Issues

- Closes #422
- Part of Epic #418: Integrate database_system for Unified Database Access Layer