### PR TITLE
feat(storage): migrate studies table operations to database_system

### DIFF
--- a/include/pacs/storage/index_database.hpp
+++ b/include/pacs/storage/index_database.hpp
@@ -1083,6 +1083,13 @@ private:
     [[nodiscard]] auto parse_patient_from_row(
         const std::map<std::string, database::database_value>& row) const
         -> patient_record;
+
+    /**
+     * @brief Parse study record from database_system result row
+     */
+    [[nodiscard]] auto parse_study_from_row(
+        const std::map<std::string, database::database_value>& row) const
+        -> study_record;
 #endif
 
     /// SQLite database handle (used for migrations and fallback)


### PR DESCRIPTION
## Summary
- Migrate all studies table operations in `index_database.cpp` to use `database_system`'s Query Builder
- Add `parse_study_from_row()` helper function for database_system result parsing
- Maintain backward compatibility with direct SQLite fallback

## Migrated Functions
| Function | Query Builder Method |
|----------|---------------------|
| `upsert_study()` | INSERT/UPDATE with check-then-act pattern |
| `find_study()` | SELECT single result |
| `find_study_by_pk()` | SELECT by primary key |
| `list_studies()` | SELECT with FK lookup (via `patient_pk`) |
| `search_studies()` | SELECT with dynamic WHERE (patient filters use fallback) |
| `delete_study()` | DELETE |
| `study_count()` | COUNT (both overloads) |
| `update_modalities_in_study()` | App-level aggregation + UPDATE |

## Technical Notes
- `list_studies()` and `study_count(patient_id)` first look up `patient_pk` via `find_patient()` to avoid JOIN
- `search_studies()` uses Query Builder only when no patient-related filters are present
- `update_modalities_in_study()` uses app-level aggregation with `std::set` for unique modalities

## Test plan
- [x] Build passes with `PACS_WITH_DATABASE_SYSTEM=ON`
- [ ] Unit tests pass
- [ ] Verify studies table CRUD operations work correctly

## Related
Closes #426
Part of #421 (Migrate index_database.cpp to database_system)