### PR TITLE
refactor(storage): migrate series table to database_system query builder

### DIFF
--- a/include/pacs/storage/index_database.hpp
+++ b/include/pacs/storage/index_database.hpp
@@ -1090,6 +1090,13 @@ private:
     [[nodiscard]] auto parse_study_from_row(
         const std::map<std::string, database::database_value>& row) const
         -> study_record;
+
+    /**
+     * @brief Parse series record from database_system result row
+     */
+    [[nodiscard]] auto parse_series_from_row(
+        const std::map<std::string, database::database_value>& row) const
+        -> series_record;
 #endif
 
     /// SQLite database handle (used for migrations and fallback)


### PR DESCRIPTION
## Summary

- Add database_system support for all series table operations in `index_database.cpp`
- Implement `parse_series_from_row` helper function for database_system result parsing
- Maintain SQLite fallback for backwards compatibility

## Scope (from Issue #427)

All series table operations have been migrated:
- `upsert_series()` → Query Builder INSERT/UPDATE with check pattern
- `find_series()` → Query Builder SELECT
- `find_series_by_pk()` → Query Builder SELECT
- `list_series()` → Query Builder SELECT with FK lookup
- `search_series()` → Query Builder with dynamic WHERE
- `delete_series()` → Query Builder DELETE
- `series_count()` → Query Builder COUNT (both overloads)

## Technical Approach

- Uses `sql_query_builder` for parameterized queries
- For JOIN operations (list_series, series_count with study_uid), performs study lookup first then filters by study_pk
- Handles nullable `series_number` field correctly in result parsing
- All operations maintain update_modalities_in_study callback

## Test Plan

- [x] Build passes with `PACS_WITH_DATABASE_SYSTEM=ON`
- [ ] Unit tests pass (pending external library fix)
- [ ] Integration tests pass

## Dependencies

- Depends on #426 (studies table migration) - ✅ Completed

Closes #427