### PR TITLE
refactor(storage): migrate instances table to database_system query builder (#428)

### DIFF
--- a/include/pacs/storage/index_database.hpp
+++ b/include/pacs/storage/index_database.hpp
@@ -1097,6 +1097,13 @@ private:
     [[nodiscard]] auto parse_series_from_row(
         const std::map<std::string, database::database_value>& row) const
         -> series_record;
+
+    /**
+     * @brief Parse instance record from database_system result row
+     */
+    [[nodiscard]] auto parse_instance_from_row(
+        const std::map<std::string, database::database_value>& row) const
+        -> instance_record;
 #endif
 
     /// SQLite database handle (used for migrations and fallback)


### PR DESCRIPTION
## Summary
- Add `parse_instance_from_row()` helper for database_system result parsing
- Migrate instance table operations (find, list, search, delete, count) to use `sql_query_builder` for parameterized queries
- Migrate file path functions (`get_file_path`, `get_study_files`, `get_series_files`)
- Move helper functions to top of file for proper visibility
- Maintain SQLite fallback for builds without `PACS_WITH_DATABASE_SYSTEM`

## Changes
- **include/pacs/storage/index_database.hpp**: Add `parse_instance_from_row()` declaration
- **src/storage/index_database.cpp**: Migrate all 11 instance-related functions to database_system

## Test plan
- [x] All instance tests pass (188 assertions in 22 test cases)
- [x] All file path tests pass (43 assertions in 6 test cases)
- [x] All index_database tests pass (753 assertions in 96 test cases)
- [x] Build succeeds with and without `PACS_WITH_DATABASE_SYSTEM`

Closes #428