### PR TITLE
feat(storage): migrate worklist table to database_system query builder

### DIFF
--- a/docs/database/MIGRATION_GUIDE.md
+++ b/docs/database/MIGRATION_GUIDE.md
@@ -62,7 +62,7 @@ The following tables in `index_database.cpp` have been migrated to use `sql_quer
 | `series` | #427 | Complete | Series metadata |
 | `instances` | #428 | Complete | DICOM instance metadata |
 | `mpps` | #429 | Complete | Modality Performed Procedure Step |
-| `worklist` | #430 | Pending | Modality Worklist |
+| `worklist` | #430 | Complete | Modality Worklist |
 | `audit_logs` | #431 | Pending | Audit trail records |
 
 ---

--- a/include/pacs/storage/index_database.hpp
+++ b/include/pacs/storage/index_database.hpp
@@ -1111,6 +1111,13 @@ private:
     [[nodiscard]] auto parse_mpps_from_row(
         const std::map<std::string, database::database_value>& row) const
         -> mpps_record;
+
+    /**
+     * @brief Parse worklist record from database_system result row
+     */
+    [[nodiscard]] auto parse_worklist_from_row(
+        const std::map<std::string, database::database_value>& row) const
+        -> worklist_item;
 #endif
 
     /// SQLite database handle (used for migrations and fallback)


### PR DESCRIPTION
## Summary

- Migrate all worklist table operations to use `database_system`'s `sql_query_builder`
- Add `parse_worklist_from_row` helper function for result parsing
- Update MIGRATION_GUIDE.md to mark worklist table as complete

## Changes

### Functions Migrated (10 total)

| Function | Operation | Pattern Used |
|----------|-----------|--------------|
| `add_worklist_item` | INSERT | `insert_into().values()` |
| `update_worklist_status` | UPDATE | `update().set().where()` |
| `query_worklist` | SELECT | Dynamic WHERE with `where()` and `where_raw()` |
| `find_worklist_item` | SELECT | `select().from().where()` |
| `find_worklist_by_pk` | SELECT | `select().from().where()` |
| `delete_worklist_item` | DELETE | `delete_from().where()` |
| `cleanup_old_worklist_items` | DELETE | `delete_from().where().where_raw()` |
| `cleanup_worklist_items_before` | DELETE | `delete_from().where().where_raw()` |
| `worklist_count()` | SELECT COUNT | `select().from()` |
| `worklist_count(status)` | SELECT COUNT | `select().from().where()` |

### Backward Compatibility

- All functions maintain SQLite fallback when `database_system` is not available
- Uses `#ifdef PACS_WITH_DATABASE_SYSTEM` conditional compilation
- No breaking changes to public API

## Test Plan

- [ ] Build succeeds with `PACS_WITH_DATABASE_SYSTEM=ON`
- [ ] Build succeeds without database_system (fallback path)
- [ ] Unit tests pass for worklist operations
- [ ] Integration tests pass for MWL C-FIND operations

## Related Issues

- Closes #430
- Part of Epic #418
- Depends on #429 (mpps table migration)