### PR TITLE
feat(services): implement DICOM file parsing in storage_scu (#462)

### DIFF
--- a/include/pacs/core/result.hpp
+++ b/include/pacs/core/result.hpp
@@ -176,6 +176,7 @@ namespace error_codes {
     constexpr int file_not_found_service = service_base - 91;
     constexpr int not_a_regular_file = service_base - 92;
     constexpr int file_parsing_not_implemented = service_base - 93;
+    constexpr int file_parse_failed = service_base - 94;
 } // namespace error_codes
 
 // Re-export common utility functions

--- a/include/pacs/services/storage_scu.hpp
+++ b/include/pacs/services/storage_scu.hpp
@@ -244,6 +244,23 @@ public:
         const std::filesystem::path& file_path);
 
     /**
+     * @brief Store multiple DICOM files
+     *
+     * Reads and parses multiple DICOM files, then sends them via C-STORE.
+     * If continue_on_error is true (default), continues with remaining
+     * files after failures.
+     *
+     * @param assoc The established association to use
+     * @param file_paths Vector of paths to DICOM files
+     * @param progress_callback Optional callback for progress updates
+     * @return Vector of store_result for each file
+     */
+    [[nodiscard]] std::vector<store_result> store_files(
+        network::association& assoc,
+        const std::vector<std::filesystem::path>& file_paths,
+        store_progress_callback progress_callback = nullptr);
+
+    /**
      * @brief Store all DICOM files in a directory
      *
      * Scans a directory for DICOM files and stores them via C-STORE.


### PR DESCRIPTION
## Summary

- Implement `store_file()` method that parses DICOM files using `dicom_file::open()` and sends them via C-STORE
- Add `store_files()` batch method for sending multiple files with progress callback support
- Refactor `store_directory()` to internally use `store_files()` for code reuse
- Add `file_parse_failed` error code for proper error handling

## Changes

### `include/pacs/services/storage_scu.hpp`
- Added `store_files()` method declaration with progress callback support

### `src/services/storage_scu.cpp`
- Added `dicom_file.hpp` include for file parsing
- Implemented `store_file()` using `dicom_file::open()` instead of TODO stub
- Implemented `store_files()` for batch file operations
- Simplified `store_directory()` to delegate to `store_files()`

### `include/pacs/core/result.hpp`
- Added `file_parse_failed` error code (-894)

### `tests/services/storage_scu_test.cpp`
- Added tests for `store_files()` with empty vector
- Added tests for `store_files()` with non-existent files
- Added tests for progress callback functionality

## Test plan

- [x] Build succeeds with `cmake --build build --target pacs_services`
- [x] All existing tests pass (81 assertions in 19 test cases)
- [x] New tests pass (90 assertions in 23 test cases)
- [x] CLI example `store_scu` is compatible with new implementation

## Related Issue

Closes #462

## Checklist

- [x] Code follows the project coding style
- [x] Unit tests added for new functionality
- [x] Documentation updated (inline code documentation)
- [x] Build verified on macOS