### PR TITLE
feat(modules): Phase 4 - Update workflow, web, integration partitions

### DIFF
--- a/src/modules/pacs-integration.cppm
+++ b/src/modules/pacs-integration.cppm
@@ -14,7 +14,7 @@
  * - network_adapter: Network integration
  * - container_adapter: DI container
  * - dicom_session: DICOM-aware session wrapper
- * - itk_adapter: ITK integration (optional)
+ * - itk_adapter: ITK integration (optional, requires PACS_WITH_ITK)
  * - monitoring_adapter: Monitoring system bridge
  *
  * Part of the kcenon.pacs module.
@@ -23,9 +23,12 @@
 module;
 
 // Standard library imports
+#include <array>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <functional>
+#include <map>
 #include <memory>
 #include <optional>
 #include <string>
@@ -41,6 +44,11 @@ module;
 #include <pacs/integration/container_adapter.hpp>
 #include <pacs/integration/dicom_session.hpp>
 #include <pacs/integration/monitoring_adapter.hpp>
+
+// ITK adapter (optional)
+#ifdef PACS_WITH_ITK
+#include <pacs/integration/itk_adapter.hpp>
+#endif
 
 export module kcenon.pacs:integration;
 
@@ -64,3 +72,51 @@ using pacs::integration::monitoring_adapter;
 using pacs::integration::dicom_session;
 
 } // namespace pacs::integration
+
+// ============================================================================
+// Re-export pacs::integration::itk namespace (optional)
+// ============================================================================
+
+#ifdef PACS_WITH_ITK
+
+export namespace pacs::integration::itk {
+
+// Type aliases
+using pacs::integration::itk::ct_image_type;
+using pacs::integration::itk::mr_image_type;
+using pacs::integration::itk::grayscale_2d_type;
+using pacs::integration::itk::grayscale_3d_type;
+using pacs::integration::itk::signed_grayscale_3d_type;
+using pacs::integration::itk::rgb_pixel_type;
+using pacs::integration::itk::rgb_2d_type;
+
+// Metadata types
+using pacs::integration::itk::image_metadata;
+using pacs::integration::itk::slice_info;
+
+// Metadata extraction
+using pacs::integration::itk::extract_metadata;
+using pacs::integration::itk::sort_slices;
+
+// Dataset conversion
+using pacs::integration::itk::dataset_to_image;
+using pacs::integration::itk::series_to_image;
+
+// Pixel data utilities
+using pacs::integration::itk::get_pixel_data;
+using pacs::integration::itk::is_signed_pixel_data;
+using pacs::integration::itk::is_multi_frame;
+using pacs::integration::itk::get_frame_count;
+
+// Hounsfield Unit conversion
+using pacs::integration::itk::apply_hounsfield_conversion;
+
+// Convenience functions
+using pacs::integration::itk::load_ct_series;
+using pacs::integration::itk::load_mr_series;
+using pacs::integration::itk::scan_dicom_directory;
+using pacs::integration::itk::group_by_series;
+
+} // namespace pacs::integration::itk
+
+#endif // PACS_WITH_ITK

--- a/src/modules/pacs-web.cppm
+++ b/src/modules/pacs-web.cppm
@@ -8,8 +8,9 @@
  *
  * This module partition exports web-related types:
  * - rest_server: HTTP/REST server
- * - rest_types: Request/Response types
- * - Endpoint handlers for DICOMweb and custom APIs
+ * - rest_server_config: Server configuration
+ * - http_status, api_error: Request/Response types
+ * - DICOMweb: WADO-RS, STOW-RS, QIDO-RS support
  *
  * Part of the kcenon.pacs module.
  */
@@ -22,13 +23,16 @@ module;
 #include <functional>
 #include <memory>
 #include <optional>
+#include <span>
 #include <string>
 #include <string_view>
 #include <vector>
 
 // PACS web headers
 #include <pacs/web/rest_server.hpp>
+#include <pacs/web/rest_config.hpp>
 #include <pacs/web/rest_types.hpp>
+#include <pacs/web/endpoints/dicomweb_endpoints.hpp>
 
 export module kcenon.pacs:web;
 
@@ -40,10 +44,67 @@ export namespace pacs::web {
 
 // REST server
 using pacs::web::rest_server;
-using pacs::web::rest_config;
+using pacs::web::rest_server_config;
 
 // REST types
-using pacs::web::rest_request;
-using pacs::web::rest_response;
+using pacs::web::http_status;
+using pacs::web::api_error;
+using pacs::web::to_json;
+using pacs::web::make_error_json;
+using pacs::web::make_success_json;
+using pacs::web::json_escape;
 
 } // namespace pacs::web
+
+// ============================================================================
+// Re-export pacs::web::dicomweb namespace
+// ============================================================================
+
+export namespace pacs::web::dicomweb {
+
+// Media types
+using pacs::web::dicomweb::media_type;
+
+// Accept header parsing
+using pacs::web::dicomweb::accept_info;
+using pacs::web::dicomweb::parse_accept_header;
+using pacs::web::dicomweb::is_acceptable;
+
+// Multipart response builder
+using pacs::web::dicomweb::multipart_builder;
+
+// DicomJSON conversion
+using pacs::web::dicomweb::dataset_to_dicom_json;
+using pacs::web::dicomweb::vr_to_string;
+using pacs::web::dicomweb::is_bulk_data_tag;
+
+// STOW-RS support
+using pacs::web::dicomweb::multipart_part;
+using pacs::web::dicomweb::multipart_parser;
+using pacs::web::dicomweb::store_instance_result;
+using pacs::web::dicomweb::store_response;
+using pacs::web::dicomweb::validation_result;
+using pacs::web::dicomweb::validate_instance;
+using pacs::web::dicomweb::build_store_response_json;
+
+// QIDO-RS support
+using pacs::web::dicomweb::study_record_to_dicom_json;
+using pacs::web::dicomweb::series_record_to_dicom_json;
+using pacs::web::dicomweb::instance_record_to_dicom_json;
+using pacs::web::dicomweb::parse_study_query_params;
+using pacs::web::dicomweb::parse_series_query_params;
+using pacs::web::dicomweb::parse_instance_query_params;
+
+// Frame retrieval (WADO-RS)
+using pacs::web::dicomweb::parse_frame_numbers;
+using pacs::web::dicomweb::extract_frame;
+
+// Rendered images (WADO-RS)
+using pacs::web::dicomweb::rendered_format;
+using pacs::web::dicomweb::rendered_params;
+using pacs::web::dicomweb::rendered_result;
+using pacs::web::dicomweb::parse_rendered_params;
+using pacs::web::dicomweb::apply_window_level;
+using pacs::web::dicomweb::render_dicom_image;
+
+} // namespace pacs::web::dicomweb


### PR DESCRIPTION
## Summary

- Complete pacs-web partition with DICOMweb types exports (WADO-RS, STOW-RS, QIDO-RS)
- Complete pacs-integration partition with optional ITK adapter exports
- Fix incorrect type exports in pacs-web (rest_request/rest_response don't exist)

## Changes

### pacs-web.cppm
- Fix incorrect exports (removed non-existent rest_request/rest_response)
- Add http_status, api_error, and JSON utility functions
- Add rest_server_config export
- Add complete pacs::web::dicomweb namespace exports:
  - Media types and Accept header parsing
  - Multipart builder for WADO-RS responses
  - STOW-RS support (multipart_parser, store_response, validation)
  - QIDO-RS support (query functions for study/series/instance)
  - Frame retrieval and rendered image support

### pacs-integration.cppm
- Add optional ITK adapter exports (gated by PACS_WITH_ITK)
- Export image types (ct_image_type, mr_image_type, grayscale types)
- Export metadata types and extraction functions
- Export pixel data utilities and Hounsfield conversion
- Export convenience functions (load_ct_series, load_mr_series, etc.)

### pacs-workflow.cppm
- Already complete with IExecutor integration (Issue #487)
- Exports task_scheduler, auto_prefetch_service, study_lock_manager

## Test plan

- [ ] Module files compile successfully
- [ ] REST API endpoints accessible when imported
- [ ] ITK adapter works when PACS_WITH_ITK is enabled

## Related Issues

Closes #505
Part of #489 (C++20 Module Migration Epic)