### PR TITLE
[MODULE] Phase 5: Create ai, monitoring, di partitions

### DIFF
--- a/src/modules/pacs-ai.cppm
+++ b/src/modules/pacs-ai.cppm
@@ -27,22 +27,41 @@ module;
 #include <string_view>
 #include <vector>
 
-// PACS AI headers
+// PACS AI headers (feature-gated)
+#ifdef KCENON_WITH_AI
 #include <pacs/ai/ai_service_connector.hpp>
 #include <pacs/ai/ai_result_handler.hpp>
+#endif
 
 export module kcenon.pacs:ai;
 
 // ============================================================================
-// Re-export pacs::ai namespace
+// Re-export pacs::ai namespace (feature-gated)
 // ============================================================================
+
+#ifdef KCENON_WITH_AI
 
 export namespace pacs::ai {
 
-// AI service
+// Configuration structures
+using pacs::ai::ai_service_config;
+using pacs::ai::inference_request;
+using pacs::ai::inference_status;
+using pacs::ai::model_info;
+
+// Enumerations
+using pacs::ai::inference_status_code;
+using pacs::ai::authentication_type;
+
+// AI service connector
 using pacs::ai::ai_service_connector;
 
 // Result handling
 using pacs::ai::ai_result_handler;
 
+// Helper functions
+using pacs::ai::to_string;
+
 } // namespace pacs::ai
+
+#endif // KCENON_WITH_AI

--- a/src/modules/pacs-di.cppm
+++ b/src/modules/pacs-di.cppm
@@ -7,21 +7,29 @@
  * @brief C++20 module partition for dependency injection.
  *
  * This module partition exports DI-related types:
- * - ILogger: Logger interface
- * - service_interfaces: Service interface registry
- * - service_registration: Registration helpers
- * - test_support: Testing utilities
+ * - ILogger: Logger interface and implementations
+ * - Service interfaces: IDicomStorage, IDicomNetwork, IDicomCodec
+ * - service_registration: Registration helpers for common_system::di
+ * - test_support: Testing utilities (mocks, TestContainerBuilder)
  *
  * Part of the kcenon.pacs module.
+ *
+ * Integration with common_system::di:
+ * This module works with kcenon::common::di::service_container for
+ * dependency injection throughout pacs_system.
  */
 
 module;
 
 // Standard library imports
+#include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <filesystem>
 #include <functional>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
@@ -41,17 +49,49 @@ export module kcenon.pacs:di;
 
 export namespace pacs::di {
 
-// Logger interface
+// Logger interface and implementations
 using pacs::di::ILogger;
+using pacs::di::NullLogger;
+using pacs::di::LoggerService;
 using pacs::di::null_logger;
 
 // Service interfaces
-using pacs::di::service_interfaces;
+using pacs::di::IDicomStorage;
+using pacs::di::IDicomCodec;
+using pacs::di::IDicomNetwork;
+using pacs::di::DicomNetworkService;
 
-// Registration
-using pacs::di::service_registration;
+// Registration configuration
+using pacs::di::registration_config;
 
-// Testing
-using pacs::di::test_support;
+// Registration functions
+using pacs::di::register_services;
+using pacs::di::register_storage;
+using pacs::di::register_storage_instance;
+using pacs::di::register_network;
+using pacs::di::register_network_instance;
+using pacs::di::register_logger;
+using pacs::di::register_logger_instance;
+using pacs::di::create_container;
 
 } // namespace pacs::di
+
+// ============================================================================
+// Re-export pacs::di::test namespace
+// ============================================================================
+
+export namespace pacs::di::test {
+
+// Mock implementations
+using pacs::di::test::MockStorage;
+using pacs::di::test::MockNetwork;
+
+// Test container builder
+using pacs::di::test::TestContainerBuilder;
+
+// Convenience functions
+using pacs::di::test::create_test_container;
+using pacs::di::test::register_mock_storage;
+using pacs::di::test::register_mock_network;
+
+} // namespace pacs::di::test

--- a/src/modules/pacs-monitoring.cppm
+++ b/src/modules/pacs-monitoring.cppm
@@ -19,15 +19,18 @@
 module;
 
 // Standard library imports
+#include <array>
 #include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <string_view>
+#include <unordered_map>
 #include <vector>
 
 // PACS monitoring headers
@@ -36,6 +39,13 @@ module;
 #include <pacs/monitoring/health_status.hpp>
 #include <pacs/monitoring/health_json.hpp>
 #include <pacs/monitoring/pacs_metrics.hpp>
+
+// PACS metric collectors (CRTP-based)
+#include <pacs/monitoring/collectors/dicom_collector_base.hpp>
+#include <pacs/monitoring/collectors/dicom_metrics_collector.hpp>
+#include <pacs/monitoring/collectors/dicom_association_collector.hpp>
+#include <pacs/monitoring/collectors/dicom_service_collector.hpp>
+#include <pacs/monitoring/collectors/dicom_storage_collector.hpp>
 
 export module kcenon.pacs:monitoring;
 
@@ -53,7 +63,33 @@ using pacs::monitoring::metric_type;
 using pacs::monitoring::health_checker;
 using pacs::monitoring::health_status;
 
-// Metrics
+// Metrics core
 using pacs::monitoring::pacs_metrics;
+using pacs::monitoring::association_counters;
+using pacs::monitoring::transfer_counters;
+using pacs::monitoring::pool_counters;
+using pacs::monitoring::operation_counter;
+using pacs::monitoring::dimse_operation;
+using pacs::monitoring::to_string;
+
+// CRTP collector base
+using pacs::monitoring::dicom_collector_base;
+using pacs::monitoring::dicom_metric;
+using pacs::monitoring::config_map;
+using pacs::monitoring::stats_map;
+
+// Unified DICOM metrics collector
+using pacs::monitoring::dicom_metrics_collector;
+using pacs::monitoring::dicom_metrics_snapshot;
+
+// Specialized collectors
+using pacs::monitoring::dicom_association_collector;
+using pacs::monitoring::association_metric;
+
+using pacs::monitoring::dicom_service_collector;
+using pacs::monitoring::service_metric;
+
+using pacs::monitoring::dicom_storage_collector;
+using pacs::monitoring::storage_metric;
 
 } // namespace pacs::monitoring


### PR DESCRIPTION
## Summary

- Add KCENON_WITH_AI feature gate to pacs-ai.cppm module partition
- Add CRTP-based metric collectors to pacs-monitoring.cppm module partition
- Complete common_system::di integration in pacs-di.cppm module partition

## Changes

### pacs-ai.cppm
- Added `#ifdef KCENON_WITH_AI` feature gate for optional AI module
- Export additional types: ai_service_config, inference_request, inference_status, model_info
- Export enumerations: inference_status_code, authentication_type
- Export helper function: to_string

### pacs-monitoring.cppm
- Added CRTP-based collector headers and types
- Export dicom_collector_base and related types (dicom_metric, config_map, stats_map)
- Export unified collector: dicom_metrics_collector, dicom_metrics_snapshot
- Export specialized collectors:
  - dicom_association_collector (association_metric)
  - dicom_service_collector (service_metric)
  - dicom_storage_collector (storage_metric)
- Export metrics core types: operation_counter, dimse_operation

### pacs-di.cppm
- Complete integration with common_system::di::service_container
- Export service interfaces: IDicomStorage, IDicomNetwork, IDicomCodec
- Export logger implementations: ILogger, NullLogger, LoggerService
- Export registration functions: register_services, register_storage, etc.
- Export test support namespace with MockStorage, MockNetwork, TestContainerBuilder

## Test Plan

- [ ] Verify module compiles with PACS_BUILD_MODULES=ON
- [ ] Verify AI module feature gate works correctly
- [ ] Verify monitoring collectors integrate with monitoring_system
- [ ] Verify DI module works with common_system::di

## Related Issues

Closes #506
Part of #489 (C++20 module migration)