### PR TITLE
ci(dcmtk): increase shell test timeout to prevent job cancellation

### DIFF
--- a/.github/workflows/dcmtk-interop.yml
+++ b/.github/workflows/dcmtk-interop.yml
@@ -222,7 +222,7 @@ jobs:
   dcmtk-shell-tests:
     name: DCMTK Shell Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 25
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
@@ -298,7 +298,7 @@ jobs:
 
     - name: Run DCMTK Echo Shell Test
       working-directory: pacs_system
-      timeout-minutes: 5
+      timeout-minutes: 8
       continue-on-error: true
       run: |
         if [ -f "./examples/integration_tests/scripts/test_dcmtk_echo.sh" ]; then
@@ -308,7 +308,7 @@ jobs:
 
     - name: Run DCMTK Store Shell Test
       working-directory: pacs_system
-      timeout-minutes: 5
+      timeout-minutes: 8
       continue-on-error: true
       run: |
         if [ -f "./examples/integration_tests/scripts/test_dcmtk_store.sh" ]; then
@@ -318,7 +318,7 @@ jobs:
 
     - name: Run DCMTK Find Shell Test
       working-directory: pacs_system
-      timeout-minutes: 5
+      timeout-minutes: 8
       continue-on-error: true
       run: |
         if [ -f "./examples/integration_tests/scripts/test_dcmtk_find.sh" ]; then
@@ -328,7 +328,7 @@ jobs:
 
     - name: Run DCMTK Move Shell Test
       working-directory: pacs_system
-      timeout-minutes: 5
+      timeout-minutes: 8
       continue-on-error: true
       run: |
         if [ -f "./examples/integration_tests/scripts/test_dcmtk_move.sh" ]; then


### PR DESCRIPTION
## Summary

Increase timeout values for DCMTK Shell Tests workflow to prevent job cancellation on ubuntu-24.04.

## What

| Setting | Before | After |
|---------|--------|-------|
| Job timeout | 25 min | 40 min |
| Echo test step | 5 min | 8 min |
| Store test step | 5 min | 8 min |
| Find test step | 5 min | 8 min |
| Move test step | 5 min | 8 min |

## Why

The DCMTK Shell Tests job on ubuntu-24.04 was being cancelled due to:
1. Individual test steps exceeding the 5-minute timeout
2. Cumulative execution time exceeding the 25-minute job timeout

This was observed in PR #550 where:
- "Run DCMTK Store Shell Test" timed out after 5 minutes
- "Run DCMTK Find Shell Test" timed out after 5 minutes
- The entire job exceeded 25 minutes and was cancelled

## Test Plan

- [ ] Verify DCMTK Shell Tests complete without timeout on ubuntu-24.04
- [ ] Verify DCMTK Shell Tests complete without timeout on macos-14
- [ ] Confirm all workflow jobs report SUCCESS status