### PR TITLE
feat(web): implement Jobs WebSocket progress streaming

### DIFF
--- a/include/pacs/web/endpoints/jobs_endpoints.hpp
+++ b/include/pacs/web/endpoints/jobs_endpoints.hpp
@@ -1,13 +1,15 @@
 /**
  * @file jobs_endpoints.hpp
- * @brief Job management REST API endpoints
+ * @brief Job management REST API and WebSocket endpoints
  *
  * This file provides the jobs endpoints for listing, creating,
  * deleting, and controlling async DICOM jobs via REST API.
+ * Also provides WebSocket endpoints for real-time progress streaming.
  *
  * @see Issue #538 - Implement Job REST API & WebSocket Progress Streaming
  * @see Issue #558 - Part 1: Jobs REST API Endpoints (CRUD)
  * @see Issue #559 - Part 2: Jobs REST API Control Endpoints
+ * @see Issue #560 - Part 3: Jobs WebSocket Progress Streaming
  * @copyright Copyright (c) 2025
  * @license MIT
  */
@@ -23,7 +25,7 @@ struct rest_server_context;
 namespace endpoints {
 
 // Internal function - implementation in cpp file
-// Registers jobs endpoints with the Crow app
+// Registers jobs endpoints with the Crow app (REST + WebSocket)
 // Called from rest_server.cpp
 
 } // namespace endpoints


### PR DESCRIPTION
Closes #560

## Summary
- Add WebSocket endpoints for real-time job progress streaming
- Implement thread-safe subscriber management with `shared_mutex`
- Register job_manager callbacks for broadcasting progress and completion events

## Changes
### WebSocket Endpoints
- `WS /api/v1/jobs/{jobId}/progress/stream` - Stream progress for a specific job
- `WS /api/v1/jobs/stream` - Stream all job status updates

### Message Types
```typescript
// Progress update
{ "type": "progress", "job_id": "...", "progress": {...} }

// Status change
{ "type": "status_change", "job_id": "...", "old_status": "...", "new_status": "..." }

// Job completion
{ "type": "completed", "job_id": "...", "status": "...", "progress": {...} }

// Connected (for /jobs/stream)
{ "type": "connected", "message": "Subscribed to all job updates" }
```

### Implementation Details
- `ws_subscriber_state` singleton manages WebSocket connections
- URL parameter extraction via `onaccept` handler for job-specific streams
- Proper connection lifecycle management with userdata cleanup
- Job callbacks broadcast to all relevant subscribers

## Test Plan
- [ ] Connect to `/api/v1/jobs/{jobId}/progress/stream` and verify progress updates
- [ ] Connect to `/api/v1/jobs/stream` and verify all job updates received
- [ ] Verify proper cleanup when WebSocket disconnects
- [ ] Test multiple concurrent subscribers
- [ ] Verify error handling for non-existent jobs