### PR TITLE
feat(web): add TypeScript types and API client for Jobs REST API

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,5 +1,13 @@
 import axios, { type AxiosError, type AxiosInstance } from 'axios';
-import type { ApiError, WorklistItemInput } from '../types/api';
+import type {
+  ApiError,
+  WorklistItemInput,
+  Job,
+  JobListResponse,
+  JobProgress,
+  JobQuery,
+  CreateJobRequest,
+} from '../types/api';
 
 const API_BASE_URL = '/api/v1';
 
@@ -216,6 +224,56 @@ class ApiClient {
     const response = await this.client.get('/audit/logs', {
       params: { limit, offset: 0 },
     });
+    return response.data;
+  }
+
+  // Job endpoints
+  async getJobs(params?: JobQuery): Promise<JobListResponse> {
+    const response = await this.client.get('/jobs', { params });
+    return response.data;
+  }
+
+  async getJob(jobId: string): Promise<Job> {
+    const response = await this.client.get(`/jobs/${encodeURIComponent(jobId)}`);
+    return response.data;
+  }
+
+  async createJob(job: CreateJobRequest): Promise<Job> {
+    const response = await this.client.post('/jobs', job);
+    return response.data;
+  }
+
+  async deleteJob(jobId: string): Promise<void> {
+    await this.client.delete(`/jobs/${encodeURIComponent(jobId)}`);
+  }
+
+  async getJobProgress(jobId: string): Promise<JobProgress> {
+    const response = await this.client.get(`/jobs/${encodeURIComponent(jobId)}/progress`);
+    return response.data;
+  }
+
+  async startJob(jobId: string): Promise<Job> {
+    const response = await this.client.post(`/jobs/${encodeURIComponent(jobId)}/start`);
+    return response.data;
+  }
+
+  async pauseJob(jobId: string): Promise<Job> {
+    const response = await this.client.post(`/jobs/${encodeURIComponent(jobId)}/pause`);
+    return response.data;
+  }
+
+  async resumeJob(jobId: string): Promise<Job> {
+    const response = await this.client.post(`/jobs/${encodeURIComponent(jobId)}/resume`);
+    return response.data;
+  }
+
+  async cancelJob(jobId: string): Promise<Job> {
+    const response = await this.client.post(`/jobs/${encodeURIComponent(jobId)}/cancel`);
+    return response.data;
+  }
+
+  async retryJob(jobId: string): Promise<Job> {
+    const response = await this.client.post(`/jobs/${encodeURIComponent(jobId)}/retry`);
     return response.data;
   }
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -295,3 +295,69 @@ export interface ApiError {
     message: string;
   };
 }
+
+// Job types - aligned with backend pacs::client::job_types
+export type JobType = 'query' | 'retrieve' | 'store' | 'export' | 'import' | 'prefetch' | 'sync';
+export type JobStatus = 'pending' | 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused';
+export type JobPriority = 'low' | 'normal' | 'high' | 'urgent';
+
+export interface JobProgress {
+  total_items: number;
+  completed_items: number;
+  failed_items: number;
+  skipped_items: number;
+  bytes_transferred: number;
+  percent_complete: number;
+  current_item?: string;
+  current_item_description?: string;
+  elapsed_ms: number;
+  estimated_remaining_ms: number;
+}
+
+export interface Job {
+  job_id: string;
+  type: JobType;
+  status: JobStatus;
+  priority: JobPriority;
+  source_node_id?: string;
+  destination_node_id?: string;
+  patient_id?: string;
+  study_uid?: string;
+  series_uid?: string;
+  progress: JobProgress;
+  error_message?: string;
+  error_details?: string;
+  retry_count: number;
+  max_retries: number;
+  created_at?: string;
+  queued_at?: string;
+  started_at?: string;
+  completed_at?: string;
+  created_by?: string;
+}
+
+export interface JobQuery {
+  status?: JobStatus;
+  type?: JobType;
+  limit?: number;
+  offset?: number;
+}
+
+export interface CreateJobRequest {
+  type: JobType;
+  source_node_id?: string;
+  destination_node_id?: string;
+  study_uid?: string;
+  series_uid?: string;
+  instance_uids?: string[];
+  patient_id?: string;
+  patient_name?: string;
+  node_id?: string;
+  query_level?: string;
+  priority?: JobPriority;
+}
+
+export interface JobListResponse {
+  jobs: Job[];
+  total: number;
+}


### PR DESCRIPTION
Closes #538

## Summary
- Add Job-related TypeScript types to `api.ts` matching backend `pacs::client::job_types`
- Add complete Jobs API client methods to `client.ts` for all REST endpoints
- Create sub-issue #564 for WebSocket streaming implementation (Phase 3-3)

## Changes

### TypeScript Types (`web/src/types/api.ts`)
- `JobType`: 'query' | 'retrieve' | 'store' | 'export' | 'import' | 'prefetch' | 'sync'
- `JobStatus`: 'pending' | 'queued' | 'running' | 'completed' | 'failed' | 'cancelled' | 'paused'
- `JobPriority`: 'low' | 'normal' | 'high' | 'urgent'
- `JobProgress`: Progress tracking with items, bytes, timing
- `Job`: Complete job record with all metadata
- `JobQuery`: Query parameters for listing jobs
- `CreateJobRequest`: Request body for job creation
- `JobListResponse`: Paginated job list response

### API Client (`web/src/api/client.ts`)
- `getJobs(params?)`: List jobs with optional filters
- `getJob(jobId)`: Get single job by ID
- `createJob(job)`: Create new job
- `deleteJob(jobId)`: Delete job
- `getJobProgress(jobId)`: Get job progress
- `startJob(jobId)`: Start pending job
- `pauseJob(jobId)`: Pause running job
- `resumeJob(jobId)`: Resume paused job
- `cancelJob(jobId)`: Cancel job
- `retryJob(jobId)`: Retry failed job

## Test Plan
- [x] TypeScript compilation passes (`npx tsc --noEmit`)
- [ ] Manual API testing via web UI (pending backend availability)

## Related Issues
- #564: WebSocket Progress Streaming (Phase 3-3) - created as follow-up