### PR TITLE
feat(samples): add sample infrastructure and common utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 option(PACS_BUILD_TESTS "Build unit tests" ON)
 option(PACS_BUILD_EXAMPLES "Build examples" OFF)
 option(PACS_BUILD_BENCHMARKS "Build benchmarks" OFF)
+option(PACS_BUILD_SAMPLES "Build developer samples" OFF)
 
 # Dependency integration options
 option(PACS_WITH_COMMON_SYSTEM "Enable common_system integration (REQUIRED)" ON)
@@ -2364,6 +2365,18 @@ endif()
 message(STATUS "")
 
 ##################################################
+# Developer Samples
+##################################################
+
+if(PACS_BUILD_SAMPLES)
+    message(STATUS "")
+    message(STATUS "=== Building Developer Samples ===")
+    add_subdirectory(samples)
+    pacs_apply_warnings(pacs_samples_common)
+    message(STATUS "Developer samples: ON")
+endif()
+
+##################################################
 # Build Summary
 ##################################################
 
@@ -2401,6 +2414,7 @@ else()
     message(STATUS "  Examples: ${PACS_BUILD_EXAMPLES}")
 endif()
 message(STATUS "  Benchmarks: ${PACS_BUILD_BENCHMARKS}")
+message(STATUS "  Samples: ${PACS_BUILD_SAMPLES}")
 message(STATUS "  Services: ON")
 if(TARGET pacs_storage)
     message(STATUS "  Storage: ON (SQLite3)")

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -1,0 +1,17 @@
+# samples/CMakeLists.txt
+# Root CMake configuration for developer samples
+#
+# This directory contains developer samples demonstrating various PACS system
+# features in a progressive learning path from basic to advanced.
+
+cmake_minimum_required(VERSION 3.20)
+
+# Common utilities library (used by all samples)
+add_subdirectory(common)
+
+# Sample applications (to be added in subsequent issues)
+# add_subdirectory(01_hello_dicom)     # Level 1: Basic DICOM file operations
+# add_subdirectory(02_echo_server)     # Level 2: C-ECHO SCP/SCU
+# add_subdirectory(03_storage_server)  # Level 3: C-STORE SCP/SCU
+# add_subdirectory(04_mini_pacs)       # Level 4: Full PACS with query/retrieve
+# add_subdirectory(05_production_pacs) # Level 5: Production-ready features

--- a/samples/common/CMakeLists.txt
+++ b/samples/common/CMakeLists.txt
@@ -1,0 +1,23 @@
+# samples/common/CMakeLists.txt
+# Common utilities library for developer samples
+
+add_library(pacs_samples_common STATIC
+    signal_handler.cpp
+    test_data_generator.cpp
+    console_utils.cpp
+)
+
+target_include_directories(pacs_samples_common PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(pacs_samples_common PUBLIC
+    pacs_core
+    pacs_encoding
+)
+
+# Require C++20
+target_compile_features(pacs_samples_common PUBLIC cxx_std_20)
+
+# Add alias for cleaner target names
+add_library(pacs::samples::common ALIAS pacs_samples_common)

--- a/samples/common/console_utils.cpp
+++ b/samples/common/console_utils.cpp
@@ -1,0 +1,370 @@
+/**
+ * @file console_utils.cpp
+ * @brief Implementation of console output utilities
+ */
+
+#include "console_utils.hpp"
+
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+#ifdef _WIN32
+#include <io.h>
+#include <windows.h>
+#define isatty _isatty
+#define fileno _fileno
+#else
+#include <unistd.h>
+#endif
+
+namespace pacs::samples {
+
+// ============================================================================
+// Static State
+// ============================================================================
+
+namespace {
+bool g_color_enabled = true;
+bool g_color_checked = false;
+}  // namespace
+
+// ============================================================================
+// Color Support Detection
+// ============================================================================
+
+auto supports_color() noexcept -> bool {
+    // Check if stdout is a terminal
+    if (!isatty(fileno(stdout))) {
+        return false;
+    }
+
+#ifdef _WIN32
+    // Enable virtual terminal processing on Windows 10+
+    HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (hOut == INVALID_HANDLE_VALUE) {
+        return false;
+    }
+
+    DWORD dwMode = 0;
+    if (!GetConsoleMode(hOut, &dwMode)) {
+        return false;
+    }
+
+    dwMode |= ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    if (!SetConsoleMode(hOut, dwMode)) {
+        // Fallback: check if TERM is set (e.g., running in mintty)
+        const char* term = std::getenv("TERM");
+        return term != nullptr;
+    }
+    return true;
+#else
+    // Check common environment variables
+    const char* term = std::getenv("TERM");
+    if (term == nullptr) {
+        return false;
+    }
+
+    // Check for dumb terminal
+    if (std::string_view{term} == "dumb") {
+        return false;
+    }
+
+    // Check for NO_COLOR environment variable
+    if (std::getenv("NO_COLOR") != nullptr) {
+        return false;
+    }
+
+    return true;
+#endif
+}
+
+void set_color_enabled(bool enabled) {
+    g_color_enabled = enabled;
+    g_color_checked = true;
+}
+
+auto is_color_enabled() noexcept -> bool {
+    if (!g_color_checked) {
+        g_color_enabled = supports_color();
+        g_color_checked = true;
+    }
+    return g_color_enabled;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+namespace {
+
+auto color(const char* code) -> const char* {
+    return is_color_enabled() ? code : "";
+}
+
+constexpr int kDefaultWidth = 78;
+
+}  // namespace
+
+// ============================================================================
+// Message Printing
+// ============================================================================
+
+void print_header(std::string_view title) {
+    std::cout << color(colors::bold) << color(colors::cyan);
+    std::cout << "\n";
+    std::cout << std::string(kDefaultWidth, '=') << "\n";
+    std::cout << center_text(title, kDefaultWidth) << "\n";
+    std::cout << std::string(kDefaultWidth, '=') << "\n";
+    std::cout << color(colors::reset) << "\n";
+}
+
+void print_section(std::string_view title) {
+    std::string line = "--- " + std::string(title) + " ";
+    line += std::string(kDefaultWidth - line.length(), '-');
+
+    std::cout << "\n" << color(colors::bold) << color(colors::blue)
+              << line << color(colors::reset) << "\n\n";
+}
+
+void print_success(std::string_view message) {
+    std::cout << color(colors::green) << "[OK] " << color(colors::reset)
+              << message << "\n";
+}
+
+void print_error(std::string_view message) {
+    std::cout << color(colors::red) << "[ERROR] " << color(colors::reset)
+              << message << "\n";
+}
+
+void print_warning(std::string_view message) {
+    std::cout << color(colors::yellow) << "[WARN] " << color(colors::reset)
+              << message << "\n";
+}
+
+void print_info(std::string_view message) {
+    std::cout << color(colors::cyan) << "[INFO] " << color(colors::reset)
+              << message << "\n";
+}
+
+void print_debug(std::string_view message) {
+    std::cout << color(colors::dim) << "[DEBUG] " << message
+              << color(colors::reset) << "\n";
+}
+
+// ============================================================================
+// DICOM Data Display
+// ============================================================================
+
+void print_dataset_summary(const core::dicom_dataset& ds) {
+    using namespace core::tags;
+
+    std::vector<std::pair<std::string, std::string>> patient_rows = {
+        {"Patient Name", ds.get_string(patient_name)},
+        {"Patient ID", ds.get_string(patient_id)},
+        {"Birth Date", ds.get_string(patient_birth_date)},
+        {"Sex", ds.get_string(patient_sex)},
+    };
+    print_table("Patient", patient_rows);
+
+    std::vector<std::pair<std::string, std::string>> study_rows = {
+        {"Study UID", truncate(ds.get_string(study_instance_uid), 40)},
+        {"Study Date", ds.get_string(study_date)},
+        {"Accession #", ds.get_string(accession_number)},
+        {"Description", ds.get_string(study_description)},
+    };
+    print_table("Study", study_rows);
+
+    std::vector<std::pair<std::string, std::string>> series_rows = {
+        {"Series UID", truncate(ds.get_string(series_instance_uid), 40)},
+        {"Modality", ds.get_string(modality)},
+        {"Series #", ds.get_string(series_number)},
+        {"Description", ds.get_string(series_description)},
+    };
+    print_table("Series", series_rows);
+
+    std::vector<std::pair<std::string, std::string>> image_rows = {
+        {"SOP Instance", truncate(ds.get_string(sop_instance_uid), 40)},
+        {"Rows", ds.get_string(rows)},
+        {"Columns", ds.get_string(columns)},
+        {"Bits Allocated", ds.get_string(bits_allocated)},
+        {"Photometric", ds.get_string(photometric_interpretation)},
+    };
+    print_table("Image", image_rows);
+}
+
+void print_dataset_elements(const core::dicom_dataset& ds,
+                            size_t max_value_length) {
+    std::cout << color(colors::bold)
+              << std::left << std::setw(14) << "Tag"
+              << std::setw(6) << "VR"
+              << "Value"
+              << color(colors::reset) << "\n";
+    std::cout << std::string(kDefaultWidth, '-') << "\n";
+
+    for (const auto& [tag, element] : ds) {
+        std::cout << color(colors::cyan) << tag.to_string() << color(colors::reset)
+                  << "  ";
+
+        std::cout << color(colors::yellow)
+                  << std::setw(4) << encoding::to_string(element.vr())
+                  << color(colors::reset) << "  ";
+
+        auto value_result = element.as_string();
+        std::string value = value_result.is_ok() ? value_result.value() : "<binary>";
+        std::cout << truncate(value, max_value_length) << "\n";
+    }
+}
+
+// ============================================================================
+// Box Drawing
+// ============================================================================
+
+void print_box(const std::vector<std::string>& lines) {
+    if (lines.empty()) {
+        return;
+    }
+
+    // Find maximum line length
+    size_t max_len = 0;
+    for (const auto& line : lines) {
+        max_len = std::max(max_len, line.length());
+    }
+    max_len = std::min(max_len, static_cast<size_t>(kDefaultWidth - 4));
+
+    std::cout << color(colors::dim);
+    std::cout << "+" << std::string(max_len + 2, '-') << "+\n";
+    for (const auto& line : lines) {
+        std::cout << "| " << std::left << std::setw(static_cast<int>(max_len))
+                  << truncate(line, max_len) << " |\n";
+    }
+    std::cout << "+" << std::string(max_len + 2, '-') << "+\n";
+    std::cout << color(colors::reset);
+}
+
+void print_table(std::string_view title,
+                 const std::vector<std::pair<std::string, std::string>>& rows) {
+    if (rows.empty()) {
+        return;
+    }
+
+    // Find maximum key length
+    size_t max_key_len = 0;
+    for (const auto& [key, _] : rows) {
+        max_key_len = std::max(max_key_len, key.length());
+    }
+
+    std::cout << color(colors::bold) << color(colors::magenta)
+              << title << ":" << color(colors::reset) << "\n";
+
+    for (const auto& [key, value] : rows) {
+        std::cout << "  " << color(colors::dim)
+                  << std::right << std::setw(static_cast<int>(max_key_len)) << key
+                  << color(colors::reset) << ": "
+                  << value << "\n";
+    }
+    std::cout << "\n";
+}
+
+// ============================================================================
+// Progress Display
+// ============================================================================
+
+void print_progress(size_t current, size_t total, int width,
+                    std::string_view label) {
+    if (total == 0) {
+        return;
+    }
+
+    double progress = static_cast<double>(current) / static_cast<double>(total);
+    int filled = static_cast<int>(progress * width);
+    int percent = static_cast<int>(progress * 100.0);
+
+    std::cout << "\r" << label << ": [";
+    std::cout << color(colors::green);
+    for (int i = 0; i < filled; ++i) {
+        std::cout << "#";
+    }
+    std::cout << color(colors::dim);
+    for (int i = filled; i < width; ++i) {
+        std::cout << "-";
+    }
+    std::cout << color(colors::reset);
+    std::cout << "] " << std::setw(3) << percent << "% ("
+              << current << "/" << total << ")" << std::flush;
+}
+
+void clear_line() {
+    std::cout << "\r" << std::string(kDefaultWidth, ' ') << "\r" << std::flush;
+}
+
+// ============================================================================
+// Formatting Utilities
+// ============================================================================
+
+auto format_bytes(uint64_t bytes) -> std::string {
+    constexpr uint64_t KB = 1024;
+    constexpr uint64_t MB = KB * 1024;
+    constexpr uint64_t GB = MB * 1024;
+
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(1);
+
+    if (bytes >= GB) {
+        oss << static_cast<double>(bytes) / static_cast<double>(GB) << " GB";
+    } else if (bytes >= MB) {
+        oss << static_cast<double>(bytes) / static_cast<double>(MB) << " MB";
+    } else if (bytes >= KB) {
+        oss << static_cast<double>(bytes) / static_cast<double>(KB) << " KB";
+    } else {
+        oss << bytes << " B";
+    }
+
+    return oss.str();
+}
+
+auto format_duration(uint64_t milliseconds) -> std::string {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(1);
+
+    if (milliseconds >= 60000) {
+        oss << static_cast<double>(milliseconds) / 60000.0 << " min";
+    } else if (milliseconds >= 1000) {
+        oss << static_cast<double>(milliseconds) / 1000.0 << " s";
+    } else {
+        oss << milliseconds << " ms";
+    }
+
+    return oss.str();
+}
+
+auto center_text(std::string_view text, size_t width) -> std::string {
+    if (text.length() >= width) {
+        return std::string{text.substr(0, width)};
+    }
+
+    size_t padding = (width - text.length()) / 2;
+    return std::string(padding, ' ') + std::string{text} +
+           std::string(width - padding - text.length(), ' ');
+}
+
+auto truncate(std::string_view text, size_t max_length,
+              std::string_view suffix) -> std::string {
+    if (text.length() <= max_length) {
+        return std::string{text};
+    }
+
+    if (max_length <= suffix.length()) {
+        return std::string{suffix.substr(0, max_length)};
+    }
+
+    return std::string{text.substr(0, max_length - suffix.length())} +
+           std::string{suffix};
+}
+
+}  // namespace pacs::samples

--- a/samples/common/console_utils.hpp
+++ b/samples/common/console_utils.hpp
@@ -1,0 +1,273 @@
+/**
+ * @file console_utils.hpp
+ * @brief Console output utilities for developer samples
+ *
+ * This file provides utilities for formatted console output with
+ * ANSI color support and pretty-printing of DICOM data.
+ */
+
+#pragma once
+
+#include <pacs/core/dicom_dataset.hpp>
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::samples {
+
+// ============================================================================
+// ANSI Color Codes
+// ============================================================================
+
+/**
+ * @brief ANSI escape codes for terminal colors
+ *
+ * These codes work on most modern terminals including:
+ * - Linux terminals (GNOME Terminal, Konsole, etc.)
+ * - macOS Terminal and iTerm2
+ * - Windows Terminal and PowerShell (Windows 10+)
+ *
+ * For older Windows cmd.exe, colors may not display correctly.
+ */
+namespace colors {
+
+/// Reset all formatting
+constexpr const char* reset = "\033[0m";
+
+/// Bold text
+constexpr const char* bold = "\033[1m";
+
+/// Dim/faint text
+constexpr const char* dim = "\033[2m";
+
+/// Standard colors
+constexpr const char* black = "\033[30m";
+constexpr const char* red = "\033[31m";
+constexpr const char* green = "\033[32m";
+constexpr const char* yellow = "\033[33m";
+constexpr const char* blue = "\033[34m";
+constexpr const char* magenta = "\033[35m";
+constexpr const char* cyan = "\033[36m";
+constexpr const char* white = "\033[37m";
+
+/// Bright/bold colors
+constexpr const char* bright_red = "\033[91m";
+constexpr const char* bright_green = "\033[92m";
+constexpr const char* bright_yellow = "\033[93m";
+constexpr const char* bright_blue = "\033[94m";
+constexpr const char* bright_magenta = "\033[95m";
+constexpr const char* bright_cyan = "\033[96m";
+constexpr const char* bright_white = "\033[97m";
+
+/// Background colors
+constexpr const char* bg_red = "\033[41m";
+constexpr const char* bg_green = "\033[42m";
+constexpr const char* bg_yellow = "\033[43m";
+constexpr const char* bg_blue = "\033[44m";
+
+}  // namespace colors
+
+// ============================================================================
+// Console Utilities
+// ============================================================================
+
+/**
+ * @brief Check if the terminal supports ANSI colors
+ * @return true if ANSI colors are supported
+ *
+ * Checks environment variables and terminal type to determine support.
+ */
+[[nodiscard]] auto supports_color() noexcept -> bool;
+
+/**
+ * @brief Enable or disable color output globally
+ * @param enabled Whether to enable colors
+ *
+ * When disabled, all color functions will output plain text.
+ */
+void set_color_enabled(bool enabled);
+
+/**
+ * @brief Check if colors are currently enabled
+ * @return true if colors are enabled
+ */
+[[nodiscard]] auto is_color_enabled() noexcept -> bool;
+
+// ============================================================================
+// Message Printing
+// ============================================================================
+
+/**
+ * @brief Print a header/title with decorative border
+ * @param title The title text
+ *
+ * Example output:
+ * ╔══════════════════════════════════════════════════════════════════════════╗
+ * ║                        PACS System Sample Application                     ║
+ * ╚══════════════════════════════════════════════════════════════════════════╝
+ */
+void print_header(std::string_view title);
+
+/**
+ * @brief Print a section header
+ * @param title The section title
+ *
+ * Example output:
+ * ─── Configuration ───────────────────────────────────────────────────────────
+ */
+void print_section(std::string_view title);
+
+/**
+ * @brief Print a success message
+ * @param message The message text
+ *
+ * Prints with green color and checkmark symbol.
+ */
+void print_success(std::string_view message);
+
+/**
+ * @brief Print an error message
+ * @param message The message text
+ *
+ * Prints with red color and X symbol.
+ */
+void print_error(std::string_view message);
+
+/**
+ * @brief Print a warning message
+ * @param message The message text
+ *
+ * Prints with yellow color and warning symbol.
+ */
+void print_warning(std::string_view message);
+
+/**
+ * @brief Print an informational message
+ * @param message The message text
+ *
+ * Prints with cyan color and info symbol.
+ */
+void print_info(std::string_view message);
+
+/**
+ * @brief Print a debug message
+ * @param message The message text
+ *
+ * Prints with dim/gray color.
+ */
+void print_debug(std::string_view message);
+
+// ============================================================================
+// DICOM Data Display
+// ============================================================================
+
+/**
+ * @brief Print a summary of a DICOM dataset
+ * @param ds The dataset to summarize
+ *
+ * Displays key patient, study, series, and image information
+ * in a formatted table.
+ */
+void print_dataset_summary(const core::dicom_dataset& ds);
+
+/**
+ * @brief Print all elements in a DICOM dataset
+ * @param ds The dataset to display
+ * @param max_value_length Maximum length for value display (truncated if longer)
+ *
+ * Displays all elements with tag, VR, and value.
+ */
+void print_dataset_elements(const core::dicom_dataset& ds,
+                            size_t max_value_length = 60);
+
+// ============================================================================
+// Box Drawing
+// ============================================================================
+
+/**
+ * @brief Print text in a decorative box
+ * @param lines Vector of text lines to display
+ *
+ * Example output:
+ * ┌─────────────────────────────────┐
+ * │ Line 1                          │
+ * │ Line 2                          │
+ * └─────────────────────────────────┘
+ */
+void print_box(const std::vector<std::string>& lines);
+
+/**
+ * @brief Print a key-value table
+ * @param title Table title
+ * @param rows Vector of {key, value} pairs
+ *
+ * Example output:
+ * ┌─ Patient Information ───────────┐
+ * │ Name:     DOE^JOHN              │
+ * │ ID:       PAT001                │
+ * │ Sex:      M                     │
+ * └─────────────────────────────────┘
+ */
+void print_table(std::string_view title,
+                 const std::vector<std::pair<std::string, std::string>>& rows);
+
+// ============================================================================
+// Progress Display
+// ============================================================================
+
+/**
+ * @brief Print a progress bar
+ * @param current Current value
+ * @param total Total value
+ * @param width Width of the progress bar in characters
+ * @param label Optional label to display
+ *
+ * Example output:
+ * Processing: [████████████░░░░░░░░] 60% (6/10)
+ */
+void print_progress(size_t current, size_t total, int width = 40,
+                    std::string_view label = "Progress");
+
+/**
+ * @brief Clear the current line (for updating progress)
+ */
+void clear_line();
+
+// ============================================================================
+// Formatting Utilities
+// ============================================================================
+
+/**
+ * @brief Format a byte size for human-readable display
+ * @param bytes Number of bytes
+ * @return Formatted string (e.g., "1.5 MB", "256 KB")
+ */
+[[nodiscard]] auto format_bytes(uint64_t bytes) -> std::string;
+
+/**
+ * @brief Format a duration in milliseconds
+ * @param milliseconds Duration in milliseconds
+ * @return Formatted string (e.g., "1.5s", "250ms")
+ */
+[[nodiscard]] auto format_duration(uint64_t milliseconds) -> std::string;
+
+/**
+ * @brief Center a string within a given width
+ * @param text The text to center
+ * @param width The total width
+ * @return Centered string with padding
+ */
+[[nodiscard]] auto center_text(std::string_view text, size_t width) -> std::string;
+
+/**
+ * @brief Truncate a string to a maximum length
+ * @param text The text to truncate
+ * @param max_length Maximum length
+ * @param suffix Suffix to add when truncated (default: "...")
+ * @return Truncated string
+ */
+[[nodiscard]] auto truncate(std::string_view text, size_t max_length,
+                            std::string_view suffix = "...") -> std::string;
+
+}  // namespace pacs::samples

--- a/samples/common/signal_handler.cpp
+++ b/samples/common/signal_handler.cpp
@@ -1,0 +1,100 @@
+/**
+ * @file signal_handler.cpp
+ * @brief Implementation of cross-platform signal handling
+ */
+
+#include "signal_handler.hpp"
+
+#include <iostream>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
+
+namespace pacs::samples {
+
+// ============================================================================
+// Static Member Definitions
+// ============================================================================
+
+std::atomic<bool> signal_handler::shutdown_requested_{false};
+signal_handler::shutdown_callback signal_handler::callback_;
+std::mutex signal_handler::mutex_;
+std::condition_variable signal_handler::cv_;
+std::atomic<bool> signal_handler::callback_invoked_{false};
+
+// ============================================================================
+// Signal Handler Implementation
+// ============================================================================
+
+void signal_handler::install(shutdown_callback callback) {
+    callback_ = std::move(callback);
+    shutdown_requested_.store(false, std::memory_order_release);
+    callback_invoked_.store(false, std::memory_order_release);
+
+#ifdef _WIN32
+    std::signal(SIGINT, handler);
+    std::signal(SIGBREAK, handler);
+#else
+    std::signal(SIGINT, handler);
+    std::signal(SIGTERM, handler);
+#endif
+}
+
+auto signal_handler::should_shutdown() noexcept -> bool {
+    return shutdown_requested_.load(std::memory_order_acquire);
+}
+
+void signal_handler::wait_for_shutdown() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    cv_.wait(lock, []() {
+        return shutdown_requested_.load(std::memory_order_acquire);
+    });
+}
+
+void signal_handler::request_shutdown() {
+    bool expected = false;
+    if (shutdown_requested_.compare_exchange_strong(expected, true,
+            std::memory_order_release, std::memory_order_relaxed)) {
+        // Invoke callback only once
+        if (callback_ && !callback_invoked_.exchange(true, std::memory_order_acq_rel)) {
+            callback_();
+        }
+        cv_.notify_all();
+    }
+}
+
+void signal_handler::reset() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    shutdown_requested_.store(false, std::memory_order_release);
+    callback_invoked_.store(false, std::memory_order_release);
+    callback_ = nullptr;
+}
+
+void signal_handler::handler(int /*signal*/) {
+    request_shutdown();
+}
+
+// ============================================================================
+// Scoped Signal Handler Implementation
+// ============================================================================
+
+scoped_signal_handler::scoped_signal_handler(signal_handler::shutdown_callback callback) {
+    signal_handler::install(std::move(callback));
+}
+
+scoped_signal_handler::~scoped_signal_handler() {
+    signal_handler::reset();
+}
+
+void scoped_signal_handler::wait() {
+    signal_handler::wait_for_shutdown();
+}
+
+auto scoped_signal_handler::should_shutdown() const noexcept -> bool {
+    return signal_handler::should_shutdown();
+}
+
+}  // namespace pacs::samples

--- a/samples/common/signal_handler.hpp
+++ b/samples/common/signal_handler.hpp
@@ -1,0 +1,169 @@
+/**
+ * @file signal_handler.hpp
+ * @brief Cross-platform signal handling for graceful shutdown
+ *
+ * This file provides signal handling utilities for developer samples,
+ * enabling graceful shutdown on SIGINT/SIGTERM across different platforms.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <csignal>
+#include <functional>
+#include <mutex>
+
+namespace pacs::samples {
+
+/**
+ * @brief Cross-platform signal handler for graceful shutdown
+ *
+ * Provides static methods for installing signal handlers and checking
+ * shutdown state. Supports SIGINT (Ctrl+C) and SIGTERM on POSIX systems,
+ * and SIGINT/SIGBREAK on Windows.
+ *
+ * Thread Safety: All methods are thread-safe.
+ *
+ * @example
+ * @code
+ * signal_handler::install([]() {
+ *     std::cout << "Shutting down...\n";
+ * });
+ *
+ * while (!signal_handler::should_shutdown()) {
+ *     // Main loop
+ * }
+ *
+ * // Or use wait_for_shutdown for blocking
+ * signal_handler::wait_for_shutdown();
+ * @endcode
+ */
+class signal_handler {
+public:
+    /// Callback type for shutdown notification
+    using shutdown_callback = std::function<void()>;
+
+    // ========================================================================
+    // Static Interface
+    // ========================================================================
+
+    /**
+     * @brief Install signal handlers with optional callback
+     * @param callback Function to call when shutdown signal is received
+     *
+     * Installs handlers for SIGINT and SIGTERM (POSIX) or SIGINT and
+     * SIGBREAK (Windows). The callback is invoked once when the first
+     * signal is received.
+     */
+    static void install(shutdown_callback callback = nullptr);
+
+    /**
+     * @brief Check if shutdown has been requested
+     * @return true if a shutdown signal has been received
+     */
+    [[nodiscard]] static auto should_shutdown() noexcept -> bool;
+
+    /**
+     * @brief Block until a shutdown signal is received
+     *
+     * This method blocks the calling thread until SIGINT/SIGTERM
+     * is received. Useful for main threads that need to wait for
+     * graceful shutdown.
+     */
+    static void wait_for_shutdown();
+
+    /**
+     * @brief Request shutdown programmatically
+     *
+     * Sets the shutdown flag and notifies waiting threads.
+     * Useful for triggering shutdown from application code.
+     */
+    static void request_shutdown();
+
+    /**
+     * @brief Reset the shutdown state
+     *
+     * Clears the shutdown flag. Useful for tests or when restarting
+     * a service within the same process.
+     */
+    static void reset();
+
+private:
+    /// Signal handler function for C signal API
+    static void handler(int signal);
+
+    /// Shutdown flag
+    static std::atomic<bool> shutdown_requested_;
+
+    /// Callback function
+    static shutdown_callback callback_;
+
+    /// Mutex for condition variable
+    static std::mutex mutex_;
+
+    /// Condition variable for wait_for_shutdown
+    static std::condition_variable cv_;
+
+    /// Flag to prevent multiple callback invocations
+    static std::atomic<bool> callback_invoked_;
+};
+
+// ============================================================================
+// RAII Wrapper
+// ============================================================================
+
+/**
+ * @brief RAII wrapper for automatic signal handler setup and cleanup
+ *
+ * Installs signal handlers on construction and provides convenient
+ * methods for checking and waiting for shutdown.
+ *
+ * @example
+ * @code
+ * int main() {
+ *     scoped_signal_handler signals([]() {
+ *         std::cout << "Received shutdown signal\n";
+ *     });
+ *
+ *     // Start services...
+ *
+ *     signals.wait();  // Block until shutdown
+ *
+ *     // Cleanup...
+ *     return 0;
+ * }
+ * @endcode
+ */
+class scoped_signal_handler {
+public:
+    /**
+     * @brief Construct and install signal handlers
+     * @param callback Optional callback for shutdown notification
+     */
+    explicit scoped_signal_handler(signal_handler::shutdown_callback callback = nullptr);
+
+    /**
+     * @brief Destructor - resets signal handler state
+     */
+    ~scoped_signal_handler();
+
+    // Non-copyable, non-movable
+    scoped_signal_handler(const scoped_signal_handler&) = delete;
+    auto operator=(const scoped_signal_handler&) -> scoped_signal_handler& = delete;
+    scoped_signal_handler(scoped_signal_handler&&) = delete;
+    auto operator=(scoped_signal_handler&&) -> scoped_signal_handler& = delete;
+
+    /**
+     * @brief Block until shutdown signal is received
+     */
+    void wait();
+
+    /**
+     * @brief Check if shutdown has been requested
+     * @return true if shutdown signal received
+     */
+    [[nodiscard]] auto should_shutdown() const noexcept -> bool;
+};
+
+}  // namespace pacs::samples

--- a/samples/common/test_data_generator.cpp
+++ b/samples/common/test_data_generator.cpp
@@ -1,0 +1,456 @@
+/**
+ * @file test_data_generator.cpp
+ * @brief Implementation of test data generation utilities
+ */
+
+#include "test_data_generator.hpp"
+
+#include <pacs/core/dicom_file.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/transfer_syntax.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <iomanip>
+#include <sstream>
+
+namespace pacs::samples {
+
+// ============================================================================
+// Static Member Definitions
+// ============================================================================
+
+std::atomic<uint64_t> test_data_generator::uid_counter_{0};
+
+// ============================================================================
+// SOP Class UIDs
+// ============================================================================
+
+namespace sop_class {
+constexpr std::string_view ct_image_storage = "1.2.840.10008.5.1.4.1.1.2";
+constexpr std::string_view mr_image_storage = "1.2.840.10008.5.1.4.1.1.4";
+constexpr std::string_view cr_image_storage = "1.2.840.10008.5.1.4.1.1.1";
+constexpr std::string_view dx_image_storage = "1.2.840.10008.5.1.4.1.1.1.1";
+}  // namespace sop_class
+
+// ============================================================================
+// UID Generation
+// ============================================================================
+
+auto test_data_generator::generate_uid(std::string_view root) -> std::string {
+    auto now = std::chrono::system_clock::now();
+    auto time = std::chrono::duration_cast<std::chrono::microseconds>(
+        now.time_since_epoch()).count();
+
+    auto counter = uid_counter_.fetch_add(1, std::memory_order_relaxed);
+
+    std::ostringstream oss;
+    oss << root << "." << time << "." << counter;
+    return oss.str();
+}
+
+// ============================================================================
+// Date/Time Utilities
+// ============================================================================
+
+auto test_data_generator::current_date() -> std::string {
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &time_t);
+#else
+    localtime_r(&time_t, &tm);
+#endif
+
+    std::ostringstream oss;
+    oss << std::setfill('0')
+        << std::setw(4) << (tm.tm_year + 1900)
+        << std::setw(2) << (tm.tm_mon + 1)
+        << std::setw(2) << tm.tm_mday;
+    return oss.str();
+}
+
+auto test_data_generator::current_time() -> std::string {
+    auto now = std::chrono::system_clock::now();
+    auto time_t = std::chrono::system_clock::to_time_t(now);
+    auto ms = std::chrono::duration_cast<std::chrono::microseconds>(
+        now.time_since_epoch()).count() % 1000000;
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &time_t);
+#else
+    localtime_r(&time_t, &tm);
+#endif
+
+    std::ostringstream oss;
+    oss << std::setfill('0')
+        << std::setw(2) << tm.tm_hour
+        << std::setw(2) << tm.tm_min
+        << std::setw(2) << tm.tm_sec
+        << "." << std::setw(6) << ms;
+    return oss.str();
+}
+
+// ============================================================================
+// Base Dataset Creation
+// ============================================================================
+
+auto test_data_generator::create_base_dataset(
+    const patient_info& patient,
+    const image_params& params) -> core::dicom_dataset {
+
+    using namespace core::tags;
+    using vr = encoding::vr_type;
+
+    core::dicom_dataset ds;
+
+    // Patient Module
+    ds.set_string(patient_name, vr::PN, patient.patient_name);
+    ds.set_string(patient_id, vr::LO, patient.patient_id);
+    ds.set_string(patient_birth_date, vr::DA, patient.birth_date);
+    ds.set_string(patient_sex, vr::CS, patient.sex);
+
+    // General Study Module
+    auto study_uid = generate_uid();
+    ds.set_string(study_instance_uid, vr::UI, study_uid);
+    ds.set_string(study_date, vr::DA, current_date());
+    ds.set_string(study_time, vr::TM, current_time());
+    ds.set_string(accession_number, vr::SH, "ACC" + patient.patient_id);
+    ds.set_string(study_id, vr::SH, "1");
+    ds.set_string(study_description, vr::LO, "Test Study");
+    ds.set_string(referring_physician_name, vr::PN, "REFERRING^PHYSICIAN");
+
+    // General Series Module
+    auto series_uid = generate_uid();
+    ds.set_string(series_instance_uid, vr::UI, series_uid);
+    ds.set_string(modality, vr::CS, params.modality);
+    ds.set_numeric<int32_t>(series_number, vr::IS, 1);
+    ds.set_string(series_date, vr::DA, current_date());
+    ds.set_string(series_time, vr::TM, current_time());
+    ds.set_string(series_description, vr::LO, params.modality + " Series");
+
+    // Frame of Reference Module
+    ds.set_string(frame_of_reference_uid, vr::UI, generate_uid());
+
+    // General Equipment Module
+    ds.set_string(manufacturer, vr::LO, "PACS System");
+    ds.set_string(station_name, vr::SH, "SAMPLE_STATION");
+    ds.set_string(manufacturers_model_name, vr::LO, "Sample Generator");
+
+    // General Image Module
+    auto instance_uid = generate_uid();
+    ds.set_string(sop_instance_uid, vr::UI, instance_uid);
+    ds.set_numeric<int32_t>(instance_number, vr::IS, 1);
+    ds.set_string(content_date, vr::DA, current_date());
+    ds.set_string(content_time, vr::TM, current_time());
+    ds.set_string(image_type, vr::CS, "ORIGINAL\\PRIMARY\\AXIAL");
+
+    // Image Pixel Module
+    ds.set_numeric<uint16_t>(samples_per_pixel, vr::US, 1);
+    ds.set_string(photometric_interpretation, vr::CS, params.photometric);
+    ds.set_numeric<uint16_t>(rows, vr::US, params.rows);
+    ds.set_numeric<uint16_t>(columns, vr::US, params.columns);
+    ds.set_numeric<uint16_t>(bits_allocated, vr::US, params.bits_allocated);
+    ds.set_numeric<uint16_t>(bits_stored, vr::US, params.bits_stored);
+    ds.set_numeric<uint16_t>(high_bit, vr::US, params.high_bit);
+    ds.set_numeric<uint16_t>(pixel_representation, vr::US, params.pixel_representation);
+
+    // VOI LUT Module
+    ds.set_string(window_center, vr::DS, std::to_string(params.window_center));
+    ds.set_string(window_width, vr::DS, std::to_string(params.window_width));
+
+    return ds;
+}
+
+// ============================================================================
+// Pixel Data Generation
+// ============================================================================
+
+auto test_data_generator::generate_pixel_data(
+    uint16_t row_count,
+    uint16_t col_count,
+    uint16_t bits_alloc) -> std::vector<uint8_t> {
+
+    size_t bytes_per_pixel = bits_alloc / 8;
+    size_t total_pixels = static_cast<size_t>(row_count) * col_count;
+    std::vector<uint8_t> data(total_pixels * bytes_per_pixel);
+
+    // Generate a simple gradient pattern
+    uint16_t max_value = static_cast<uint16_t>((1 << (bits_alloc > 16 ? 16 : bits_alloc)) - 1);
+
+    for (uint16_t y = 0; y < row_count; ++y) {
+        for (uint16_t x = 0; x < col_count; ++x) {
+            size_t idx = (static_cast<size_t>(y) * col_count + x) * bytes_per_pixel;
+
+            // Create a circular gradient pattern
+            double cx = col_count / 2.0;
+            double cy = row_count / 2.0;
+            double dx = x - cx;
+            double dy = y - cy;
+            double dist = std::sqrt(dx * dx + dy * dy);
+            double max_dist = std::sqrt(cx * cx + cy * cy);
+            double normalized = 1.0 - (dist / max_dist);
+
+            uint16_t value = static_cast<uint16_t>(normalized * max_value * 0.8);
+
+            // Store as little-endian
+            data[idx] = static_cast<uint8_t>(value & 0xFF);
+            if (bytes_per_pixel > 1) {
+                data[idx + 1] = static_cast<uint8_t>((value >> 8) & 0xFF);
+            }
+        }
+    }
+
+    return data;
+}
+
+// ============================================================================
+// CT Dataset Creation
+// ============================================================================
+
+auto test_data_generator::create_ct_dataset(
+    const patient_info& patient,
+    const image_params& params) -> core::dicom_dataset {
+
+    using namespace core::tags;
+    using vr = encoding::vr_type;
+
+    image_params ct_params = params;
+    ct_params.modality = "CT";
+    ct_params.photometric = "MONOCHROME2";
+    ct_params.window_center = 40.0;
+    ct_params.window_width = 400.0;
+
+    auto ds = create_base_dataset(patient, ct_params);
+
+    // SOP Class
+    ds.set_string(sop_class_uid, vr::UI, std::string{sop_class::ct_image_storage});
+
+    // CT-specific attributes
+    ds.set_string(rescale_intercept, vr::DS, "-1024");
+    ds.set_string(rescale_slope, vr::DS, "1");
+    ds.set_string(rescale_type, vr::LO, "HU");
+    ds.set_string(pixel_spacing, vr::DS, "0.5\\0.5");
+    ds.set_string(slice_location, vr::DS, "0.0");
+    ds.set_string(image_position_patient, vr::DS, "0.0\\0.0\\0.0");
+    ds.set_string(image_orientation_patient, vr::DS, "1.0\\0.0\\0.0\\0.0\\1.0\\0.0");
+
+    // Add pixel data
+    auto pixel_bytes = generate_pixel_data(ct_params.rows, ct_params.columns,
+                                           ct_params.bits_allocated);
+    ds.insert(core::dicom_element{pixel_data, vr::OW, pixel_bytes});
+
+    return ds;
+}
+
+// ============================================================================
+// MR Dataset Creation
+// ============================================================================
+
+auto test_data_generator::create_mr_dataset(
+    const patient_info& patient,
+    image_params params) -> core::dicom_dataset {
+
+    using namespace core::tags;
+    using vr = encoding::vr_type;
+
+    params.modality = "MR";
+    params.photometric = "MONOCHROME2";
+    params.window_center = 500.0;
+    params.window_width = 1000.0;
+
+    auto ds = create_base_dataset(patient, params);
+
+    // SOP Class
+    ds.set_string(sop_class_uid, vr::UI, std::string{sop_class::mr_image_storage});
+
+    // MR-specific attributes
+    ds.set_string(pixel_spacing, vr::DS, "1.0\\1.0");
+    ds.set_string(slice_location, vr::DS, "0.0");
+    ds.set_string(image_position_patient, vr::DS, "0.0\\0.0\\0.0");
+    ds.set_string(image_orientation_patient, vr::DS, "1.0\\0.0\\0.0\\0.0\\1.0\\0.0");
+
+    // Add pixel data
+    auto pixel_bytes = generate_pixel_data(params.rows, params.columns,
+                                           params.bits_allocated);
+    ds.insert(core::dicom_element{pixel_data, vr::OW, pixel_bytes});
+
+    return ds;
+}
+
+// ============================================================================
+// CR Dataset Creation
+// ============================================================================
+
+auto test_data_generator::create_cr_dataset(
+    const patient_info& patient,
+    image_params params) -> core::dicom_dataset {
+
+    using namespace core::tags;
+    using vr = encoding::vr_type;
+
+    params.modality = "CR";
+    params.photometric = "MONOCHROME2";
+    params.rows = 2048;
+    params.columns = 2048;
+    params.bits_allocated = 16;
+    params.bits_stored = 14;
+    params.high_bit = 13;
+    params.window_center = 8192.0;
+    params.window_width = 16384.0;
+
+    auto ds = create_base_dataset(patient, params);
+
+    // SOP Class
+    ds.set_string(sop_class_uid, vr::UI, std::string{sop_class::cr_image_storage});
+
+    // Add pixel data
+    auto pixel_bytes = generate_pixel_data(params.rows, params.columns,
+                                           params.bits_allocated);
+    ds.insert(core::dicom_element{pixel_data, vr::OW, pixel_bytes});
+
+    return ds;
+}
+
+// ============================================================================
+// DX Dataset Creation
+// ============================================================================
+
+auto test_data_generator::create_dx_dataset(
+    const patient_info& patient,
+    image_params params) -> core::dicom_dataset {
+
+    using namespace core::tags;
+    using vr = encoding::vr_type;
+
+    params.modality = "DX";
+    params.photometric = "MONOCHROME2";
+    params.rows = 3000;
+    params.columns = 3000;
+    params.bits_allocated = 16;
+    params.bits_stored = 14;
+    params.high_bit = 13;
+    params.window_center = 8192.0;
+    params.window_width = 16384.0;
+
+    auto ds = create_base_dataset(patient, params);
+
+    // SOP Class
+    ds.set_string(sop_class_uid, vr::UI, std::string{sop_class::dx_image_storage});
+
+    // DX-specific attributes
+    ds.set_string(pixel_spacing, vr::DS, "0.15\\0.15");
+    ds.set_string(image_orientation_patient, vr::DS, "1.0\\0.0\\0.0\\0.0\\1.0\\0.0");
+
+    // Add pixel data
+    auto pixel_bytes = generate_pixel_data(params.rows, params.columns,
+                                           params.bits_allocated);
+    ds.insert(core::dicom_element{pixel_data, vr::OW, pixel_bytes});
+
+    return ds;
+}
+
+// ============================================================================
+// Study Generation
+// ============================================================================
+
+auto test_data_generator::create_study(
+    const patient_info& patient,
+    const study_info& study,
+    int series_count,
+    int instances_per_series) -> std::vector<core::dicom_dataset> {
+
+    using namespace core::tags;
+    using vr = encoding::vr_type;
+
+    std::vector<core::dicom_dataset> datasets;
+    datasets.reserve(static_cast<size_t>(series_count * instances_per_series));
+
+    auto study_uid = study.study_uid.empty() ? generate_uid() : study.study_uid;
+    auto study_dt = study.study_date.empty() ? current_date() : study.study_date;
+    auto study_tm = study.study_time.empty() ? current_time() : study.study_time;
+
+    for (int series_idx = 0; series_idx < series_count; ++series_idx) {
+        auto series_uid = generate_uid();
+        auto frame_uid = generate_uid();
+
+        for (int instance_idx = 0; instance_idx < instances_per_series; ++instance_idx) {
+            auto ds = create_ct_dataset(patient);
+
+            // Override with study-level info
+            ds.set_string(study_instance_uid, vr::UI, study_uid);
+            ds.set_string(study_date, vr::DA, study_dt);
+            ds.set_string(study_time, vr::TM, study_tm);
+
+            if (!study.accession_number.empty()) {
+                ds.set_string(accession_number, vr::SH, study.accession_number);
+            }
+            if (!study.description.empty()) {
+                ds.set_string(study_description, vr::LO, study.description);
+            }
+            if (!study.referring_physician.empty()) {
+                ds.set_string(referring_physician_name, vr::PN, study.referring_physician);
+            }
+
+            // Series-level info
+            ds.set_string(series_instance_uid, vr::UI, series_uid);
+            ds.set_numeric<int32_t>(series_number, vr::IS, series_idx + 1);
+            ds.set_string(frame_of_reference_uid, vr::UI, frame_uid);
+
+            // Instance-level info
+            ds.set_string(sop_instance_uid, vr::UI, generate_uid());
+            ds.set_numeric<int32_t>(instance_number, vr::IS, instance_idx + 1);
+
+            // Slice location for 3D datasets
+            double slice_loc = static_cast<double>(instance_idx) * 5.0;
+            ds.set_string(slice_location, vr::DS, std::to_string(slice_loc));
+            ds.set_string(image_position_patient, vr::DS,
+                "0.0\\0.0\\" + std::to_string(slice_loc));
+
+            datasets.push_back(std::move(ds));
+        }
+    }
+
+    return datasets;
+}
+
+// ============================================================================
+// File Operations
+// ============================================================================
+
+void test_data_generator::save_to_directory(
+    const std::vector<core::dicom_dataset>& datasets,
+    const std::filesystem::path& directory) {
+
+    using namespace core::tags;
+    namespace fs = std::filesystem;
+
+    fs::create_directories(directory);
+
+    for (const auto& ds : datasets) {
+        auto pat_id = ds.get_string(patient_id, "UNKNOWN");
+        auto study_uid_str = ds.get_string(study_instance_uid, "UNKNOWN");
+        auto series_uid_str = ds.get_string(series_instance_uid, "UNKNOWN");
+        auto instance_uid_str = ds.get_string(sop_instance_uid, "UNKNOWN");
+
+        // Create hierarchical path
+        auto path = directory / pat_id / study_uid_str / series_uid_str;
+        fs::create_directories(path);
+
+        auto file_path = path / (instance_uid_str + ".dcm");
+
+        // Create DICOM file and save
+        auto file = core::dicom_file::create(
+            ds, encoding::transfer_syntax::explicit_vr_little_endian);
+        auto result = file.save(file_path);
+
+        if (!result.is_ok()) {
+            throw std::runtime_error("Failed to save DICOM file: " +
+                                     file_path.string());
+        }
+    }
+}
+
+}  // namespace pacs::samples

--- a/samples/common/test_data_generator.hpp
+++ b/samples/common/test_data_generator.hpp
@@ -1,0 +1,232 @@
+/**
+ * @file test_data_generator.hpp
+ * @brief Test data generation utilities for developer samples
+ *
+ * This file provides utilities for generating test DICOM datasets
+ * with realistic patient, study, and image data for sample applications.
+ */
+
+#pragma once
+
+#include <pacs/core/dicom_dataset.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::samples {
+
+// ============================================================================
+// Data Structures
+// ============================================================================
+
+/**
+ * @brief Patient information for test data generation
+ */
+struct patient_info {
+    std::string patient_id{"PAT001"};
+    std::string patient_name{"DOE^JOHN"};
+    std::string birth_date{"19800101"};
+    std::string sex{"M"};
+};
+
+/**
+ * @brief Study information for test data generation
+ */
+struct study_info {
+    std::string study_uid;
+    std::string study_date;
+    std::string study_time;
+    std::string accession_number;
+    std::string description;
+    std::string referring_physician;
+};
+
+/**
+ * @brief Image parameters for test data generation
+ */
+struct image_params {
+    uint16_t rows{512};
+    uint16_t columns{512};
+    uint16_t bits_allocated{16};
+    uint16_t bits_stored{12};
+    uint16_t high_bit{11};
+    uint16_t pixel_representation{0};  // 0 = unsigned, 1 = signed
+    std::string modality{"CT"};
+    std::string photometric{"MONOCHROME2"};
+    double window_center{40.0};
+    double window_width{400.0};
+};
+
+// ============================================================================
+// Test Data Generator
+// ============================================================================
+
+/**
+ * @brief Utility class for generating test DICOM datasets
+ *
+ * Provides static methods for creating realistic DICOM datasets
+ * for testing and sample applications. Supports various modalities
+ * including CT, MR, CR, and DX.
+ *
+ * Thread Safety: UID generation is thread-safe using atomic counters.
+ *
+ * @example
+ * @code
+ * // Generate a simple CT dataset
+ * auto ds = test_data_generator::create_ct_dataset();
+ *
+ * // Generate with custom patient info
+ * patient_info patient{"PAT123", "SMITH^JANE", "19900515", "F"};
+ * auto ds = test_data_generator::create_ct_dataset(patient);
+ *
+ * // Generate a complete study
+ * auto datasets = test_data_generator::create_study(
+ *     patient, study, 2, 10);  // 2 series, 10 instances each
+ *
+ * // Save to directory
+ * test_data_generator::save_to_directory(datasets, "./test_data");
+ * @endcode
+ */
+class test_data_generator {
+public:
+    // ========================================================================
+    // Single Dataset Generation
+    // ========================================================================
+
+    /**
+     * @brief Create a CT dataset with default or custom parameters
+     * @param patient Patient information (default if not provided)
+     * @param params Image parameters (default CT params if not provided)
+     * @return A valid DICOM dataset for CT Storage
+     */
+    [[nodiscard]] static auto create_ct_dataset(
+        const patient_info& patient = {},
+        const image_params& params = {}) -> core::dicom_dataset;
+
+    /**
+     * @brief Create an MR dataset with default or custom parameters
+     * @param patient Patient information
+     * @param params Image parameters (default MR params if not provided)
+     * @return A valid DICOM dataset for MR Storage
+     */
+    [[nodiscard]] static auto create_mr_dataset(
+        const patient_info& patient = {},
+        image_params params = {}) -> core::dicom_dataset;
+
+    /**
+     * @brief Create a CR (Computed Radiography) dataset
+     * @param patient Patient information
+     * @param params Image parameters (default CR params if not provided)
+     * @return A valid DICOM dataset for CR Storage
+     */
+    [[nodiscard]] static auto create_cr_dataset(
+        const patient_info& patient = {},
+        image_params params = {}) -> core::dicom_dataset;
+
+    /**
+     * @brief Create a DX (Digital X-Ray) dataset
+     * @param patient Patient information
+     * @param params Image parameters (default DX params if not provided)
+     * @return A valid DICOM dataset for DX Storage
+     */
+    [[nodiscard]] static auto create_dx_dataset(
+        const patient_info& patient = {},
+        image_params params = {}) -> core::dicom_dataset;
+
+    // ========================================================================
+    // Study Generation
+    // ========================================================================
+
+    /**
+     * @brief Generate a complete study with multiple series and instances
+     * @param patient Patient information
+     * @param study Study information
+     * @param series_count Number of series to generate
+     * @param instances_per_series Number of instances per series
+     * @return Vector of DICOM datasets comprising the study
+     */
+    [[nodiscard]] static auto create_study(
+        const patient_info& patient,
+        const study_info& study,
+        int series_count = 1,
+        int instances_per_series = 5) -> std::vector<core::dicom_dataset>;
+
+    // ========================================================================
+    // File Operations
+    // ========================================================================
+
+    /**
+     * @brief Save datasets to a directory structure
+     * @param datasets The datasets to save
+     * @param directory Target directory path
+     *
+     * Creates a hierarchical directory structure:
+     * directory/PatientID/StudyUID/SeriesUID/InstanceUID.dcm
+     */
+    static void save_to_directory(
+        const std::vector<core::dicom_dataset>& datasets,
+        const std::filesystem::path& directory);
+
+    // ========================================================================
+    // UID Generation
+    // ========================================================================
+
+    /**
+     * @brief Generate a unique DICOM UID
+     * @param root UID root (default: pacs_system sample root)
+     * @return A unique UID string
+     *
+     * Generated UIDs follow the format: root.timestamp.counter
+     * Thread-safe using atomic counter.
+     */
+    [[nodiscard]] static auto generate_uid(
+        std::string_view root = "1.2.410.200001.1.1") -> std::string;
+
+    // ========================================================================
+    // Date/Time Utilities
+    // ========================================================================
+
+    /**
+     * @brief Get current date in DICOM format (YYYYMMDD)
+     * @return Current date string
+     */
+    [[nodiscard]] static auto current_date() -> std::string;
+
+    /**
+     * @brief Get current time in DICOM format (HHMMSS.FFFFFF)
+     * @return Current time string
+     */
+    [[nodiscard]] static auto current_time() -> std::string;
+
+private:
+    /**
+     * @brief Create a base dataset with common elements
+     * @param patient Patient information
+     * @param params Image parameters
+     * @return Dataset with common elements populated
+     */
+    [[nodiscard]] static auto create_base_dataset(
+        const patient_info& patient,
+        const image_params& params) -> core::dicom_dataset;
+
+    /**
+     * @brief Generate test pixel data
+     * @param rows Number of rows
+     * @param columns Number of columns
+     * @param bits_allocated Bits allocated per pixel
+     * @return Vector of pixel data bytes
+     */
+    [[nodiscard]] static auto generate_pixel_data(
+        uint16_t rows,
+        uint16_t columns,
+        uint16_t bits_allocated) -> std::vector<uint8_t>;
+
+    /// Atomic counter for UID generation
+    static std::atomic<uint64_t> uid_counter_;
+};
+
+}  // namespace pacs::samples


### PR DESCRIPTION
## Summary
- Add cross-platform signal handler for graceful shutdown support
- Implement test data generator for CT, MR, CR, DX DICOM datasets
- Add console utilities with ANSI color support and formatted output
- Create CMake integration with `PACS_BUILD_SAMPLES` option

Closes #591

## Test Plan
- [x] Build `pacs_samples_common` library with `cmake -DPACS_BUILD_SAMPLES=ON`
- [x] Verify library compiles without warnings
- [ ] Test signal handler on Linux/macOS/Windows
- [ ] Verify test data generator creates valid DICOM files