### PR TITLE
feat(samples): add Level 4 Mini PACS sample

### DIFF
--- a/samples/04_mini_pacs/CMakeLists.txt
+++ b/samples/04_mini_pacs/CMakeLists.txt
@@ -1,0 +1,69 @@
+# samples/04_mini_pacs/CMakeLists.txt
+# Level 4: Mini PACS - Complete DICOM server with all services
+#
+# This sample demonstrates integrating all DICOM services:
+# - Verification SCP (C-ECHO)
+# - Storage SCP (C-STORE)
+# - Query SCP (C-FIND)
+# - Retrieve SCP (C-MOVE/C-GET)
+# - Modality Worklist SCP (MWL)
+# - MPPS SCP
+
+cmake_minimum_required(VERSION 3.20)
+
+# Executable name
+set(SAMPLE_NAME mini_pacs)
+
+# Source files
+set(SAMPLE_SOURCES
+    main.cpp
+    mini_pacs.cpp
+)
+
+# Header files (for IDE visibility)
+set(SAMPLE_HEADERS
+    mini_pacs.hpp
+)
+
+# Create executable
+add_executable(${SAMPLE_NAME}
+    ${SAMPLE_SOURCES}
+    ${SAMPLE_HEADERS}
+)
+
+# Include directories
+target_include_directories(${SAMPLE_NAME} PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../common
+)
+
+# Link dependencies
+target_link_libraries(${SAMPLE_NAME} PRIVATE
+    pacs_core
+    pacs_encoding
+    pacs_network
+    pacs_services
+    pacs_storage
+    pacs_samples_common
+)
+
+# C++ standard
+target_compile_features(${SAMPLE_NAME} PRIVATE cxx_std_20)
+
+# Compiler warnings
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|GNU")
+    target_compile_options(${SAMPLE_NAME} PRIVATE
+        -Wall
+        -Wextra
+        -Wpedantic
+    )
+elseif(MSVC)
+    target_compile_options(${SAMPLE_NAME} PRIVATE
+        /W4
+    )
+endif()
+
+# Set output directory
+set_target_properties(${SAMPLE_NAME} PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/samples"
+)

--- a/samples/04_mini_pacs/README.md
+++ b/samples/04_mini_pacs/README.md
@@ -1,0 +1,400 @@
+# Level 4: Mini PACS
+
+A complete Mini PACS implementation integrating all core DICOM services into a single server.
+
+## Learning Objectives
+
+After completing this sample, you will understand:
+
+1. **Service Integration** - How to combine multiple SCPs in one DICOM server
+2. **Query/Retrieve (Q/R)** - C-FIND and C-MOVE/C-GET operations
+3. **Modality Worklist (MWL)** - Scheduled procedure queries
+4. **MPPS** - Modality Performed Procedure Step tracking
+5. **Class-Based Design** - Encapsulating PACS functionality in a reusable class
+
+## Prerequisites
+
+- Completed Level 1-3 samples
+- Understanding of DICOM networking (associations, DIMSE)
+- Familiarity with C-STORE and C-ECHO operations
+- DCMTK tools for testing (optional but recommended)
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        Mini PACS                            │
+│                                                             │
+│  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐         │
+│  │  Storage    │  │   Index     │  │   Server    │         │
+│  │  Backend    │  │  Database   │  │   Config    │         │
+│  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘         │
+│         │                │                │                │
+│  ┌──────▼────────────────▼────────────────▼──────┐         │
+│  │                DICOM Server                    │         │
+│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐          │         │
+│  │  │Verify   │ │Storage  │ │Query    │          │         │
+│  │  │SCP      │ │SCP      │ │SCP      │          │         │
+│  │  └─────────┘ └─────────┘ └─────────┘          │         │
+│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐          │         │
+│  │  │Retrieve │ │Worklist │ │MPPS     │          │         │
+│  │  │SCP      │ │SCP      │ │SCP      │          │         │
+│  │  └─────────┘ └─────────┘ └─────────┘          │         │
+│  └────────────────────────────────────────────────┘         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Services Overview
+
+| Service | Operation | Purpose |
+|---------|-----------|---------|
+| Verification SCP | C-ECHO | Network connectivity testing |
+| Storage SCP | C-STORE | Receive and archive DICOM images |
+| Query SCP | C-FIND | Search at Patient/Study/Series/Image levels |
+| Retrieve SCP | C-MOVE/C-GET | Send images to destinations |
+| Worklist SCP | MWL C-FIND | Return scheduled procedures to modalities |
+| MPPS SCP | N-CREATE/N-SET | Track procedure progress |
+
+## Build
+
+```bash
+# From repository root
+cmake -B build -DPACS_BUILD_SAMPLES=ON
+cmake --build build --target mini_pacs
+```
+
+## Run
+
+```bash
+# Default port 11112
+./build/samples/mini_pacs
+
+# Custom port
+./build/samples/mini_pacs 4242
+```
+
+## Test Commands
+
+### 1. Connectivity Test (C-ECHO)
+
+```bash
+echoscu -v -aec MINI_PACS localhost 11112
+```
+
+Expected output: `Received Echo Response (Success)`
+
+### 2. Store Images (C-STORE)
+
+```bash
+# Store a single image
+storescu -v -aec MINI_PACS localhost 11112 image.dcm
+
+# Store multiple images
+storescu -v -aec MINI_PACS localhost 11112 *.dcm
+
+# Store from Level 1 sample output
+storescu -v -aec MINI_PACS localhost 11112 hello_dicom_output.dcm
+```
+
+### 3. Query at Patient Level (C-FIND)
+
+```bash
+# Find all patients
+findscu -v -aec MINI_PACS -P \
+    -k QueryRetrieveLevel=PATIENT \
+    -k PatientName="*" \
+    -k PatientID \
+    localhost 11112
+
+# Find specific patient
+findscu -v -aec MINI_PACS -P \
+    -k QueryRetrieveLevel=PATIENT \
+    -k PatientName="DOE*" \
+    localhost 11112
+```
+
+### 4. Query at Study Level (C-FIND)
+
+```bash
+# Find all studies for a patient
+findscu -v -aec MINI_PACS -S \
+    -k QueryRetrieveLevel=STUDY \
+    -k PatientID="PAT001" \
+    -k StudyDate \
+    -k StudyDescription \
+    -k AccessionNumber \
+    localhost 11112
+
+# Find studies by date range
+findscu -v -aec MINI_PACS -S \
+    -k QueryRetrieveLevel=STUDY \
+    -k StudyDate="20240101-20241231" \
+    localhost 11112
+```
+
+### 5. Query at Series Level (C-FIND)
+
+```bash
+findscu -v -aec MINI_PACS -S \
+    -k QueryRetrieveLevel=SERIES \
+    -k StudyInstanceUID="1.2.3..." \
+    -k Modality \
+    -k SeriesDescription \
+    localhost 11112
+```
+
+### 6. Query Worklist (MWL C-FIND)
+
+```bash
+# Query all scheduled procedures
+findscu -v -aec MINI_PACS -W \
+    -k ScheduledProcedureStepStartDate="" \
+    -k Modality="" \
+    -k PatientName="" \
+    -k PatientID="" \
+    localhost 11112
+
+# Query CT procedures only
+findscu -v -aec MINI_PACS -W \
+    -k Modality="CT" \
+    -k PatientName="" \
+    localhost 11112
+```
+
+### 7. Retrieve Study (C-MOVE)
+
+```bash
+# Start a receiver first
+storescp -v -aet DEST_SCP 11113
+
+# Then retrieve (in another terminal)
+movescu -v -aec MINI_PACS -aem DEST_SCP \
+    -k QueryRetrieveLevel=STUDY \
+    -k StudyInstanceUID="1.2.3..." \
+    localhost 11112
+```
+
+## Code Walkthrough
+
+### Configuration
+
+```cpp
+mini_pacs_config config;
+config.ae_title = "MINI_PACS";      // Application Entity title
+config.port = 11112;                 // TCP port
+config.storage_path = "./pacs_data"; // File storage root
+config.enable_worklist = true;       // Enable MWL service
+config.enable_mpps = true;           // Enable MPPS service
+config.verbose_logging = true;       // Print operations to console
+```
+
+### Service Integration
+
+The `mini_pacs` class initializes all services in `initialize_services()`:
+
+```cpp
+void mini_pacs::initialize_services() {
+    // Verification SCP - Always enabled
+    verification_scp_ = std::make_shared<services::verification_scp>();
+
+    // Storage SCP - With custom handler
+    storage_scp_ = std::make_shared<services::storage_scp>();
+    storage_scp_->set_handler([this](auto& ds, auto& ae, auto& sop_class, auto& sop_uid) {
+        return handle_store(ds, ae, sop_class, sop_uid);
+    });
+
+    // Query SCP - C-FIND at all levels
+    query_scp_ = std::make_shared<services::query_scp>();
+    query_scp_->set_handler([this](auto level, auto& keys, auto& ae) {
+        return handle_query(level, keys, ae);
+    });
+
+    // ... more services
+}
+```
+
+### Query Handler Implementation
+
+```cpp
+std::vector<core::dicom_dataset> mini_pacs::handle_query(
+    services::query_level level,
+    const core::dicom_dataset& query_keys,
+    const std::string& calling_ae) {
+
+    std::vector<core::dicom_dataset> results;
+
+    switch (level) {
+        case services::query_level::patient:
+            // Query patient table
+            auto patients = index_db_->query_patients(...);
+            // Build response datasets
+            break;
+
+        case services::query_level::study:
+            // Query study table
+            break;
+
+        case services::query_level::series:
+            // Query series table
+            break;
+
+        case services::query_level::image:
+            // Query instance table
+            break;
+    }
+
+    return results;
+}
+```
+
+### Worklist Management
+
+```cpp
+// Add worklist items programmatically
+worklist_entry wl;
+wl.patient_id = "PAT001";
+wl.patient_name = "DOE^JOHN";
+wl.modality = "CT";
+wl.scheduled_date = "20240115";
+wl.procedure_description = "CT CHEST";
+pacs.add_worklist_item(wl);
+
+// Query handler returns matching items
+std::vector<core::dicom_dataset> handle_worklist_query(
+    const core::dicom_dataset& query_keys,
+    const std::string& calling_ae) {
+    // Filter worklist_items_ based on query_keys
+    // Return matching items as datasets
+}
+```
+
+## Query/Retrieve Information Model
+
+### Patient Root
+
+```
+PATIENT (0010,0020) PatientID
+  └─ STUDY (0020,000D) StudyInstanceUID
+       └─ SERIES (0020,000E) SeriesInstanceUID
+            └─ IMAGE (0008,0018) SOPInstanceUID
+```
+
+### Query Keys by Level
+
+| Level | Required Keys | Optional Keys |
+|-------|---------------|---------------|
+| PATIENT | PatientID or PatientName | BirthDate, Sex |
+| STUDY | PatientID | StudyDate, Modality, AccessionNumber |
+| SERIES | StudyInstanceUID | Modality, SeriesNumber |
+| IMAGE | SeriesInstanceUID | InstanceNumber |
+
+## MPPS Workflow
+
+```
+Modality                         PACS (MPPS SCP)
+   │                                  │
+   │  [Exam Started]                  │
+   │                                  │
+   │  N-CREATE-RQ                     │
+   │  Status: "IN PROGRESS"           │
+   │─────────────────────────────────►│
+   │                                  │
+   │  N-CREATE-RSP (Success)          │
+   │◄─────────────────────────────────│
+   │                                  │
+   │  [Exam Completed]                │
+   │                                  │
+   │  N-SET-RQ                        │
+   │  Status: "COMPLETED"             │
+   │─────────────────────────────────►│
+   │                                  │
+   │  N-SET-RSP (Success)             │
+   │◄─────────────────────────────────│
+```
+
+## Database Schema
+
+The Mini PACS uses SQLite for indexing. View the data:
+
+```bash
+# List patients
+sqlite3 ./pacs_data/index.db "SELECT * FROM patients;"
+
+# List studies
+sqlite3 ./pacs_data/index.db "SELECT * FROM studies;"
+
+# List series
+sqlite3 ./pacs_data/index.db "SELECT * FROM series;"
+
+# List instances
+sqlite3 ./pacs_data/index.db "SELECT * FROM instances;"
+
+# Count images by modality
+sqlite3 ./pacs_data/index.db \
+    "SELECT modality, COUNT(*) FROM series GROUP BY modality;"
+```
+
+## File Structure
+
+```
+samples/04_mini_pacs/
+├── CMakeLists.txt      # Build configuration
+├── mini_pacs.hpp       # Mini PACS class header
+├── mini_pacs.cpp       # Mini PACS implementation
+├── main.cpp            # Application entry point
+└── README.md           # This documentation
+```
+
+## Statistics
+
+The Mini PACS tracks operation statistics:
+
+```cpp
+const auto& stats = pacs.statistics();
+std::cout << "C-STORE: " << stats.c_store_count << "\n";
+std::cout << "C-FIND:  " << stats.c_find_count << "\n";
+std::cout << "C-MOVE:  " << stats.c_move_count << "\n";
+std::cout << "MWL:     " << stats.mwl_count << "\n";
+```
+
+## Troubleshooting
+
+### Connection Refused
+
+- Verify the server is running
+- Check the port number
+- Ensure no firewall is blocking
+
+### Association Rejected
+
+- Verify AE Title matches (case-sensitive)
+- Check the called AE in your command
+
+### Query Returns No Results
+
+- Verify images have been stored first
+- Check query key spelling
+- Use wildcards (`*`) for partial matching
+
+### C-MOVE Fails
+
+- Ensure destination AE is resolvable
+- Start a receiver (storescp) before moving
+
+## Next Steps
+
+Proceed to **Level 5: Production PACS** to learn:
+
+- TLS/SSL encryption for secure communication
+- Role-based access control (RBAC)
+- Anonymization/De-identification
+- REST API for web integration
+- Health monitoring and metrics
+- Event-driven architecture
+
+## References
+
+- [DICOM PS3.4 - Storage Service Class](https://dicom.nema.org/medical/dicom/current/output/html/part04.html#chapter_B)
+- [DICOM PS3.4 - Query/Retrieve Service Class](https://dicom.nema.org/medical/dicom/current/output/html/part04.html#chapter_C)
+- [DICOM PS3.4 - Modality Worklist](https://dicom.nema.org/medical/dicom/current/output/html/part04.html#chapter_K)
+- [DICOM PS3.4 - MPPS Service Class](https://dicom.nema.org/medical/dicom/current/output/html/part04.html#chapter_F)

--- a/samples/04_mini_pacs/main.cpp
+++ b/samples/04_mini_pacs/main.cpp
@@ -1,0 +1,318 @@
+/**
+ * @file main.cpp
+ * @brief Level 4 Sample: Mini PACS - Complete DICOM server with all services
+ *
+ * This sample demonstrates a complete Mini PACS implementation integrating:
+ * - Verification SCP (C-ECHO) for connectivity testing
+ * - Storage SCP (C-STORE) for receiving images from modalities
+ * - Query SCP (C-FIND) at Patient/Study/Series/Image levels
+ * - Retrieve SCP (C-MOVE/C-GET) for image retrieval
+ * - Modality Worklist SCP (MWL C-FIND) for scheduled procedures
+ * - MPPS SCP (N-CREATE/N-SET) for procedure tracking
+ *
+ * After completing this sample, you will understand:
+ * 1. Service Integration - Combining multiple SCPs in one server
+ * 2. Query/Retrieve (Q/R) - C-FIND and C-MOVE operations
+ * 3. Modality Worklist - Scheduled procedure management
+ * 4. MPPS - Modality Performed Procedure Step tracking
+ * 5. Class-Based Design - Encapsulating PACS functionality
+ *
+ * @see DICOM PS3.4 - Storage, Query/Retrieve, Worklist, MPPS Service Classes
+ */
+
+#include "mini_pacs.hpp"
+#include "console_utils.hpp"
+#include "signal_handler.hpp"
+
+#include <iostream>
+#include <string>
+
+using namespace pacs::samples;
+
+namespace {
+
+/**
+ * @brief Generate a unique UID for worklist items
+ */
+std::string generate_uid() {
+    static int counter = 0;
+    auto now = std::chrono::system_clock::now();
+    auto epoch = now.time_since_epoch();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(epoch).count();
+    return "1.2.410.200001.4." + std::to_string(ms) + "." + std::to_string(++counter);
+}
+
+/**
+ * @brief Get current date in YYYYMMDD format
+ */
+std::string current_date() {
+    auto now = std::chrono::system_clock::now();
+    auto time = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_time{};
+    localtime_r(&time, &tm_time);
+
+    char buffer[16];
+    std::strftime(buffer, sizeof(buffer), "%Y%m%d", &tm_time);
+    return buffer;
+}
+
+/**
+ * @brief Add sample worklist items for testing
+ */
+void add_sample_worklist_items(mini_pacs& pacs) {
+    // Sample patient 1 - CT scan
+    worklist_entry wl1;
+    wl1.patient_id = "PAT001";
+    wl1.patient_name = "DOE^JOHN";
+    wl1.patient_birth_date = "19800115";
+    wl1.patient_sex = "M";
+    wl1.study_uid = generate_uid();
+    wl1.accession_number = "ACC001";
+    wl1.modality = "CT";
+    wl1.scheduled_station_ae = pacs.config().ae_title;
+    wl1.scheduled_date = current_date();
+    wl1.scheduled_time = "100000";
+    wl1.step_id = "STEP001";
+    wl1.procedure_description = "CT CHEST WITH CONTRAST";
+    wl1.referring_physician = "SMITH^JANE^MD";
+    pacs.add_worklist_item(wl1);
+
+    // Sample patient 2 - MRI scan
+    worklist_entry wl2;
+    wl2.patient_id = "PAT002";
+    wl2.patient_name = "SMITH^MARY";
+    wl2.patient_birth_date = "19751220";
+    wl2.patient_sex = "F";
+    wl2.study_uid = generate_uid();
+    wl2.accession_number = "ACC002";
+    wl2.modality = "MR";
+    wl2.scheduled_station_ae = pacs.config().ae_title;
+    wl2.scheduled_date = current_date();
+    wl2.scheduled_time = "110000";
+    wl2.step_id = "STEP002";
+    wl2.procedure_description = "MRI BRAIN WITHOUT CONTRAST";
+    wl2.referring_physician = "JONES^ROBERT^MD";
+    pacs.add_worklist_item(wl2);
+
+    // Sample patient 3 - X-ray
+    worklist_entry wl3;
+    wl3.patient_id = "PAT003";
+    wl3.patient_name = "WILSON^DAVID";
+    wl3.patient_birth_date = "19900310";
+    wl3.patient_sex = "M";
+    wl3.study_uid = generate_uid();
+    wl3.accession_number = "ACC003";
+    wl3.modality = "CR";
+    wl3.scheduled_station_ae = pacs.config().ae_title;
+    wl3.scheduled_date = current_date();
+    wl3.scheduled_time = "140000";
+    wl3.step_id = "STEP003";
+    wl3.procedure_description = "CHEST X-RAY PA AND LATERAL";
+    wl3.referring_physician = "BROWN^LISA^MD";
+    pacs.add_worklist_item(wl3);
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    print_header("Mini PACS - Level 4 Sample");
+
+    // ==========================================================================
+    // Part 1: Configuration
+    // ==========================================================================
+    // The Mini PACS integrates all core DICOM services:
+    // - Verification: Network connectivity testing (C-ECHO)
+    // - Storage: Image reception and archiving (C-STORE)
+    // - Query: Searching for patients/studies/series/images (C-FIND)
+    // - Retrieve: Sending images to destinations (C-MOVE/C-GET)
+    // - Worklist: Providing scheduled procedures to modalities (MWL)
+    // - MPPS: Tracking procedure progress from modalities
+
+    print_section("Part 1: Configuration");
+
+    std::cout << "Mini PACS provides a complete DICOM server with:\n";
+    std::cout << "  - Verification SCP:  C-ECHO for connectivity\n";
+    std::cout << "  - Storage SCP:       C-STORE for image reception\n";
+    std::cout << "  - Query SCP:         C-FIND at all levels\n";
+    std::cout << "  - Retrieve SCP:      C-MOVE/C-GET for retrieval\n";
+    std::cout << "  - Worklist SCP:      MWL for scheduled procedures\n";
+    std::cout << "  - MPPS SCP:          N-CREATE/N-SET for tracking\n\n";
+
+    // Parse command line arguments
+    mini_pacs_config config;
+    config.ae_title = "MINI_PACS";
+    config.port = argc > 1 ? static_cast<uint16_t>(std::stoi(argv[1])) : 11112;
+    config.storage_path = "./pacs_data";
+    config.max_associations = 50;
+    config.enable_worklist = true;
+    config.enable_mpps = true;
+    config.verbose_logging = true;
+
+    print_table("Mini PACS Configuration", {
+        {"AE Title", config.ae_title},
+        {"Port", std::to_string(config.port)},
+        {"Storage Path", config.storage_path.string()},
+        {"Max Associations", std::to_string(config.max_associations)},
+        {"Worklist Enabled", config.enable_worklist ? "Yes" : "No"},
+        {"MPPS Enabled", config.enable_mpps ? "Yes" : "No"}
+    });
+
+    print_success("Part 1 complete - Configuration ready!");
+
+    // ==========================================================================
+    // Part 2: Create and Start PACS
+    // ==========================================================================
+    // The mini_pacs class encapsulates all services and manages:
+    // - File storage with hierarchical organization
+    // - SQLite index database for fast queries
+    // - All SCP services with proper handler registration
+    // - Event handlers for association lifecycle
+
+    print_section("Part 2: Create and Start PACS");
+
+    mini_pacs pacs(config);
+
+    // Add sample worklist items for testing
+    add_sample_worklist_items(pacs);
+
+    std::cout << "Added " << pacs.get_worklist_items().size()
+              << " sample worklist items for MWL testing.\n\n";
+
+    if (!pacs.start()) {
+        print_error("Failed to start Mini PACS");
+        return 1;
+    }
+
+    print_success("Part 2 complete - Mini PACS started!");
+
+    // ==========================================================================
+    // Part 3: Display Service Information
+    // ==========================================================================
+
+    print_section("Part 3: Running Server");
+
+    std::cout << "\n";
+    std::cout << "╔══════════════════════════════════════════════════════════════╗\n";
+    std::cout << "║                   Mini PACS Server Started                   ║\n";
+    std::cout << "╠══════════════════════════════════════════════════════════════╣\n";
+    std::cout << "║  AE Title: " << config.ae_title;
+    for (size_t i = config.ae_title.length(); i < 48; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "║  Port:     " << config.port;
+    std::string port_str = std::to_string(config.port);
+    for (size_t i = port_str.length(); i < 48; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "╠══════════════════════════════════════════════════════════════╣\n";
+    std::cout << "║  Services:                                                   ║\n";
+    std::cout << "║    [x] Verification (C-ECHO)                                 ║\n";
+    std::cout << "║    [x] Storage (C-STORE)                                     ║\n";
+    std::cout << "║    [x] Query (C-FIND Patient/Study/Series/Image)             ║\n";
+    std::cout << "║    [x] Retrieve (C-MOVE/C-GET)                               ║\n";
+    std::cout << "║    [x] Modality Worklist (MWL C-FIND)                        ║\n";
+    std::cout << "║    [x] MPPS (N-CREATE/N-SET)                                 ║\n";
+    std::cout << "╠══════════════════════════════════════════════════════════════╣\n";
+    std::cout << "║  Test Commands:                                              ║\n";
+    std::cout << "║                                                              ║\n";
+    std::cout << "║  Connectivity:                                               ║\n";
+    std::cout << "║    echoscu -aec MINI_PACS localhost " << config.port;
+    for (size_t i = port_str.length(); i < 22; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "║                                                              ║\n";
+    std::cout << "║  Store Images:                                               ║\n";
+    std::cout << "║    storescu -aec MINI_PACS localhost " << config.port << " *.dcm";
+    for (size_t i = port_str.length(); i < 16; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "║                                                              ║\n";
+    std::cout << "║  Query Patient Level:                                        ║\n";
+    std::cout << "║    findscu -aec MINI_PACS -P \\                               ║\n";
+    std::cout << "║      -k QueryRetrieveLevel=PATIENT \\                         ║\n";
+    std::cout << "║      -k PatientName=\"*\" localhost " << config.port;
+    for (size_t i = port_str.length(); i < 27; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "║                                                              ║\n";
+    std::cout << "║  Query Study Level:                                          ║\n";
+    std::cout << "║    findscu -aec MINI_PACS -S \\                               ║\n";
+    std::cout << "║      -k QueryRetrieveLevel=STUDY \\                           ║\n";
+    std::cout << "║      -k StudyDate=\"\" localhost " << config.port;
+    for (size_t i = port_str.length(); i < 29; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "║                                                              ║\n";
+    std::cout << "║  Query Worklist:                                             ║\n";
+    std::cout << "║    findscu -aec MINI_PACS -W \\                               ║\n";
+    std::cout << "║      -k ScheduledProcedureStepStartDate=\"\" \\                 ║\n";
+    std::cout << "║      -k Modality=\"\" localhost " << config.port;
+    for (size_t i = port_str.length(); i < 30; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "║                                                              ║\n";
+    std::cout << "║  Retrieve Study:                                             ║\n";
+    std::cout << "║    movescu -aec MINI_PACS -aem DEST \\                        ║\n";
+    std::cout << "║      -k QueryRetrieveLevel=STUDY \\                           ║\n";
+    std::cout << "║      -k StudyInstanceUID=\"...\" localhost " << config.port;
+    for (size_t i = port_str.length(); i < 20; ++i) std::cout << " ";
+    std::cout << "║\n";
+    std::cout << "╠══════════════════════════════════════════════════════════════╣\n";
+    std::cout << "║  Worklist Items: 3 scheduled procedures                      ║\n";
+    std::cout << "║                                                              ║\n";
+    std::cout << "║  Press Ctrl+C to stop                                        ║\n";
+    std::cout << "╚══════════════════════════════════════════════════════════════╝\n\n";
+
+    // Install signal handler for graceful shutdown
+    scoped_signal_handler sig_handler([&pacs]() {
+        std::cout << "\n" << colors::yellow
+                  << "Shutdown signal received..."
+                  << colors::reset << "\n";
+        pacs.stop();
+    });
+
+    // Wait for shutdown
+    sig_handler.wait();
+
+    // ==========================================================================
+    // Part 4: Statistics and Cleanup
+    // ==========================================================================
+
+    print_section("Final Statistics");
+
+    const auto& stats = pacs.statistics();
+
+    print_table("Association Statistics", {
+        {"Total Associations", std::to_string(stats.associations_total.load())},
+        {"Active Associations", std::to_string(stats.associations_active.load())}
+    });
+
+    print_table("Operation Statistics", {
+        {"C-ECHO Count", std::to_string(stats.c_echo_count.load())},
+        {"C-STORE Count", std::to_string(stats.c_store_count.load())},
+        {"C-FIND Count", std::to_string(stats.c_find_count.load())},
+        {"C-MOVE Count", std::to_string(stats.c_move_count.load())},
+        {"C-GET Count", std::to_string(stats.c_get_count.load())},
+        {"MWL Queries", std::to_string(stats.mwl_count.load())},
+        {"MPPS N-CREATE", std::to_string(stats.mpps_create_count.load())},
+        {"MPPS N-SET", std::to_string(stats.mpps_set_count.load())}
+    });
+
+    print_table("Data Statistics", {
+        {"Bytes Received", std::to_string(stats.bytes_received.load()) + " bytes"}
+    });
+
+    // Summary
+    print_box({
+        "Congratulations! You have learned:",
+        "",
+        "1. Service Integration  - Combining multiple SCPs",
+        "2. Query/Retrieve       - C-FIND and C-MOVE operations",
+        "3. Modality Worklist    - Scheduled procedure queries",
+        "4. MPPS                 - Procedure progress tracking",
+        "5. Class-Based Design   - Encapsulating PACS functionality",
+        "",
+        "Query the database:",
+        "  sqlite3 ./pacs_data/index.db \"SELECT * FROM patients;\"",
+        "  sqlite3 ./pacs_data/index.db \"SELECT * FROM studies;\"",
+        "",
+        "Next step: Level 5 - Production PACS (TLS, RBAC, REST API)"
+    });
+
+    print_success("Mini PACS terminated successfully.");
+
+    return 0;
+}

--- a/samples/04_mini_pacs/mini_pacs.cpp
+++ b/samples/04_mini_pacs/mini_pacs.cpp
@@ -1,0 +1,679 @@
+/**
+ * @file mini_pacs.cpp
+ * @brief Implementation of Mini PACS class
+ */
+
+#include "mini_pacs.hpp"
+
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <chrono>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+
+namespace pacs::samples {
+
+namespace tags = pacs::core::tags;
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+mini_pacs::mini_pacs(const mini_pacs_config& config)
+    : config_(config) {
+    initialize_storage();
+    initialize_services();
+    configure_server();
+    setup_event_handlers();
+}
+
+mini_pacs::~mini_pacs() {
+    stop();
+}
+
+// =============================================================================
+// Lifecycle
+// =============================================================================
+
+bool mini_pacs::start() {
+    if (running_) {
+        return true;
+    }
+
+    auto result = server_->start();
+    if (result.is_err()) {
+        std::cerr << "Failed to start server: " << result.error().message << "\n";
+        return false;
+    }
+
+    running_ = true;
+    return true;
+}
+
+void mini_pacs::stop() {
+    if (!running_) {
+        return;
+    }
+
+    running_ = false;
+    if (server_) {
+        server_->stop();
+    }
+}
+
+void mini_pacs::wait() {
+    if (server_) {
+        server_->wait_for_shutdown();
+    }
+}
+
+bool mini_pacs::is_running() const noexcept {
+    return running_;
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+const mini_pacs_statistics& mini_pacs::statistics() const noexcept {
+    return stats_;
+}
+
+// =============================================================================
+// Worklist Management
+// =============================================================================
+
+void mini_pacs::add_worklist_item(const worklist_entry& item) {
+    std::lock_guard<std::mutex> lock(worklist_mutex_);
+    worklist_items_.push_back(item);
+}
+
+void mini_pacs::clear_worklist() {
+    std::lock_guard<std::mutex> lock(worklist_mutex_);
+    worklist_items_.clear();
+}
+
+std::vector<worklist_entry> mini_pacs::get_worklist_items() const {
+    std::lock_guard<std::mutex> lock(worklist_mutex_);
+    return worklist_items_;
+}
+
+// =============================================================================
+// Configuration Access
+// =============================================================================
+
+const mini_pacs_config& mini_pacs::config() const noexcept {
+    return config_;
+}
+
+// =============================================================================
+// Initialization
+// =============================================================================
+
+void mini_pacs::initialize_storage() {
+    // Create storage directories
+    std::filesystem::create_directories(config_.storage_path);
+
+    // Configure file storage
+    storage::file_storage_config fs_config;
+    fs_config.root_path = config_.storage_path;
+    fs_config.naming = storage::naming_scheme::uid_hierarchical;
+    fs_config.duplicate = storage::duplicate_policy::replace;
+    fs_config.create_directories = true;
+    fs_config.file_extension = ".dcm";
+
+    file_storage_ = std::make_shared<storage::file_storage>(fs_config);
+
+    // Initialize index database
+    auto db_path = config_.storage_path / "index.db";
+    auto db_result = storage::index_database::open(db_path.string());
+    if (db_result.is_err()) {
+        throw std::runtime_error("Failed to open index database: " +
+                                 db_result.error().message);
+    }
+    index_db_ = std::move(db_result.value());
+}
+
+void mini_pacs::initialize_services() {
+    // Verification SCP (C-ECHO)
+    verification_scp_ = std::make_shared<services::verification_scp>();
+
+    // Storage SCP (C-STORE)
+    services::storage_scp_config scp_config;
+    storage_scp_ = std::make_shared<services::storage_scp>(scp_config);
+    storage_scp_->set_handler(
+        [this](const auto& ds, const auto& ae, const auto& sop_class,
+               const auto& sop_instance) {
+            return handle_store(ds, ae, sop_class, sop_instance);
+        });
+
+    // Query SCP (C-FIND)
+    query_scp_ = std::make_shared<services::query_scp>();
+    query_scp_->set_handler(
+        [this](auto level, const auto& keys, const auto& ae) {
+            return handle_query(level, keys, ae);
+        });
+
+    // Retrieve SCP (C-MOVE/C-GET)
+    retrieve_scp_ = std::make_shared<services::retrieve_scp>();
+    retrieve_scp_->set_retrieve_handler(
+        [this](const auto& keys) { return handle_retrieve(keys); });
+    retrieve_scp_->set_destination_resolver(
+        [this](const auto& ae) { return resolve_destination(ae); });
+
+    // Worklist SCP (MWL C-FIND)
+    if (config_.enable_worklist) {
+        worklist_scp_ = std::make_shared<services::worklist_scp>();
+        worklist_scp_->set_handler(
+            [this](const auto& keys, const auto& ae) {
+                return handle_worklist_query(keys, ae);
+            });
+    }
+
+    // MPPS SCP (N-CREATE/N-SET)
+    if (config_.enable_mpps) {
+        mpps_scp_ = std::make_shared<services::mpps_scp>();
+        mpps_scp_->set_create_handler(
+            [this](const auto& inst) { return handle_mpps_create(inst); });
+        mpps_scp_->set_set_handler(
+            [this](const auto& uid, const auto& mods, auto status) {
+                return handle_mpps_set(uid, mods, status);
+            });
+    }
+}
+
+void mini_pacs::configure_server() {
+    network::server_config server_config;
+    server_config.ae_title = config_.ae_title;
+    server_config.port = config_.port;
+    server_config.max_associations = config_.max_associations;
+    server_config.idle_timeout = std::chrono::seconds(60);
+    server_config.max_pdu_size = 65536;
+    server_config.implementation_class_uid = "1.2.410.200001.1.4";
+    server_config.implementation_version_name = "MINI_PACS_4.0";
+
+    server_ = std::make_unique<network::dicom_server>(server_config);
+
+    // Register all services
+    server_->register_service(verification_scp_);
+    server_->register_service(storage_scp_);
+    server_->register_service(query_scp_);
+    server_->register_service(retrieve_scp_);
+
+    if (worklist_scp_) {
+        server_->register_service(worklist_scp_);
+    }
+    if (mpps_scp_) {
+        server_->register_service(mpps_scp_);
+    }
+}
+
+void mini_pacs::setup_event_handlers() {
+    server_->on_association_established(
+        [this](const network::association& assoc) {
+            stats_.associations_total++;
+            stats_.associations_active++;
+            if (config_.verbose_logging) {
+                std::cout << "[CONNECT] " << assoc.calling_ae()
+                          << " -> " << assoc.called_ae()
+                          << " (active: " << stats_.associations_active << ")\n";
+            }
+        });
+
+    server_->on_association_released(
+        [this](const network::association& assoc) {
+            stats_.associations_active--;
+            if (config_.verbose_logging) {
+                std::cout << "[RELEASE] " << assoc.calling_ae()
+                          << " (active: " << stats_.associations_active << ")\n";
+            }
+        });
+
+    server_->on_error(
+        [this](const std::string& msg) {
+            std::cerr << "[ERROR] " << msg << "\n";
+        });
+}
+
+// =============================================================================
+// Storage Handlers
+// =============================================================================
+
+services::storage_status mini_pacs::handle_store(
+    const core::dicom_dataset& dataset,
+    const std::string& calling_ae,
+    const std::string& /*sop_class_uid*/,
+    const std::string& sop_instance_uid) {
+
+    stats_.c_store_count++;
+
+    if (config_.verbose_logging) {
+        std::cout << "[C-STORE] From: " << calling_ae
+                  << " Patient: " << dataset.get_string(tags::patient_name)
+                  << " Modality: " << dataset.get_string(tags::modality) << "\n";
+    }
+
+    // Store to filesystem
+    auto store_result = file_storage_->store(dataset);
+    if (store_result.is_err()) {
+        std::cerr << "  Storage failed: " << store_result.error().message << "\n";
+        return services::storage_status::storage_error;
+    }
+
+    // Get stored file path and update index
+    auto file_path = file_storage_->get_file_path(sop_instance_uid);
+    if (!update_index(dataset, file_path)) {
+        return services::storage_status::storage_error;
+    }
+
+    stats_.bytes_received += std::filesystem::exists(file_path)
+        ? std::filesystem::file_size(file_path)
+        : 0;
+
+    return services::storage_status::success;
+}
+
+bool mini_pacs::update_index(
+    const core::dicom_dataset& ds,
+    const std::filesystem::path& file_path) {
+
+    // Patient
+    auto patient_result = index_db_->upsert_patient(
+        ds.get_string(tags::patient_id),
+        ds.get_string(tags::patient_name),
+        ds.get_string(tags::patient_birth_date),
+        ds.get_string(tags::patient_sex));
+
+    if (patient_result.is_err()) {
+        std::cerr << "Database error (patient): "
+                  << patient_result.error().message << "\n";
+        return false;
+    }
+    int64_t patient_pk = patient_result.value();
+
+    // Study
+    auto study_result = index_db_->upsert_study(
+        patient_pk,
+        ds.get_string(tags::study_instance_uid),
+        ds.get_string(tags::study_id),
+        ds.get_string(tags::study_date),
+        ds.get_string(tags::study_time),
+        ds.get_string(tags::accession_number),
+        ds.get_string(tags::referring_physician_name),
+        ds.get_string(tags::study_description));
+
+    if (study_result.is_err()) {
+        std::cerr << "Database error (study): "
+                  << study_result.error().message << "\n";
+        return false;
+    }
+    int64_t study_pk = study_result.value();
+
+    // Series
+    auto series_result = index_db_->upsert_series(
+        study_pk,
+        ds.get_string(tags::series_instance_uid),
+        ds.get_string(tags::modality),
+        ds.get_numeric<int>(tags::series_number),
+        ds.get_string(tags::series_description),
+        "",  // body_part_examined
+        ds.get_string(tags::station_name));
+
+    if (series_result.is_err()) {
+        std::cerr << "Database error (series): "
+                  << series_result.error().message << "\n";
+        return false;
+    }
+    int64_t series_pk = series_result.value();
+
+    // Instance
+    auto file_size = std::filesystem::exists(file_path)
+        ? static_cast<int64_t>(std::filesystem::file_size(file_path))
+        : 0;
+
+    auto instance_result = index_db_->upsert_instance(
+        series_pk,
+        ds.get_string(tags::sop_instance_uid),
+        ds.get_string(tags::sop_class_uid),
+        file_path.string(),
+        file_size,
+        ds.get_string(tags::transfer_syntax_uid),
+        ds.get_numeric<int>(tags::instance_number));
+
+    if (instance_result.is_err()) {
+        std::cerr << "Database error (instance): "
+                  << instance_result.error().message << "\n";
+        return false;
+    }
+
+    return true;
+}
+
+// =============================================================================
+// Query Handlers
+// =============================================================================
+
+std::vector<core::dicom_dataset> mini_pacs::handle_query(
+    services::query_level level,
+    const core::dicom_dataset& query_keys,
+    const std::string& /*calling_ae*/) {
+
+    stats_.c_find_count++;
+
+    std::vector<core::dicom_dataset> results;
+
+    switch (level) {
+        case services::query_level::patient: {
+            storage::patient_query pq;
+            auto pid = query_keys.get_string(tags::patient_id);
+            auto pname = query_keys.get_string(tags::patient_name);
+            if (!pid.empty()) pq.patient_id = pid;
+            if (!pname.empty()) pq.patient_name = pname;
+
+            auto patients = index_db_->search_patients(pq);
+
+            if (patients.is_ok()) {
+                for (const auto& p : patients.value()) {
+                    core::dicom_dataset ds;
+                    ds.set_string(tags::patient_id, encoding::vr_type::LO, p.patient_id);
+                    ds.set_string(tags::patient_name, encoding::vr_type::PN, p.patient_name);
+                    ds.set_string(tags::patient_birth_date, encoding::vr_type::DA, p.birth_date);
+                    ds.set_string(tags::patient_sex, encoding::vr_type::CS, p.sex);
+                    results.push_back(std::move(ds));
+                }
+            }
+            break;
+        }
+
+        case services::query_level::study: {
+            storage::study_query sq;
+            auto pid = query_keys.get_string(tags::patient_id);
+            auto study_uid = query_keys.get_string(tags::study_instance_uid);
+            auto study_date = query_keys.get_string(tags::study_date);
+            auto accession = query_keys.get_string(tags::accession_number);
+            if (!pid.empty()) sq.patient_id = pid;
+            if (!study_uid.empty()) sq.study_uid = study_uid;
+            if (!study_date.empty()) sq.study_date = study_date;
+            if (!accession.empty()) sq.accession_number = accession;
+
+            auto studies = index_db_->search_studies(sq);
+
+            if (studies.is_ok()) {
+                for (const auto& s : studies.value()) {
+                    core::dicom_dataset ds;
+                    ds.set_string(tags::study_instance_uid, encoding::vr_type::UI, s.study_uid);
+                    ds.set_string(tags::study_id, encoding::vr_type::SH, s.study_id);
+                    ds.set_string(tags::study_date, encoding::vr_type::DA, s.study_date);
+                    ds.set_string(tags::study_time, encoding::vr_type::TM, s.study_time);
+                    ds.set_string(tags::accession_number, encoding::vr_type::SH, s.accession_number);
+                    ds.set_string(tags::study_description, encoding::vr_type::LO, s.study_description);
+                    ds.set_string(tags::referring_physician_name, encoding::vr_type::PN, s.referring_physician);
+                    results.push_back(std::move(ds));
+                }
+            }
+            break;
+        }
+
+        case services::query_level::series: {
+            storage::series_query sq;
+            auto study_uid = query_keys.get_string(tags::study_instance_uid);
+            auto series_uid = query_keys.get_string(tags::series_instance_uid);
+            auto modality = query_keys.get_string(tags::modality);
+            if (!study_uid.empty()) sq.study_uid = study_uid;
+            if (!series_uid.empty()) sq.series_uid = series_uid;
+            if (!modality.empty()) sq.modality = modality;
+
+            auto series = index_db_->search_series(sq);
+
+            if (series.is_ok()) {
+                for (const auto& ser : series.value()) {
+                    core::dicom_dataset ds;
+                    ds.set_string(tags::series_instance_uid, encoding::vr_type::UI, ser.series_uid);
+                    ds.set_string(tags::modality, encoding::vr_type::CS, ser.modality);
+                    if (ser.series_number.has_value()) {
+                        ds.set_numeric(tags::series_number, encoding::vr_type::IS, ser.series_number.value());
+                    }
+                    ds.set_string(tags::series_description, encoding::vr_type::LO, ser.series_description);
+                    ds.set_string(tags::station_name, encoding::vr_type::SH, ser.station_name);
+                    results.push_back(std::move(ds));
+                }
+            }
+            break;
+        }
+
+        case services::query_level::image: {
+            storage::instance_query iq;
+            auto series_uid = query_keys.get_string(tags::series_instance_uid);
+            auto sop_uid = query_keys.get_string(tags::sop_instance_uid);
+            if (!series_uid.empty()) iq.series_uid = series_uid;
+            if (!sop_uid.empty()) iq.sop_uid = sop_uid;
+
+            auto instances = index_db_->search_instances(iq);
+
+            if (instances.is_ok()) {
+                for (const auto& inst : instances.value()) {
+                    core::dicom_dataset ds;
+                    ds.set_string(tags::sop_instance_uid, encoding::vr_type::UI, inst.sop_uid);
+                    ds.set_string(tags::sop_class_uid, encoding::vr_type::UI, inst.sop_class_uid);
+                    if (inst.instance_number.has_value()) {
+                        ds.set_numeric(tags::instance_number, encoding::vr_type::IS, inst.instance_number.value());
+                    }
+                    results.push_back(std::move(ds));
+                }
+            }
+            break;
+        }
+    }
+
+    if (config_.verbose_logging) {
+        std::cout << "[C-FIND] Level: " << to_string(level)
+                  << " Results: " << results.size() << "\n";
+    }
+
+    return results;
+}
+
+// =============================================================================
+// Retrieve Handlers
+// =============================================================================
+
+std::vector<core::dicom_file> mini_pacs::handle_retrieve(
+    const core::dicom_dataset& query_keys) {
+
+    std::vector<core::dicom_file> files;
+
+    // Determine query level from keys
+    auto study_uid = query_keys.get_string(tags::study_instance_uid);
+    auto series_uid = query_keys.get_string(tags::series_instance_uid);
+    auto sop_uid = query_keys.get_string(tags::sop_instance_uid);
+
+    std::vector<storage::instance_record> instances;
+
+    if (!sop_uid.empty()) {
+        // Instance level retrieve
+        storage::instance_query iq;
+        iq.sop_uid = sop_uid;
+        auto result = index_db_->search_instances(iq);
+        if (result.is_ok()) {
+            instances = result.value();
+        }
+    } else if (!series_uid.empty()) {
+        // Series level retrieve
+        storage::instance_query iq;
+        iq.series_uid = series_uid;
+        auto result = index_db_->search_instances(iq);
+        if (result.is_ok()) {
+            instances = result.value();
+        }
+    } else if (!study_uid.empty()) {
+        // Study level retrieve - get all series first
+        storage::series_query sq;
+        sq.study_uid = study_uid;
+        auto series_result = index_db_->search_series(sq);
+        if (series_result.is_ok()) {
+            for (const auto& ser : series_result.value()) {
+                storage::instance_query iq;
+                iq.series_uid = ser.series_uid;
+                auto inst_result = index_db_->search_instances(iq);
+                if (inst_result.is_ok()) {
+                    for (const auto& inst : inst_result.value()) {
+                        instances.push_back(inst);
+                    }
+                }
+            }
+        }
+    }
+
+    // Load files from disk
+    for (const auto& inst : instances) {
+        auto file_result = core::dicom_file::open(inst.file_path);
+        if (file_result.is_ok()) {
+            files.push_back(std::move(file_result.value()));
+        }
+    }
+
+    stats_.c_move_count++;
+
+    if (config_.verbose_logging) {
+        std::cout << "[C-MOVE/C-GET] Files: " << files.size() << "\n";
+    }
+
+    return files;
+}
+
+std::optional<std::pair<std::string, uint16_t>> mini_pacs::resolve_destination(
+    const std::string& ae_title) {
+    // Simple in-memory AE resolution
+    // In a production system, this would query a configuration database
+    if (ae_title == config_.ae_title) {
+        return std::make_pair("localhost", config_.port);
+    }
+    // Return nullopt for unknown destinations
+    return std::nullopt;
+}
+
+// =============================================================================
+// Worklist Handlers
+// =============================================================================
+
+std::vector<core::dicom_dataset> mini_pacs::handle_worklist_query(
+    const core::dicom_dataset& query_keys,
+    const std::string& /*calling_ae*/) {
+
+    stats_.mwl_count++;
+
+    std::vector<core::dicom_dataset> results;
+
+    // Extract filter criteria
+    auto filter_modality = query_keys.get_string(tags::modality);
+    auto filter_date = query_keys.get_string(tags::scheduled_procedure_step_start_date);
+    auto filter_patient_id = query_keys.get_string(tags::patient_id);
+
+    std::lock_guard<std::mutex> lock(worklist_mutex_);
+
+    for (const auto& item : worklist_items_) {
+        // Apply filters
+        if (!filter_modality.empty() && item.modality != filter_modality) {
+            continue;
+        }
+        if (!filter_date.empty() && item.scheduled_date != filter_date) {
+            continue;
+        }
+        if (!filter_patient_id.empty() && item.patient_id != filter_patient_id) {
+            continue;
+        }
+
+        results.push_back(create_worklist_response(item));
+    }
+
+    if (config_.verbose_logging) {
+        std::cout << "[MWL] Results: " << results.size() << "\n";
+    }
+
+    return results;
+}
+
+core::dicom_dataset mini_pacs::create_worklist_response(const worklist_entry& item) {
+    core::dicom_dataset ds;
+
+    // Patient level
+    ds.set_string(tags::patient_id, encoding::vr_type::LO, item.patient_id);
+    ds.set_string(tags::patient_name, encoding::vr_type::PN, item.patient_name);
+    ds.set_string(tags::patient_birth_date, encoding::vr_type::DA, item.patient_birth_date);
+    ds.set_string(tags::patient_sex, encoding::vr_type::CS, item.patient_sex);
+
+    // Study level
+    ds.set_string(tags::study_instance_uid, encoding::vr_type::UI, item.study_uid);
+    ds.set_string(tags::accession_number, encoding::vr_type::SH, item.accession_number);
+    ds.set_string(tags::referring_physician_name, encoding::vr_type::PN, item.referring_physician);
+
+    // Scheduled Procedure Step Sequence would be set here
+    // For simplicity, we set flat attributes
+    ds.set_string(tags::modality, encoding::vr_type::CS, item.modality);
+    ds.set_string(tags::scheduled_procedure_step_start_date, encoding::vr_type::DA, item.scheduled_date);
+    ds.set_string(tags::scheduled_procedure_step_start_time, encoding::vr_type::TM, item.scheduled_time);
+    ds.set_string(tags::scheduled_procedure_step_id, encoding::vr_type::SH, item.step_id);
+    ds.set_string(tags::scheduled_procedure_step_description, encoding::vr_type::LO, item.procedure_description);
+    ds.set_string(tags::scheduled_station_ae_title, encoding::vr_type::AE, item.scheduled_station_ae);
+
+    return ds;
+}
+
+// =============================================================================
+// MPPS Handlers
+// =============================================================================
+
+network::Result<std::monostate> mini_pacs::handle_mpps_create(
+    const services::mpps_instance& instance) {
+
+    stats_.mpps_create_count++;
+
+    mpps_entry entry;
+    entry.sop_instance_uid = instance.sop_instance_uid;
+    entry.status = "IN PROGRESS";
+    entry.station_ae = instance.station_ae;
+    entry.data = instance.data;
+
+    {
+        std::lock_guard<std::mutex> lock(mpps_mutex_);
+        mpps_instances_.push_back(std::move(entry));
+    }
+
+    if (config_.verbose_logging) {
+        std::cout << "[MPPS N-CREATE] UID: " << instance.sop_instance_uid
+                  << " Station: " << instance.station_ae << "\n";
+    }
+
+    return network::Result<std::monostate>::ok({});
+}
+
+network::Result<std::monostate> mini_pacs::handle_mpps_set(
+    const std::string& sop_instance_uid,
+    const core::dicom_dataset& /*modifications*/,
+    services::mpps_status new_status) {
+
+    stats_.mpps_set_count++;
+
+    std::lock_guard<std::mutex> lock(mpps_mutex_);
+
+    for (auto& entry : mpps_instances_) {
+        if (entry.sop_instance_uid == sop_instance_uid) {
+            entry.status = std::string(services::to_string(new_status));
+
+            if (config_.verbose_logging) {
+                std::cout << "[MPPS N-SET] UID: " << sop_instance_uid
+                          << " Status: " << entry.status << "\n";
+            }
+
+            return network::Result<std::monostate>::ok({});
+        }
+    }
+
+    return pacs::pacs_error<std::monostate>(
+        pacs::error_codes::instance_not_found,
+        "MPPS instance not found: " + sop_instance_uid);
+}
+
+}  // namespace pacs::samples

--- a/samples/04_mini_pacs/mini_pacs.hpp
+++ b/samples/04_mini_pacs/mini_pacs.hpp
@@ -1,0 +1,398 @@
+/**
+ * @file mini_pacs.hpp
+ * @brief Mini PACS class integrating all DICOM services
+ *
+ * This file provides a complete Mini PACS implementation that combines:
+ * - Verification SCP (C-ECHO)
+ * - Storage SCP (C-STORE)
+ * - Query SCP (C-FIND at Patient/Study/Series/Image levels)
+ * - Retrieve SCP (C-MOVE/C-GET)
+ * - Modality Worklist SCP (MWL C-FIND)
+ * - MPPS SCP (N-CREATE/N-SET)
+ *
+ * @see DICOM PS3.4 - Service Class Specifications
+ * @see DICOM PS3.7 - Message Exchange
+ */
+
+#pragma once
+
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_file.hpp>
+#include <pacs/network/dicom_server.hpp>
+#include <pacs/network/server_config.hpp>
+#include <pacs/services/verification_scp.hpp>
+#include <pacs/services/storage_scp.hpp>
+#include <pacs/services/query_scp.hpp>
+#include <pacs/services/retrieve_scp.hpp>
+#include <pacs/services/worklist_scp.hpp>
+#include <pacs/services/mpps_scp.hpp>
+#include <pacs/storage/file_storage.hpp>
+#include <pacs/storage/index_database.hpp>
+
+#include <atomic>
+#include <filesystem>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace pacs::samples {
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+/**
+ * @brief Configuration options for Mini PACS
+ *
+ * Provides all necessary settings for server operation including
+ * network configuration, storage paths, and feature toggles.
+ */
+struct mini_pacs_config {
+    /// Application Entity title (max 16 characters)
+    std::string ae_title{"MINI_PACS"};
+
+    /// TCP port to listen on
+    uint16_t port{11112};
+
+    /// Root path for DICOM file storage
+    std::filesystem::path storage_path{"./pacs_data"};
+
+    /// Maximum concurrent associations
+    size_t max_associations{50};
+
+    /// Enable Modality Worklist service
+    bool enable_worklist{true};
+
+    /// Enable MPPS service
+    bool enable_mpps{true};
+
+    /// Enable verbose logging
+    bool verbose_logging{false};
+};
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+/**
+ * @brief Runtime statistics for Mini PACS operations
+ *
+ * Thread-safe counters tracking service usage and performance.
+ */
+struct mini_pacs_statistics {
+    /// Total associations established since start
+    std::atomic<int> associations_total{0};
+
+    /// Currently active associations
+    std::atomic<int> associations_active{0};
+
+    /// C-ECHO operations processed
+    std::atomic<int> c_echo_count{0};
+
+    /// C-STORE operations processed
+    std::atomic<int> c_store_count{0};
+
+    /// C-FIND operations processed
+    std::atomic<int> c_find_count{0};
+
+    /// C-MOVE operations processed
+    std::atomic<int> c_move_count{0};
+
+    /// C-GET operations processed
+    std::atomic<int> c_get_count{0};
+
+    /// MWL queries processed
+    std::atomic<int> mwl_count{0};
+
+    /// MPPS N-CREATE processed
+    std::atomic<int> mpps_create_count{0};
+
+    /// MPPS N-SET processed
+    std::atomic<int> mpps_set_count{0};
+
+    /// Total bytes received
+    std::atomic<size_t> bytes_received{0};
+};
+
+// =============================================================================
+// Worklist Item
+// =============================================================================
+
+/**
+ * @brief Worklist item for MWL queries
+ *
+ * Represents a scheduled procedure step that can be queried by modalities.
+ */
+struct worklist_entry {
+    std::string patient_id;
+    std::string patient_name;
+    std::string patient_birth_date;
+    std::string patient_sex;
+    std::string study_uid;
+    std::string accession_number;
+    std::string modality;
+    std::string scheduled_station_ae;
+    std::string scheduled_date;
+    std::string scheduled_time;
+    std::string step_id;
+    std::string procedure_description;
+    std::string referring_physician;
+};
+
+// =============================================================================
+// MPPS Instance
+// =============================================================================
+
+/**
+ * @brief MPPS instance for tracking procedure progress
+ */
+struct mpps_entry {
+    std::string sop_instance_uid;
+    std::string status;  // "IN PROGRESS", "COMPLETED", "DISCONTINUED"
+    std::string station_ae;
+    core::dicom_dataset data;
+};
+
+// =============================================================================
+// Mini PACS Class
+// =============================================================================
+
+/**
+ * @brief Complete Mini PACS server integrating all DICOM services
+ *
+ * The mini_pacs class provides a fully functional PACS server with:
+ * - Image storage and retrieval
+ * - Patient/Study/Series level queries
+ * - Modality worklist management
+ * - MPPS procedure tracking
+ *
+ * ## Architecture
+ *
+ * ```
+ * ┌─────────────────────────────────────────────────────────┐
+ * │                      MiniPACS                           │
+ * │                                                         │
+ * │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐     │
+ * │  │  Storage    │  │   Index     │  │   Server    │     │
+ * │  │  Backend    │  │  Database   │  │   Config    │     │
+ * │  └──────┬──────┘  └──────┬──────┘  └──────┬──────┘     │
+ * │         │                │                │            │
+ * │  ┌──────▼────────────────▼────────────────▼──────┐     │
+ * │  │                DICOM Server                   │     │
+ * │  │  ┌─────────┐ ┌─────────┐ ┌─────────┐         │     │
+ * │  │  │Verify   │ │Storage  │ │Query    │         │     │
+ * │  │  │SCP      │ │SCP      │ │SCP      │         │     │
+ * │  │  └─────────┘ └─────────┘ └─────────┘         │     │
+ * │  │  ┌─────────┐ ┌─────────┐ ┌─────────┐         │     │
+ * │  │  │Retrieve │ │Worklist │ │MPPS     │         │     │
+ * │  │  │SCP      │ │SCP      │ │SCP      │         │     │
+ * │  │  └─────────┘ └─────────┘ └─────────┘         │     │
+ * │  └───────────────────────────────────────────────┘     │
+ * └─────────────────────────────────────────────────────────┘
+ * ```
+ *
+ * @example Basic Usage
+ * @code
+ * mini_pacs_config config;
+ * config.ae_title = "MY_PACS";
+ * config.port = 11112;
+ *
+ * mini_pacs pacs(config);
+ *
+ * if (!pacs.start()) {
+ *     std::cerr << "Failed to start PACS\n";
+ *     return 1;
+ * }
+ *
+ * pacs.wait();  // Block until shutdown
+ * @endcode
+ */
+class mini_pacs {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct Mini PACS with configuration
+     * @param config Configuration options
+     */
+    explicit mini_pacs(const mini_pacs_config& config);
+
+    /**
+     * @brief Destructor - ensures clean shutdown
+     */
+    ~mini_pacs();
+
+    // Non-copyable, non-movable
+    mini_pacs(const mini_pacs&) = delete;
+    mini_pacs& operator=(const mini_pacs&) = delete;
+    mini_pacs(mini_pacs&&) = delete;
+    mini_pacs& operator=(mini_pacs&&) = delete;
+
+    // =========================================================================
+    // Lifecycle
+    // =========================================================================
+
+    /**
+     * @brief Start the PACS server
+     * @return true if started successfully
+     */
+    [[nodiscard]] bool start();
+
+    /**
+     * @brief Stop the PACS server
+     */
+    void stop();
+
+    /**
+     * @brief Block until server shutdown
+     */
+    void wait();
+
+    /**
+     * @brief Check if server is running
+     * @return true if running
+     */
+    [[nodiscard]] bool is_running() const noexcept;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    /**
+     * @brief Get current statistics
+     * @return Reference to statistics structure
+     */
+    [[nodiscard]] const mini_pacs_statistics& statistics() const noexcept;
+
+    // =========================================================================
+    // Worklist Management
+    // =========================================================================
+
+    /**
+     * @brief Add a worklist item for MWL queries
+     * @param item The worklist entry to add
+     */
+    void add_worklist_item(const worklist_entry& item);
+
+    /**
+     * @brief Clear all worklist items
+     */
+    void clear_worklist();
+
+    /**
+     * @brief Get current worklist items
+     * @return Vector of worklist entries
+     */
+    [[nodiscard]] std::vector<worklist_entry> get_worklist_items() const;
+
+    // =========================================================================
+    // Configuration Access
+    // =========================================================================
+
+    /**
+     * @brief Get the configuration
+     * @return Reference to configuration
+     */
+    [[nodiscard]] const mini_pacs_config& config() const noexcept;
+
+private:
+    // =========================================================================
+    // Initialization
+    // =========================================================================
+
+    void initialize_storage();
+    void initialize_services();
+    void configure_server();
+    void setup_event_handlers();
+
+    // =========================================================================
+    // Storage Handlers
+    // =========================================================================
+
+    services::storage_status handle_store(
+        const core::dicom_dataset& dataset,
+        const std::string& calling_ae,
+        const std::string& sop_class_uid,
+        const std::string& sop_instance_uid);
+
+    bool update_index(
+        const core::dicom_dataset& dataset,
+        const std::filesystem::path& file_path);
+
+    // =========================================================================
+    // Query Handlers
+    // =========================================================================
+
+    std::vector<core::dicom_dataset> handle_query(
+        services::query_level level,
+        const core::dicom_dataset& query_keys,
+        const std::string& calling_ae);
+
+    // =========================================================================
+    // Retrieve Handlers
+    // =========================================================================
+
+    std::vector<core::dicom_file> handle_retrieve(
+        const core::dicom_dataset& query_keys);
+
+    std::optional<std::pair<std::string, uint16_t>> resolve_destination(
+        const std::string& ae_title);
+
+    // =========================================================================
+    // Worklist Handlers
+    // =========================================================================
+
+    std::vector<core::dicom_dataset> handle_worklist_query(
+        const core::dicom_dataset& query_keys,
+        const std::string& calling_ae);
+
+    core::dicom_dataset create_worklist_response(const worklist_entry& item);
+
+    // =========================================================================
+    // MPPS Handlers
+    // =========================================================================
+
+    network::Result<std::monostate> handle_mpps_create(
+        const services::mpps_instance& instance);
+
+    network::Result<std::monostate> handle_mpps_set(
+        const std::string& sop_instance_uid,
+        const core::dicom_dataset& modifications,
+        services::mpps_status new_status);
+
+    // =========================================================================
+    // Member Variables
+    // =========================================================================
+
+    mini_pacs_config config_;
+    mini_pacs_statistics stats_;
+
+    // Storage components
+    std::shared_ptr<storage::file_storage> file_storage_;
+    std::shared_ptr<storage::index_database> index_db_;
+
+    // Service providers
+    std::shared_ptr<services::verification_scp> verification_scp_;
+    std::shared_ptr<services::storage_scp> storage_scp_;
+    std::shared_ptr<services::query_scp> query_scp_;
+    std::shared_ptr<services::retrieve_scp> retrieve_scp_;
+    std::shared_ptr<services::worklist_scp> worklist_scp_;
+    std::shared_ptr<services::mpps_scp> mpps_scp_;
+
+    // Server
+    std::unique_ptr<network::dicom_server> server_;
+    std::atomic<bool> running_{false};
+
+    // Worklist items (in-memory for this sample)
+    mutable std::mutex worklist_mutex_;
+    std::vector<worklist_entry> worklist_items_;
+
+    // MPPS instances (in-memory for this sample)
+    mutable std::mutex mpps_mutex_;
+    std::vector<mpps_entry> mpps_instances_;
+};
+
+}  // namespace pacs::samples

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -13,5 +13,5 @@ add_subdirectory(common)
 add_subdirectory(01_hello_dicom)       # Level 1: Basic DICOM file operations
 add_subdirectory(02_echo_server)       # Level 2: C-ECHO SCP/SCU
 add_subdirectory(03_storage_server)    # Level 3: C-STORE SCP/SCU
-# add_subdirectory(04_mini_pacs)       # Level 4: Full PACS with query/retrieve
+add_subdirectory(04_mini_pacs)       # Level 4: Full PACS with query/retrieve
 # add_subdirectory(05_production_pacs) # Level 5: Production-ready features


### PR DESCRIPTION
## Summary

- Implement complete Mini PACS server with all core DICOM services
- Add Verification SCP (C-ECHO) for connectivity testing
- Add Storage SCP (C-STORE) for image reception and archiving
- Add Query SCP (C-FIND) at Patient/Study/Series/Image levels
- Add Retrieve SCP (C-MOVE/C-GET) for image retrieval
- Add Modality Worklist SCP (MWL C-FIND) for scheduled procedures
- Add MPPS SCP (N-CREATE/N-SET) for procedure tracking

## Implementation Details

The `mini_pacs` class encapsulates all DICOM services into a single reusable component:

- **Service Integration**: Combines 6 SCPs in one DICOM server
- **Index Database**: SQLite integration for fast metadata queries
- **File Storage**: Hierarchical organization (PatientID/StudyUID/SeriesUID/)
- **Statistics Tracking**: Counts for all DICOM operations
- **Sample Worklist**: 3 pre-populated entries for MWL testing

## Services Supported

| Service | Operation | Purpose |
|---------|-----------|---------|
| Verification SCP | C-ECHO | Network connectivity testing |
| Storage SCP | C-STORE | Receive and archive DICOM images |
| Query SCP | C-FIND | Search at Patient/Study/Series/Image levels |
| Retrieve SCP | C-MOVE/C-GET | Send images to destinations |
| Worklist SCP | MWL C-FIND | Return scheduled procedures to modalities |
| MPPS SCP | N-CREATE/N-SET | Track procedure progress |

## Test Plan

- [x] Build successfully with `cmake --build build --target mini_pacs`
- [ ] Run `echoscu -aec MINI_PACS localhost 11112` for C-ECHO test
- [ ] Run `storescu -aec MINI_PACS localhost 11112 <file.dcm>` for C-STORE test
- [ ] Run `findscu -aec MINI_PACS -P -k QueryRetrieveLevel=PATIENT localhost 11112` for C-FIND test
- [ ] Run `findscu -aec MINI_PACS -W -k Modality="" localhost 11112` for MWL test

Closes #595