### PR TITLE
docs(samples): add root README and common utilities documentation

### DIFF
--- a/samples/README.md
+++ b/samples/README.md
@@ -1,0 +1,271 @@
+# PACS System Developer Samples
+
+Progressive learning samples for building PACS applications with pacs_system. Each level introduces new concepts while building on previous knowledge.
+
+## Quick Start
+
+```bash
+# Clone and build with samples enabled
+git clone https://github.com/kcenon/pacs_system.git
+cd pacs_system
+cmake -B build -DPACS_BUILD_SAMPLES=ON
+cmake --build build
+
+# Run your first sample
+./build/samples/hello_dicom
+
+# Test network samples (in separate terminals)
+./build/samples/echo_server 11112          # Start server
+echoscu -aec ECHO_SCP localhost 11112      # Test with DCMTK
+```
+
+## Learning Path
+
+| Level | Sample | Description | Key Concepts | Time |
+|:-----:|--------|-------------|--------------|:----:|
+| 1 | [Hello DICOM](01_hello_dicom/) | Core data structures | Tags, VR, Dataset, File I/O | 30 min |
+| 2 | [Echo Server](02_echo_server/) | Network basics | Server config, Association, C-ECHO | 1 hour |
+| 3 | [Storage Server](03_storage_server/) | File storage & DB | C-STORE, File storage, SQLite index | 2 hours |
+| 4 | [Mini PACS](04_mini_pacs/) | Complete workflow | Q/R, Worklist, MPPS, Service integration | 4 hours |
+| 5 | Production PACS | Enterprise features | TLS, RBAC, REST API, Monitoring | Coming Soon |
+
+## Prerequisites
+
+### Required
+
+- **C++20 compiler**: GCC 11+, Clang 14+, or MSVC 2022
+- **CMake**: 3.20 or higher
+- **pacs_system library**: Built from source
+
+### Recommended
+
+- **DCMTK**: For testing DICOM communication
+  ```bash
+  # Ubuntu/Debian
+  apt-get install dcmtk
+
+  # macOS
+  brew install dcmtk
+
+  # Windows (vcpkg)
+  vcpkg install dcmtk
+  ```
+
+## Directory Structure
+
+```
+samples/
+├── CMakeLists.txt              # Root build configuration
+├── README.md                   # This file
+├── common/                     # Shared utilities for all samples
+│   ├── signal_handler.hpp/cpp  # Cross-platform signal handling
+│   ├── console_utils.hpp/cpp   # Formatted console output
+│   └── test_data_generator.hpp/cpp # Test DICOM data generation
+├── 01_hello_dicom/             # Level 1: DICOM basics
+├── 02_echo_server/             # Level 2: Network connectivity
+├── 03_storage_server/          # Level 3: Image archiving
+├── 04_mini_pacs/               # Level 4: Full PACS functionality
+└── 05_production_pacs/         # Level 5: Enterprise features (planned)
+```
+
+## Concepts by Level
+
+### Level 1: Hello DICOM
+
+Foundational DICOM data structures and file operations.
+
+- **DICOM Tags**: (Group, Element) pairs that identify data elements
+- **Value Representations (VR)**: Data types (PN, DA, UI, US, etc.)
+- **Datasets**: Collections of DICOM elements
+- **Part 10 Files**: Standard DICOM file format
+
+### Level 2: Echo Server
+
+Introduction to DICOM network communication.
+
+- **Server Configuration**: AE Title, port, timeouts
+- **Association Management**: Connection lifecycle
+- **C-ECHO**: Verification service for connectivity testing
+- **Event Callbacks**: Monitoring connections
+
+### Level 3: Storage Server
+
+Core PACS archiving functionality.
+
+- **C-STORE**: Receiving images from modalities
+- **File Storage**: Hierarchical file organization
+- **Index Database**: SQLite-based metadata indexing
+- **Handler Callbacks**: Pre/post-store validation
+
+### Level 4: Mini PACS
+
+Complete PACS implementation with all core services.
+
+- **Query/Retrieve**: C-FIND and C-MOVE operations
+- **Modality Worklist (MWL)**: Scheduled procedures
+- **MPPS**: Procedure status tracking
+- **Service Integration**: Multiple SCPs in one server
+
+### Level 5: Production PACS (Coming Soon)
+
+Enterprise-ready features for production deployment.
+
+- **TLS Security**: Encrypted communication
+- **Access Control**: Role-based permissions
+- **Anonymization**: De-identification profiles
+- **REST API**: Web-based PACS access
+- **Health Monitoring**: Service health checks
+
+## Build Options
+
+```bash
+# Build all samples
+cmake -B build -DPACS_BUILD_SAMPLES=ON
+cmake --build build
+
+# Build specific sample
+cmake --build build --target sample_01_hello_dicom
+cmake --build build --target sample_02_echo_server
+cmake --build build --target sample_03_storage_server
+cmake --build build --target mini_pacs
+```
+
+## Testing with DCMTK
+
+DCMTK provides command-line tools for testing DICOM communication.
+
+### Common Commands
+
+```bash
+# Connectivity test (C-ECHO)
+echoscu -v -aec <AE_TITLE> localhost <PORT>
+
+# Send images (C-STORE)
+storescu -v -aec <AE_TITLE> localhost <PORT> image.dcm
+
+# Query patients (C-FIND)
+findscu -v -aec <AE_TITLE> -P -k PatientName="*" localhost <PORT>
+
+# Query studies
+findscu -v -aec <AE_TITLE> -S -k StudyDate="20240101-20241231" localhost <PORT>
+
+# Query worklist
+findscu -v -aec <AE_TITLE> -W -k Modality="CT" localhost <PORT>
+
+# Retrieve images (C-MOVE)
+movescu -v -aec <AE_TITLE> -aem <DEST_AE> -k StudyInstanceUID="..." localhost <PORT>
+
+# Dump DICOM file
+dcmdump file.dcm
+```
+
+### Sample Testing Workflow
+
+```bash
+# Terminal 1: Start Mini PACS
+./build/samples/mini_pacs 11112
+
+# Terminal 2: Generate and store test data
+./build/samples/hello_dicom                              # Creates test file
+storescu -v -aec MINI_PACS localhost 11112 hello_dicom_output.dcm
+
+# Terminal 2: Query stored data
+findscu -v -aec MINI_PACS -P -k PatientName="*" localhost 11112
+```
+
+## Troubleshooting
+
+### Connection Refused
+
+- Verify the server is running
+- Check the port number matches
+- Ensure no firewall is blocking the connection
+
+### Association Rejected
+
+- Verify AE Title matches (case-sensitive)
+- Check the `-aec` parameter in your DCMTK command
+- Review presentation context negotiation
+
+### Query Returns No Results
+
+- Ensure images have been stored first
+- Check query key spelling and wildcards
+- Use `*` for partial matching
+
+### Storage Fails
+
+- Check disk space
+- Verify write permissions on storage directory
+- Review pre-store validation rules
+
+### Build Errors
+
+```bash
+# Ensure samples are enabled
+cmake -B build -DPACS_BUILD_SAMPLES=ON
+
+# Clean rebuild
+rm -rf build && cmake -B build -DPACS_BUILD_SAMPLES=ON && cmake --build build
+```
+
+## Architecture Reference
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Application Layer                        │
+│   (Samples, Custom Applications)                            │
+├─────────────────────────────────────────────────────────────┤
+│                     Services Layer                           │
+│   Verification SCP │ Storage SCP │ Query SCP │ Retrieve SCP │
+├─────────────────────────────────────────────────────────────┤
+│                     Network Layer                            │
+│   DICOM Server │ Association │ PDU │ DIMSE                  │
+├─────────────────────────────────────────────────────────────┤
+│                     Storage Layer                            │
+│   File Storage │ Index Database │ Query Builder              │
+├─────────────────────────────────────────────────────────────┤
+│                     Encoding Layer                           │
+│   Transfer Syntax │ VR Handlers │ Pixel Codecs              │
+├─────────────────────────────────────────────────────────────┤
+│                      Core Layer                              │
+│   DICOM Tag │ Dataset │ Element │ File                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Common Utilities
+
+The `common/` directory provides shared utilities used across all samples:
+
+| Utility | Purpose |
+|---------|---------|
+| `signal_handler` | Cross-platform graceful shutdown (SIGINT/SIGTERM) |
+| `console_utils` | Formatted output with colors and DICOM data display |
+| `test_data_generator` | Generate realistic test DICOM datasets |
+
+See [common/README.md](common/README.md) for detailed API documentation.
+
+## Further Reading
+
+### DICOM Standard
+
+- [Part 3: Information Object Definitions](https://dicom.nema.org/medical/dicom/current/output/html/part03.html)
+- [Part 4: Service Class Specifications](https://dicom.nema.org/medical/dicom/current/output/html/part04.html)
+- [Part 5: Data Structures and Encoding](https://dicom.nema.org/medical/dicom/current/output/html/part05.html)
+- [Part 7: Message Exchange](https://dicom.nema.org/medical/dicom/current/output/html/part07.html)
+- [Part 8: Network Communication](https://dicom.nema.org/medical/dicom/current/output/html/part08.html)
+- [Part 10: Media Storage](https://dicom.nema.org/medical/dicom/current/output/html/part10.html)
+
+### Project Resources
+
+- [pacs_system Repository](https://github.com/kcenon/pacs_system)
+- [kcenon Ecosystem](https://github.com/kcenon)
+
+## Contributing
+
+Contributions to the samples are welcome! Please ensure:
+
+1. Code follows existing style conventions
+2. Includes educational comments explaining DICOM concepts
+3. Works on Linux, macOS, and Windows
+4. Includes README with learning objectives

--- a/samples/common/README.md
+++ b/samples/common/README.md
@@ -1,0 +1,337 @@
+# Common Utilities
+
+Shared utilities library for all developer samples. These components handle cross-cutting concerns like signal handling, console output, and test data generation.
+
+## Overview
+
+| Component | Purpose | Header |
+|-----------|---------|--------|
+| Signal Handler | Cross-platform graceful shutdown | `signal_handler.hpp` |
+| Console Utils | Formatted output with colors | `console_utils.hpp` |
+| Test Data Generator | Generate test DICOM datasets | `test_data_generator.hpp` |
+
+## Signal Handler
+
+Cross-platform signal handling for graceful server shutdown. Supports SIGINT (Ctrl+C) and SIGTERM on POSIX systems, SIGINT/SIGBREAK on Windows.
+
+### Quick Usage
+
+```cpp
+#include "signal_handler.hpp"
+
+int main() {
+    // Install signal handlers
+    pacs::samples::signal_handler::install([]() {
+        std::cout << "Shutdown requested\n";
+    });
+
+    // Start your server...
+
+    // Wait for shutdown signal
+    pacs::samples::signal_handler::wait_for_shutdown();
+
+    // Cleanup...
+    return 0;
+}
+```
+
+### RAII Wrapper (Recommended)
+
+```cpp
+#include "signal_handler.hpp"
+
+int main() {
+    pacs::samples::scoped_signal_handler signals([]() {
+        std::cout << "Shutting down...\n";
+    });
+
+    // Start your server...
+
+    signals.wait();  // Blocks until Ctrl+C
+
+    // Cleanup happens automatically
+    return 0;
+}
+```
+
+### API Reference
+
+#### `signal_handler` (Static Interface)
+
+| Method | Description |
+|--------|-------------|
+| `install(callback)` | Install signal handlers with optional callback |
+| `should_shutdown()` | Check if shutdown was requested |
+| `wait_for_shutdown()` | Block until shutdown signal received |
+| `request_shutdown()` | Trigger shutdown programmatically |
+| `reset()` | Reset shutdown state (for tests) |
+
+#### `scoped_signal_handler` (RAII)
+
+| Method | Description |
+|--------|-------------|
+| Constructor | Installs handlers automatically |
+| Destructor | Resets handler state |
+| `wait()` | Block until shutdown |
+| `should_shutdown()` | Check shutdown state |
+
+## Console Utils
+
+Formatted console output with ANSI color support and DICOM-specific formatting.
+
+### Message Printing
+
+```cpp
+#include "console_utils.hpp"
+
+using namespace pacs::samples;
+
+// Headers and sections
+print_header("My Application");       // Decorative box header
+print_section("Configuration");       // Section divider
+
+// Status messages
+print_success("Operation completed"); // Green checkmark
+print_error("Operation failed");      // Red X
+print_warning("Check configuration"); // Yellow warning
+print_info("Processing...");          // Cyan info
+print_debug("Debug details");         // Dim/gray
+```
+
+### DICOM Data Display
+
+```cpp
+#include "console_utils.hpp"
+
+core::dicom_dataset ds;
+// ... populate dataset ...
+
+// Summary view (key patient/study info)
+pacs::samples::print_dataset_summary(ds);
+
+// All elements
+pacs::samples::print_dataset_elements(ds);
+pacs::samples::print_dataset_elements(ds, 40);  // Max value length 40
+```
+
+### Box Drawing
+
+```cpp
+// Simple box
+print_box({
+    "Line 1",
+    "Line 2",
+    "Line 3"
+});
+
+// Key-value table
+print_table("Patient Info", {
+    {"Name", "DOE^JOHN"},
+    {"ID", "PAT001"},
+    {"Sex", "M"}
+});
+```
+
+### Progress Display
+
+```cpp
+// Progress bar (useful for batch operations)
+for (size_t i = 0; i <= total; ++i) {
+    print_progress(i, total, 40, "Processing");
+}
+```
+
+### Formatting Utilities
+
+```cpp
+// Byte size formatting
+format_bytes(1536);         // "1.5 KB"
+format_bytes(2147483648);   // "2.0 GB"
+
+// Duration formatting
+format_duration(1500);      // "1.5s"
+format_duration(250);       // "250ms"
+
+// Text utilities
+center_text("Title", 40);   // Centers text in 40 chars
+truncate("Long text...", 10); // "Long te..."
+```
+
+### Color Configuration
+
+```cpp
+// Check color support
+if (supports_color()) {
+    set_color_enabled(true);
+}
+
+// Disable colors (for file output)
+set_color_enabled(false);
+
+// Check current state
+bool enabled = is_color_enabled();
+```
+
+### Available Colors
+
+```cpp
+namespace colors {
+    reset, bold, dim
+    black, red, green, yellow, blue, magenta, cyan, white
+    bright_red, bright_green, bright_yellow, bright_blue
+    bright_magenta, bright_cyan, bright_white
+    bg_red, bg_green, bg_yellow, bg_blue
+}
+```
+
+## Test Data Generator
+
+Generate realistic test DICOM datasets for various modalities.
+
+### Single Dataset Generation
+
+```cpp
+#include "test_data_generator.hpp"
+
+using namespace pacs::samples;
+
+// Default CT dataset
+auto ct_ds = test_data_generator::create_ct_dataset();
+
+// Custom patient
+patient_info patient{"PAT123", "SMITH^JANE", "19900515", "F"};
+auto ds = test_data_generator::create_ct_dataset(patient);
+
+// Different modalities
+auto mr_ds = test_data_generator::create_mr_dataset(patient);
+auto cr_ds = test_data_generator::create_cr_dataset(patient);
+auto dx_ds = test_data_generator::create_dx_dataset(patient);
+```
+
+### Study Generation
+
+```cpp
+// Create patient and study info
+patient_info patient{"PAT001", "DOE^JOHN", "19800101", "M"};
+study_info study;
+study.study_uid = test_data_generator::generate_uid();
+study.study_date = test_data_generator::current_date();
+study.study_time = test_data_generator::current_time();
+study.description = "CT CHEST W/CONTRAST";
+
+// Generate study with 2 series, 10 instances each
+auto datasets = test_data_generator::create_study(
+    patient, study, 2, 10);  // 20 total instances
+```
+
+### Save to Files
+
+```cpp
+// Save datasets to directory structure
+// Creates: directory/PatientID/StudyUID/SeriesUID/InstanceUID.dcm
+test_data_generator::save_to_directory(datasets, "./test_data");
+```
+
+### UID Generation
+
+```cpp
+// Generate unique DICOM UIDs
+auto uid = test_data_generator::generate_uid();
+// e.g., "1.2.410.200001.1.1.1705912345.1"
+
+// Custom root
+auto uid = test_data_generator::generate_uid("1.2.840.123456");
+```
+
+### Date/Time Utilities
+
+```cpp
+// Current date in DICOM format (YYYYMMDD)
+std::string date = test_data_generator::current_date();
+// e.g., "20240122"
+
+// Current time in DICOM format (HHMMSS.FFFFFF)
+std::string time = test_data_generator::current_time();
+// e.g., "143022.123456"
+```
+
+### Data Structures
+
+#### `patient_info`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `patient_id` | string | "PAT001" | Patient identifier |
+| `patient_name` | string | "DOE^JOHN" | Patient name (PN format) |
+| `birth_date` | string | "19800101" | Birth date (YYYYMMDD) |
+| `sex` | string | "M" | Patient sex (M/F/O) |
+
+#### `study_info`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `study_uid` | string | Study Instance UID |
+| `study_date` | string | Study date (YYYYMMDD) |
+| `study_time` | string | Study time (HHMMSS) |
+| `accession_number` | string | Accession number |
+| `description` | string | Study description |
+| `referring_physician` | string | Referring physician name |
+
+#### `image_params`
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rows` | uint16 | 512 | Image rows |
+| `columns` | uint16 | 512 | Image columns |
+| `bits_allocated` | uint16 | 16 | Bits per pixel |
+| `bits_stored` | uint16 | 12 | Significant bits |
+| `high_bit` | uint16 | 11 | High bit position |
+| `pixel_representation` | uint16 | 0 | 0=unsigned, 1=signed |
+| `modality` | string | "CT" | Modality code |
+| `photometric` | string | "MONOCHROME2" | Photometric interpretation |
+| `window_center` | double | 40.0 | Window center (HU for CT) |
+| `window_width` | double | 400.0 | Window width |
+
+## Build Configuration
+
+The common library is built as a static library and linked to all samples:
+
+```cmake
+# In samples/common/CMakeLists.txt
+add_library(pacs_samples_common STATIC
+    signal_handler.cpp
+    console_utils.cpp
+    test_data_generator.cpp
+)
+
+target_link_libraries(pacs_samples_common PUBLIC
+    pacs::core
+    pacs::encoding
+)
+```
+
+To use in your sample:
+
+```cmake
+target_link_libraries(my_sample PRIVATE
+    pacs_samples_common
+)
+```
+
+## Thread Safety
+
+| Component | Thread Safety |
+|-----------|---------------|
+| `signal_handler` | Fully thread-safe (atomic operations) |
+| `console_utils` | Single-threaded (console output only) |
+| `test_data_generator` | UID generation is thread-safe |
+
+## Platform Support
+
+| Platform | Signal Handler | Console Colors |
+|----------|----------------|----------------|
+| Linux | SIGINT, SIGTERM | Full support |
+| macOS | SIGINT, SIGTERM | Full support |
+| Windows | SIGINT, SIGBREAK | Windows Terminal (10+) |
+
+Note: Older Windows cmd.exe may not display ANSI colors correctly. Colors are automatically disabled when output is redirected to a file.


### PR DESCRIPTION
Closes #597

## Summary
- Add comprehensive root `samples/README.md` with learning path documentation
- Add `samples/common/README.md` with API documentation for shared utilities

## Changes

### Root README (`samples/README.md`)
- Quick start guide for building and running samples
- Learning path table with all 5 sample levels (1-4 implemented, 5 planned)
- Prerequisites section (compiler, CMake, DCMTK)
- Directory structure overview
- Concepts covered by each level
- Build options and commands
- DCMTK testing commands reference
- Troubleshooting guide for common issues
- Architecture reference diagram
- Links to DICOM standard documentation

### Common Utilities README (`samples/common/README.md`)
- API documentation for `signal_handler` (cross-platform graceful shutdown)
- API documentation for `console_utils` (formatted output with ANSI colors)
- API documentation for `test_data_generator` (DICOM test data creation)
- Usage examples for each utility
- Data structure reference tables
- Thread safety and platform support notes

## Test Plan
- [x] All samples build successfully with `cmake -B build -DPACS_BUILD_SAMPLES=ON`
- [x] Documentation accurately reflects existing code
- [x] Links and references are correct
- [x] Markdown renders properly