### PR TITLE
feat(storage): migrate Series/Instance operations to database adapter

### DIFF
--- a/include/pacs/storage/index_database.hpp
+++ b/include/pacs/storage/index_database.hpp
@@ -1154,6 +1154,18 @@ private:
      */
     [[nodiscard]] auto parse_study_from_adapter_row(
         const database_row& row) const -> study_record;
+
+    /**
+     * @brief Parse series record from pacs_database_adapter result row
+     */
+    [[nodiscard]] auto parse_series_from_adapter_row(
+        const database_row& row) const -> series_record;
+
+    /**
+     * @brief Parse instance record from pacs_database_adapter result row
+     */
+    [[nodiscard]] auto parse_instance_from_adapter_row(
+        const database_row& row) const -> instance_record;
 #endif
 
     /// SQLite database handle (used for migrations and fallback)


### PR DESCRIPTION
## Summary

Migrate Series and Instance operations in `index_database` to use `pacs_database_adapter` for unified database access, following the pattern established in Sub-task A (#613).

### Changes

**New Helper Functions:**
- `parse_series_from_adapter_row()` - Convert database adapter results to series_record
- `parse_instance_from_adapter_row()` - Convert database adapter results to instance_record

**Migrated Series Operations (8 functions):**
- `upsert_series()` - Insert/update series records
- `find_series()` - Find series by UID
- `find_series_by_pk()` - Find series by primary key
- `list_series()` - List series for a study
- `search_series()` - Search series with criteria
- `delete_series()` - Delete series records
- `series_count()` - Count all series
- `series_count(study_uid)` - Count series in a study

**Migrated Instance Operations (8 functions):**
- `upsert_instance()` - Insert/update instance records
- `find_instance()` - Find instance by SOP UID
- `find_instance_by_pk()` - Find instance by primary key
- `list_instances()` - List instances for a series
- `search_instances()` - Search instances with criteria
- `delete_instance()` - Delete instance records
- `instance_count()` - Count all instances
- `instance_count(series_uid)` - Count instances in a series

### Implementation Pattern

All operations follow the three-tier fallback pattern:
1. **db_adapter_** (preferred) - pacs_database_adapter for unified access
2. **db_manager_** (legacy) - database_manager fallback
3. **Direct SQLite** - Final fallback when database_system is disabled

## Related Issues

- Closes #614 (Sub-task B: Series/Instance Operations Migration)
- Part of #608 (Phase 3-1: Core Migration)
- Depends on #613 (Sub-task A: Patient/Study Operations Migration) - Completed

## Test Plan

- [x] All storage tests pass (81/81)
- [x] All index_database tests pass (96/96)
- [x] Code compiles successfully (pacs_storage library built)

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass
- [x] Related issue linked with closing keyword