### PR TITLE
fix(storage): add in-memory database fallback for adapter (#625)

### DIFF
--- a/tests/storage/index_database_test.cpp
+++ b/tests/storage/index_database_test.cpp
@@ -12,6 +12,7 @@
 
 #include <algorithm>
 #include <filesystem>
+#include <iostream>
 #include <memory>
 
 using namespace pacs::storage;
@@ -78,6 +79,9 @@ TEST_CASE("index_database: insert patient with basic info",
 
     auto result = db->upsert_patient("12345", "Doe^John", "19800115", "M");
 
+    if (result.is_err()) {
+        std::cerr << "ERROR: " << result.error().message << std::endl;
+    }
     REQUIRE(result.is_ok());
     CHECK(result.value() > 0);
 


### PR DESCRIPTION
## Summary

Adds fallback to direct SQLite when pacs_database_adapter is unavailable, fixing test failures with in-memory databases.

## Changes Made

### Infrastructure
- Enable database_system initialization for in-memory databases
- Remove skip condition that prevented :memory: DB support

### Fallback Pattern  
- Add SQLite fallback in upsert_patient when adapter unavailable
- Maintain compatibility with both file-based and in-memory DBs
- Issue: unified_database_system does not support :memory: yet

### Testing
- Add error logging to tests for debugging
- Tests now pass with SQLite fallback

## Technical Details

**Problem**: All tests failed because:
1. Tests use :memory: for isolation
2. pacs_database_adapter uses unified_database_system  
3. unified_database_system cannot connect to :memory:

**Solution**: Conditional adapter usage
- If adapter connected → use adapter (file DBs)
- If adapter unavailable → use SQLite (in-memory DBs)

## Related Issues

Closes #625

Part of #608 - Phase 3-1: Core Migration
Part of #605 - Migrate to database_system Abstraction

## Test Plan

- [x] Build succeeds
- [x] upsert_patient test passes with fallback
- [ ] Remaining patient/study functions need same pattern
- [ ] All tests passing (pending other functions)

## Notes

**Remaining Work**:
- Apply fallback pattern to find_patient, search_patients, etc.
- Or investigate unified_database_system in-memory support
- Patient/Study operations already migrated in PR #624