### PR TITLE
feat(storage): implement base repository pattern (Phase 2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1032,6 +1032,7 @@ if(PACS_BUILD_STORAGE AND SQLITE3_FOUND)
         src/storage/key_image_repository.cpp
         src/storage/viewer_state_repository.cpp
         src/storage/pacs_database_adapter.cpp
+        src/storage/repository_factory.cpp
     )
     target_include_directories(pacs_storage
         PUBLIC
@@ -1722,6 +1723,7 @@ if(PACS_BUILD_TESTS)
             tests/storage/mpps_test.cpp
             tests/storage/worklist_test.cpp
             tests/storage/pacs_database_adapter_test.cpp
+            tests/storage/base_repository_test.cpp
             # Annotation & Measurement API integration tests (Issue #545, #584)
             tests/integration/annotation_api_test.cpp
             tests/integration/measurement_api_test.cpp

--- a/include/pacs/storage/base_repository.hpp
+++ b/include/pacs/storage/base_repository.hpp
@@ -1,0 +1,427 @@
+/**
+ * @file base_repository.hpp
+ * @brief Generic base repository for CRUD operations
+ *
+ * This file provides a template base class for repositories that implement
+ * common CRUD patterns using the pacs_database_adapter. It eliminates code
+ * duplication across repository implementations and provides consistent
+ * data access patterns.
+ *
+ * @see Issue #607 - Phase 2: Base Repository Pattern Implementation
+ * @see Epic #605 - Migrate Direct Database Access to database_system
+ * Abstraction
+ */
+
+#pragma once
+
+#define PACS_STORAGE_BASE_REPOSITORY_HPP_INCLUDED
+
+#include <pacs/storage/pacs_database_adapter.hpp>
+
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+
+#include <database/core/database_backend.h>
+#include <database/database_types.h>
+
+namespace pacs::storage {
+
+/// Database value type alias
+using database_value = database::core::database_value;
+
+/**
+ * @brief Generic base repository providing common CRUD operations
+ *
+ * This template class provides standard database operations (Create, Read,
+ * Update, Delete) for domain entities. Subclasses must implement the abstract
+ * mapping methods to convert between database rows and domain entities.
+ *
+ * **Features:**
+ * - Type-safe CRUD operations with Result<T> error handling
+ * - Transaction support via pacs_database_adapter
+ * - Batch operations for efficient bulk inserts
+ * - Query builder integration for complex queries
+ * - Extensible design for domain-specific operations
+ *
+ * **Thread Safety:** This class is NOT thread-safe. External synchronization
+ * is required for concurrent access.
+ *
+ * @tparam Entity The domain entity type to be persisted
+ * @tparam PrimaryKey The primary key type (default: int64_t)
+ *
+ * @example
+ * @code
+ * // Define a domain entity
+ * struct Patient {
+ *     int64_t id{0};
+ *     std::string patient_id;
+ *     std::string patient_name;
+ * };
+ *
+ * // Create repository subclass
+ * class patient_repository : public base_repository<Patient> {
+ * public:
+ *     explicit patient_repository(std::shared_ptr<pacs_database_adapter> db)
+ *         : base_repository(db, "patients", "id") {}
+ *
+ * protected:
+ *     Patient map_row_to_entity(const database_row& row) const override {
+ *         return Patient{
+ *             std::stoll(row.at("id")),
+ *             row.at("patient_id"),
+ *             row.at("patient_name")
+ *         };
+ *     }
+ *
+ *     std::map<std::string, database::database_value>
+ *     entity_to_row(const Patient& p) const override {
+ *         return {
+ *             {"patient_id", p.patient_id},
+ *             {"patient_name", p.patient_name}
+ *         };
+ *     }
+ *
+ *     int64_t get_pk(const Patient& p) const override {
+ *         return p.id;
+ *     }
+ *
+ *     bool has_pk(const Patient& p) const override {
+ *         return p.id > 0;
+ *     }
+ * };
+ *
+ * // Usage
+ * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
+ * db->connect();
+ * patient_repository repo(db);
+ *
+ * // Find by ID
+ * auto result = repo.find_by_id(1);
+ * if (result.is_ok()) {
+ *     auto patient = result.value();
+ *     // use patient...
+ * }
+ *
+ * // Save entity
+ * Patient new_patient{0, "P001", "Doe^John"};
+ * auto save_result = repo.save(new_patient);
+ * @endcode
+ */
+template <typename Entity, typename PrimaryKey = int64_t>
+class base_repository {
+public:
+    /// Entity type alias
+    using entity_type = Entity;
+
+    /// Primary key type alias
+    using pk_type = PrimaryKey;
+
+    /// Result type for single entity operations
+    using result_type = Result<Entity>;
+
+    /// Result type for list operations
+    using list_result_type = Result<std::vector<Entity>>;
+
+    /**
+     * @brief Construct repository with database adapter and table name
+     *
+     * @param db Shared pointer to database adapter
+     * @param table_name Name of the database table
+     * @param pk_column Name of the primary key column (default: "id")
+     */
+    explicit base_repository(std::shared_ptr<pacs_database_adapter> db,
+                             std::string table_name,
+                             std::string pk_column = "id");
+
+    /// Virtual destructor for proper cleanup in derived classes
+    virtual ~base_repository() = default;
+
+    // Non-copyable
+    base_repository(const base_repository&) = delete;
+    auto operator=(const base_repository&) -> base_repository& = delete;
+
+    // Movable
+    base_repository(base_repository&&) noexcept = default;
+    auto operator=(base_repository&&) noexcept -> base_repository& = default;
+
+    // ========================================================================
+    // Read Operations
+    // ========================================================================
+
+    /**
+     * @brief Find entity by primary key
+     *
+     * Executes a SELECT query to find the entity with the specified primary
+     * key.
+     *
+     * @param id Primary key value
+     * @return Result containing the entity if found, or error
+     */
+    [[nodiscard]] virtual auto find_by_id(PrimaryKey id) -> result_type;
+
+    /**
+     * @brief Find all entities in the table
+     *
+     * Retrieves all rows from the table. Use with caution on large tables.
+     *
+     * @param limit Optional maximum number of rows to return
+     * @return Result containing vector of entities or error
+     */
+    [[nodiscard]] virtual auto find_all(std::optional<size_t> limit = std::nullopt)
+        -> list_result_type;
+
+    /**
+     * @brief Find entities matching a condition
+     *
+     * Executes a SELECT query with a WHERE clause.
+     *
+     * @param column Column name to filter on
+     * @param op Comparison operator (=, !=, <, >, <=, >=, LIKE, etc.)
+     * @param value Value to compare against
+     * @return Result containing matching entities or error
+     *
+     * @example
+     * @code
+     * // Find patients with specific patient_id
+     * auto result = repo.find_where("patient_id", "=", "P001");
+     * @endcode
+     */
+    [[nodiscard]] virtual auto find_where(const std::string& column,
+                                          const std::string& op,
+                                          const database_value& value)
+        -> list_result_type;
+
+    /**
+     * @brief Check if an entity with given ID exists
+     *
+     * @param id Primary key value
+     * @return Result containing true if exists, false otherwise
+     */
+    [[nodiscard]] virtual auto exists(PrimaryKey id) -> Result<bool>;
+
+    /**
+     * @brief Count total number of entities
+     *
+     * @return Result containing count or error
+     */
+    [[nodiscard]] virtual auto count() -> Result<size_t>;
+
+    // ========================================================================
+    // Write Operations
+    // ========================================================================
+
+    /**
+     * @brief Save entity (insert or update)
+     *
+     * If the entity has a valid primary key (has_pk() returns true), performs
+     * an UPDATE. Otherwise, performs an INSERT and returns the new primary
+     * key.
+     *
+     * @param entity Entity to save
+     * @return Result containing the primary key (existing or new)
+     */
+    [[nodiscard]] virtual auto save(const Entity& entity)
+        -> Result<PrimaryKey>;
+
+    /**
+     * @brief Insert new entity
+     *
+     * Inserts a new row into the database.
+     *
+     * @param entity Entity to insert
+     * @return Result containing the new primary key or error
+     */
+    [[nodiscard]] virtual auto insert(const Entity& entity)
+        -> Result<PrimaryKey>;
+
+    /**
+     * @brief Update existing entity
+     *
+     * Updates an existing row. The entity must have a valid primary key.
+     *
+     * @param entity Entity to update
+     * @return Result indicating success or error
+     */
+    [[nodiscard]] virtual auto update(const Entity& entity) -> VoidResult;
+
+    /**
+     * @brief Delete entity by primary key
+     *
+     * @param id Primary key of entity to delete
+     * @return Result indicating success or error
+     */
+    [[nodiscard]] virtual auto remove(PrimaryKey id) -> VoidResult;
+
+    /**
+     * @brief Delete entities matching condition
+     *
+     * @param column Column name to filter on
+     * @param op Comparison operator
+     * @param value Value to compare against
+     * @return Result containing number of deleted rows or error
+     */
+    [[nodiscard]] virtual auto remove_where(const std::string& column,
+                                            const std::string& op,
+                                            const database_value& value)
+        -> Result<size_t>;
+
+    // ========================================================================
+    // Batch Operations
+    // ========================================================================
+
+    /**
+     * @brief Insert multiple entities in a transaction
+     *
+     * Inserts all entities within a single transaction for efficiency.
+     * If any insert fails, the entire batch is rolled back.
+     *
+     * @param entities Vector of entities to insert
+     * @return Result containing vector of new primary keys or error
+     */
+    [[nodiscard]] virtual auto insert_batch(const std::vector<Entity>& entities)
+        -> Result<std::vector<PrimaryKey>>;
+
+    /**
+     * @brief Execute callback within a transaction
+     *
+     * Automatically begins transaction, executes function, and commits.
+     * Rolls back on exception or if function returns error.
+     *
+     * @tparam Func Function type that takes no args and returns a Result
+     * @param func Function to execute within transaction
+     * @return Result from the function or transaction error
+     *
+     * @example
+     * @code
+     * auto result = repo.in_transaction([&]() -> VoidResult {
+     *     auto r1 = repo.insert(entity1);
+     *     if (r1.is_err()) return r1.error();
+     *
+     *     auto r2 = repo.insert(entity2);
+     *     if (r2.is_err()) return r2.error();
+     *
+     *     return kcenon::common::ok();
+     * });
+     * @endcode
+     */
+    template <typename Func>
+    [[nodiscard]] auto in_transaction(Func&& func)
+        -> std::invoke_result_t<Func>;
+
+protected:
+    // ========================================================================
+    // Abstract Methods - Subclass Must Implement
+    // ========================================================================
+
+    /**
+     * @brief Map database row to entity
+     *
+     * Subclasses must implement this to convert a database row into a domain
+     * entity.
+     *
+     * @param row Database row with column-value pairs
+     * @return Entity constructed from row data
+     */
+    [[nodiscard]] virtual auto map_row_to_entity(const database_row& row) const
+        -> Entity = 0;
+
+    /**
+     * @brief Map entity to column-value pairs
+     *
+     * Subclasses must implement this to convert an entity into a map of
+     * column names to values for INSERT/UPDATE operations.
+     *
+     * Note: Do not include the primary key column in the returned map for
+     * INSERT operations (it will be auto-generated).
+     *
+     * @param entity Entity to map
+     * @return Map of column names to database values
+     */
+    [[nodiscard]] virtual auto entity_to_row(const Entity& entity) const
+        -> std::map<std::string, database_value> = 0;
+
+    /**
+     * @brief Get primary key value from entity
+     *
+     * @param entity Entity to extract primary key from
+     * @return Primary key value
+     */
+    [[nodiscard]] virtual auto get_pk(const Entity& entity) const
+        -> PrimaryKey = 0;
+
+    /**
+     * @brief Check if entity has a valid primary key
+     *
+     * This is used by save() to determine whether to INSERT or UPDATE.
+     *
+     * @param entity Entity to check
+     * @return true if entity has a valid (non-default) primary key
+     */
+    [[nodiscard]] virtual auto has_pk(const Entity& entity) const -> bool = 0;
+
+    /**
+     * @brief Get columns for SELECT queries
+     *
+     * Override this if you need to customize which columns are selected.
+     * Default implementation returns "*".
+     *
+     * @return Vector of column names to select
+     */
+    [[nodiscard]] virtual auto select_columns() const
+        -> std::vector<std::string>;
+
+    // ========================================================================
+    // Utility Methods for Subclasses
+    // ========================================================================
+
+    /**
+     * @brief Create a query builder for this database
+     *
+     * @return Query builder instance configured for the database
+     */
+    [[nodiscard]] auto query_builder() -> database::query_builder;
+
+    /**
+     * @brief Get the database adapter
+     *
+     * @return Shared pointer to database adapter
+     */
+    [[nodiscard]] auto db() -> std::shared_ptr<pacs_database_adapter>;
+
+    /**
+     * @brief Get the table name
+     *
+     * @return Table name
+     */
+    [[nodiscard]] auto table_name() const -> const std::string&;
+
+    /**
+     * @brief Get the primary key column name
+     *
+     * @return Primary key column name
+     */
+    [[nodiscard]] auto pk_column() const -> const std::string&;
+
+private:
+    /// Database adapter for executing queries
+    std::shared_ptr<pacs_database_adapter> db_;
+
+    /// Name of the database table
+    std::string table_name_;
+
+    /// Name of the primary key column
+    std::string pk_column_;
+};
+
+}  // namespace pacs::storage
+
+// Include template implementation
+#include "base_repository_impl.hpp"
+
+#endif  // PACS_WITH_DATABASE_SYSTEM

--- a/include/pacs/storage/base_repository_impl.hpp
+++ b/include/pacs/storage/base_repository_impl.hpp
@@ -1,0 +1,516 @@
+/**
+ * @file base_repository_impl.hpp
+ * @brief Template implementation of base_repository
+ *
+ * This file contains the template method implementations for base_repository.
+ * It is automatically included by base_repository.hpp and should not be
+ * included directly.
+ *
+ * @see base_repository.hpp
+ * @see Issue #607 - Phase 2: Base Repository Pattern Implementation
+ */
+
+#pragma once
+
+#ifndef PACS_STORAGE_BASE_REPOSITORY_HPP_INCLUDED
+#error "Do not include base_repository_impl.hpp directly. Include base_repository.hpp instead."
+#endif
+
+#include <sstream>
+
+namespace pacs::storage {
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+template <typename Entity, typename PrimaryKey>
+base_repository<Entity, PrimaryKey>::base_repository(
+    std::shared_ptr<pacs_database_adapter> db,
+    std::string table_name,
+    std::string pk_column)
+    : db_(std::move(db)),
+      table_name_(std::move(table_name)),
+      pk_column_(std::move(pk_column)) {}
+
+// =============================================================================
+// Read Operations
+// =============================================================================
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::find_by_id(PrimaryKey id)
+    -> result_type {
+    if (!db_ || !db_->is_connected()) {
+        return Result<Entity>(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    auto builder = db_->create_query_builder();
+    auto columns = select_columns();
+
+    if (columns.empty() || (columns.size() == 1 && columns[0] == "*")) {
+        builder.select({"*"});
+    } else {
+        builder.select(columns);
+    }
+
+    builder.from(table_name_);
+
+    // Convert primary key to database_value
+    database_value pk_value;
+    if constexpr (std::is_integral_v<PrimaryKey>) {
+        pk_value = static_cast<int64_t>(id);
+    } else if constexpr (std::is_same_v<PrimaryKey, std::string>) {
+        pk_value = id;
+    } else {
+        std::ostringstream oss;
+        oss << id;
+        pk_value = oss.str();
+    }
+
+    builder.where(pk_column_, "=", pk_value);
+    builder.limit(1);
+
+    auto query = builder.build();
+    auto result = db_->select(query);
+
+    if (result.is_err()) {
+        return Result<Entity>(result.error());
+    }
+
+    const auto& db_result = result.value();
+    if (db_result.empty()) {
+        return Result<Entity>(kcenon::common::error_info{
+            -1, "Entity not found with id=" + std::to_string(id), "storage"});
+    }
+
+    try {
+        auto entity = map_row_to_entity(db_result[0]);
+        return Result<Entity>(std::move(entity));
+    } catch (const std::exception& e) {
+        return Result<Entity>(kcenon::common::error_info{
+            -1, std::string("Failed to map row to entity: ") + e.what(),
+            "storage"});
+    }
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::find_all(
+    std::optional<size_t> limit) -> list_result_type {
+    if (!db_ || !db_->is_connected()) {
+        return list_result_type(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    auto builder = db_->create_query_builder();
+    auto columns = select_columns();
+
+    if (columns.empty() || (columns.size() == 1 && columns[0] == "*")) {
+        builder.select({"*"});
+    } else {
+        builder.select(columns);
+    }
+
+    builder.from(table_name_);
+
+    if (limit.has_value()) {
+        builder.limit(limit.value());
+    }
+
+    auto query = builder.build();
+    auto result = db_->select(query);
+
+    if (result.is_err()) {
+        return list_result_type(result.error());
+    }
+
+    std::vector<Entity> entities;
+    entities.reserve(result.value().size());
+
+    try {
+        for (const auto& row : result.value()) {
+            entities.push_back(map_row_to_entity(row));
+        }
+        return list_result_type(std::move(entities));
+    } catch (const std::exception& e) {
+        return list_result_type(kcenon::common::error_info{
+            -1, std::string("Failed to map rows to entities: ") + e.what(),
+            "storage"});
+    }
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::find_where(
+    const std::string& column,
+    const std::string& op,
+    const database_value& value) -> list_result_type {
+    if (!db_ || !db_->is_connected()) {
+        return list_result_type(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    auto builder = db_->create_query_builder();
+    auto columns = select_columns();
+
+    if (columns.empty() || (columns.size() == 1 && columns[0] == "*")) {
+        builder.select({"*"});
+    } else {
+        builder.select(columns);
+    }
+
+    builder.from(table_name_).where(column, op, value);
+
+    auto query = builder.build();
+    auto result = db_->select(query);
+
+    if (result.is_err()) {
+        return list_result_type(result.error());
+    }
+
+    std::vector<Entity> entities;
+    entities.reserve(result.value().size());
+
+    try {
+        for (const auto& row : result.value()) {
+            entities.push_back(map_row_to_entity(row));
+        }
+        return list_result_type(std::move(entities));
+    } catch (const std::exception& e) {
+        return list_result_type(kcenon::common::error_info{
+            -1, std::string("Failed to map rows to entities: ") + e.what(),
+            "storage"});
+    }
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::exists(PrimaryKey id)
+    -> Result<bool> {
+    if (!db_ || !db_->is_connected()) {
+        return Result<bool>(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    auto builder = db_->create_query_builder();
+
+    // Convert primary key to database_value
+    database_value pk_value;
+    if constexpr (std::is_integral_v<PrimaryKey>) {
+        pk_value = static_cast<int64_t>(id);
+    } else if constexpr (std::is_same_v<PrimaryKey, std::string>) {
+        pk_value = id;
+    } else {
+        std::ostringstream oss;
+        oss << id;
+        pk_value = oss.str();
+    }
+
+    builder.select({"COUNT(*) as count"})
+        .from(table_name_)
+        .where(pk_column_, "=", pk_value);
+
+    auto query = builder.build();
+    auto result = db_->select(query);
+
+    if (result.is_err()) {
+        return Result<bool>(result.error());
+    }
+
+    if (result.value().empty()) {
+        return Result<bool>(false);
+    }
+
+    try {
+        int count = std::stoi(result.value()[0].at("count"));
+        return Result<bool>(count > 0);
+    } catch (const std::exception& e) {
+        return Result<bool>(kcenon::common::error_info{
+            -1, std::string("Failed to parse count: ") + e.what(),
+            "storage"});
+    }
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::count() -> Result<size_t> {
+    if (!db_ || !db_->is_connected()) {
+        return Result<size_t>(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    auto builder = db_->create_query_builder();
+    builder.select({"COUNT(*) as count"}).from(table_name_);
+
+    auto query = builder.build();
+    auto result = db_->select(query);
+
+    if (result.is_err()) {
+        return Result<size_t>(result.error());
+    }
+
+    if (result.value().empty()) {
+        return Result<size_t>(static_cast<size_t>(0));
+    }
+
+    try {
+        size_t count = std::stoull(result.value()[0].at("count"));
+        return Result<size_t>(count);
+    } catch (const std::exception& e) {
+        return Result<size_t>(kcenon::common::error_info{
+            -1, std::string("Failed to parse count: ") + e.what(),
+            "storage"});
+    }
+}
+
+// =============================================================================
+// Write Operations
+// =============================================================================
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::save(const Entity& entity)
+    -> Result<PrimaryKey> {
+    if (has_pk(entity)) {
+        auto update_result = update(entity);
+        if (update_result.is_err()) {
+            return Result<PrimaryKey>(update_result.error());
+        }
+        return Result<PrimaryKey>(get_pk(entity));
+    } else {
+        return insert(entity);
+    }
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::insert(const Entity& entity)
+    -> Result<PrimaryKey> {
+    if (!db_ || !db_->is_connected()) {
+        return Result<PrimaryKey>(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    try {
+        auto row = entity_to_row(entity);
+        auto builder = db_->create_query_builder();
+        builder.insert_into(table_name_).values(row);
+
+        auto query = builder.build();
+        auto result = db_->insert(query);
+
+        if (result.is_err()) {
+            return Result<PrimaryKey>(result.error());
+        }
+
+        // Get the last insert rowid
+        auto rowid = db_->last_insert_rowid();
+
+        if constexpr (std::is_integral_v<PrimaryKey>) {
+            return Result<PrimaryKey>(static_cast<PrimaryKey>(rowid));
+        } else if constexpr (std::is_same_v<PrimaryKey, std::string>) {
+            return Result<PrimaryKey>(std::to_string(rowid));
+        } else {
+            return Result<PrimaryKey>(kcenon::common::error_info{
+                -1, "Unsupported primary key type", "storage"});
+        }
+    } catch (const std::exception& e) {
+        return Result<PrimaryKey>(kcenon::common::error_info{
+            -1, std::string("Failed to insert entity: ") + e.what(),
+            "storage"});
+    }
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::update(const Entity& entity)
+    -> VoidResult {
+    if (!db_ || !db_->is_connected()) {
+        return VoidResult(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    if (!has_pk(entity)) {
+        return VoidResult(kcenon::common::error_info{
+            -1, "Entity does not have a valid primary key for update",
+            "storage"});
+    }
+
+    try {
+        auto row = entity_to_row(entity);
+        auto pk = get_pk(entity);
+
+        auto builder = db_->create_query_builder();
+        builder.update(table_name_).set(row);
+
+        // Convert primary key to database_value
+        database_value pk_value;
+        if constexpr (std::is_integral_v<PrimaryKey>) {
+            pk_value = static_cast<int64_t>(pk);
+        } else if constexpr (std::is_same_v<PrimaryKey, std::string>) {
+            pk_value = pk;
+        } else {
+            std::ostringstream oss;
+            oss << pk;
+            pk_value = oss.str();
+        }
+
+        builder.where(pk_column_, "=", pk_value);
+
+        auto query = builder.build();
+        auto result = db_->update(query);
+
+        if (result.is_err()) {
+            return VoidResult(result.error());
+        }
+
+        if (result.value() == 0) {
+            return VoidResult(kcenon::common::error_info{
+                -1, "No rows were updated - entity may not exist", "storage"});
+        }
+
+        return kcenon::common::ok();
+    } catch (const std::exception& e) {
+        return VoidResult(kcenon::common::error_info{
+            -1, std::string("Failed to update entity: ") + e.what(),
+            "storage"});
+    }
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::remove(PrimaryKey id)
+    -> VoidResult {
+    if (!db_ || !db_->is_connected()) {
+        return VoidResult(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    auto builder = db_->create_query_builder();
+
+    // Convert primary key to database_value
+    database_value pk_value;
+    if constexpr (std::is_integral_v<PrimaryKey>) {
+        pk_value = static_cast<int64_t>(id);
+    } else if constexpr (std::is_same_v<PrimaryKey, std::string>) {
+        pk_value = id;
+    } else {
+        std::ostringstream oss;
+        oss << id;
+        pk_value = oss.str();
+    }
+
+    builder.delete_from(table_name_).where(pk_column_, "=", pk_value);
+
+    auto query = builder.build();
+    auto result = db_->remove(query);
+
+    if (result.is_err()) {
+        return VoidResult(result.error());
+    }
+
+    if (result.value() == 0) {
+        return VoidResult(kcenon::common::error_info{
+            -1, "No rows were deleted - entity may not exist", "storage"});
+    }
+
+    return kcenon::common::ok();
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::remove_where(
+    const std::string& column,
+    const std::string& op,
+    const database_value& value) -> Result<size_t> {
+    if (!db_ || !db_->is_connected()) {
+        return Result<size_t>(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    auto builder = db_->create_query_builder();
+    builder.delete_from(table_name_).where(column, op, value);
+
+    auto query = builder.build();
+    auto result = db_->remove(query);
+
+    if (result.is_err()) {
+        return Result<size_t>(result.error());
+    }
+
+    return Result<size_t>(static_cast<size_t>(result.value()));
+}
+
+// =============================================================================
+// Batch Operations
+// =============================================================================
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::insert_batch(
+    const std::vector<Entity>& entities) -> Result<std::vector<PrimaryKey>> {
+    if (!db_ || !db_->is_connected()) {
+        return Result<std::vector<PrimaryKey>>(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    std::vector<PrimaryKey> ids;
+    ids.reserve(entities.size());
+
+    auto tx_result = db_->transaction([&]() -> VoidResult {
+        for (const auto& entity : entities) {
+            auto insert_result = insert(entity);
+            if (insert_result.is_err()) {
+                return VoidResult(insert_result.error());
+            }
+            ids.push_back(insert_result.value());
+        }
+        return kcenon::common::ok();
+    });
+
+    if (tx_result.is_err()) {
+        return Result<std::vector<PrimaryKey>>(tx_result.error());
+    }
+
+    return Result<std::vector<PrimaryKey>>(std::move(ids));
+}
+
+template <typename Entity, typename PrimaryKey>
+template <typename Func>
+auto base_repository<Entity, PrimaryKey>::in_transaction(Func&& func)
+    -> std::invoke_result_t<Func> {
+    if (!db_ || !db_->is_connected()) {
+        using ResultType = std::invoke_result_t<Func>;
+        return ResultType(kcenon::common::error_info{
+            -1, "Database not connected", "storage"});
+    }
+
+    return db_->transaction(std::forward<Func>(func));
+}
+
+// =============================================================================
+// Protected Utility Methods
+// =============================================================================
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::select_columns() const
+    -> std::vector<std::string> {
+    return {"*"};
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::query_builder()
+    -> database::query_builder {
+    return db_->create_query_builder();
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::db()
+    -> std::shared_ptr<pacs_database_adapter> {
+    return db_;
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::table_name() const
+    -> const std::string& {
+    return table_name_;
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::pk_column() const
+    -> const std::string& {
+    return pk_column_;
+}
+
+}  // namespace pacs::storage

--- a/include/pacs/storage/repository_factory.hpp
+++ b/include/pacs/storage/repository_factory.hpp
@@ -1,0 +1,194 @@
+/**
+ * @file repository_factory.hpp
+ * @brief Factory for creating repository instances
+ *
+ * This file provides a factory class for creating repository instances with
+ * a shared database adapter. This ensures consistent database connection
+ * management across all repositories and simplifies dependency injection.
+ *
+ * @see Issue #607 - Phase 2: Base Repository Pattern Implementation
+ * @see Epic #605 - Migrate Direct Database Access to database_system
+ * Abstraction
+ */
+
+#pragma once
+
+#include <memory>
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+
+namespace pacs::storage {
+
+// Forward declarations
+class pacs_database_adapter;
+class job_repository;
+class annotation_repository;
+class routing_repository;
+class node_repository;
+class sync_repository;
+class key_image_repository;
+class measurement_repository;
+class viewer_state_repository;
+class prefetch_repository;
+
+/**
+ * @brief Factory for creating repository instances with shared database
+ * adapter
+ *
+ * The repository_factory provides a centralized way to create and manage
+ * repository instances. It ensures that all repositories share the same
+ * database adapter instance, which is important for:
+ * - Connection pooling
+ * - Transaction management across repositories
+ * - Consistent configuration
+ *
+ * Repositories are lazy-initialized on first access and cached for subsequent
+ * calls.
+ *
+ * **Thread Safety:** This class is NOT thread-safe. If you need concurrent
+ * access, either:
+ * - Create separate factory instances per thread
+ * - Use external synchronization (mutex)
+ * - Pre-initialize all repositories before sharing
+ *
+ * @example
+ * @code
+ * // Create database adapter
+ * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
+ * db->connect();
+ *
+ * // Create factory
+ * repository_factory factory(db);
+ *
+ * // Get repositories
+ * auto jobs = factory.jobs();
+ * auto annotations = factory.annotations();
+ *
+ * // Use repositories
+ * auto result = jobs->find_by_id(123);
+ *
+ * // All repositories share the same database connection
+ * // Transactions can span multiple repositories:
+ * db->transaction([&]() -> VoidResult {
+ *     jobs->insert(new_job);
+ *     annotations->insert(new_annotation);
+ *     return kcenon::common::ok();
+ * });
+ * @endcode
+ */
+class repository_factory {
+public:
+    /**
+     * @brief Construct factory with database adapter
+     *
+     * @param db Shared pointer to database adapter
+     */
+    explicit repository_factory(std::shared_ptr<pacs_database_adapter> db);
+
+    /// Default destructor
+    ~repository_factory() = default;
+
+    // Non-copyable
+    repository_factory(const repository_factory&) = delete;
+    auto operator=(const repository_factory&) -> repository_factory& = delete;
+
+    // Movable
+    repository_factory(repository_factory&&) noexcept = default;
+    auto operator=(repository_factory&&) noexcept
+        -> repository_factory& = default;
+
+    /**
+     * @brief Get or create job repository
+     *
+     * Returns a cached instance if already created, otherwise creates a new
+     * instance.
+     *
+     * @return Shared pointer to job repository
+     */
+    [[nodiscard]] auto jobs() -> std::shared_ptr<job_repository>;
+
+    /**
+     * @brief Get or create annotation repository
+     *
+     * @return Shared pointer to annotation repository
+     */
+    [[nodiscard]] auto annotations() -> std::shared_ptr<annotation_repository>;
+
+    /**
+     * @brief Get or create routing repository
+     *
+     * @return Shared pointer to routing repository
+     */
+    [[nodiscard]] auto routing_rules() -> std::shared_ptr<routing_repository>;
+
+    /**
+     * @brief Get or create node repository
+     *
+     * @return Shared pointer to node repository
+     */
+    [[nodiscard]] auto nodes() -> std::shared_ptr<node_repository>;
+
+    /**
+     * @brief Get or create sync repository
+     *
+     * @return Shared pointer to sync repository
+     */
+    [[nodiscard]] auto sync_states() -> std::shared_ptr<sync_repository>;
+
+    /**
+     * @brief Get or create key image repository
+     *
+     * @return Shared pointer to key image repository
+     */
+    [[nodiscard]] auto key_images() -> std::shared_ptr<key_image_repository>;
+
+    /**
+     * @brief Get or create measurement repository
+     *
+     * @return Shared pointer to measurement repository
+     */
+    [[nodiscard]] auto measurements()
+        -> std::shared_ptr<measurement_repository>;
+
+    /**
+     * @brief Get or create viewer state repository
+     *
+     * @return Shared pointer to viewer state repository
+     */
+    [[nodiscard]] auto viewer_states()
+        -> std::shared_ptr<viewer_state_repository>;
+
+    /**
+     * @brief Get or create prefetch repository
+     *
+     * @return Shared pointer to prefetch repository
+     */
+    [[nodiscard]] auto prefetch_queue()
+        -> std::shared_ptr<prefetch_repository>;
+
+    /**
+     * @brief Get the database adapter
+     *
+     * @return Shared pointer to database adapter
+     */
+    [[nodiscard]] auto db() const -> std::shared_ptr<pacs_database_adapter>;
+
+private:
+    /// Shared database adapter
+    std::shared_ptr<pacs_database_adapter> db_;
+
+    /// Lazy-initialized repositories
+    std::shared_ptr<job_repository> jobs_;
+    std::shared_ptr<annotation_repository> annotations_;
+    std::shared_ptr<routing_repository> routing_rules_;
+    std::shared_ptr<node_repository> nodes_;
+    std::shared_ptr<sync_repository> sync_states_;
+    std::shared_ptr<key_image_repository> key_images_;
+    std::shared_ptr<measurement_repository> measurements_;
+    std::shared_ptr<viewer_state_repository> viewer_states_;
+    std::shared_ptr<prefetch_repository> prefetch_queue_;
+};
+
+}  // namespace pacs::storage
+
+#endif  // PACS_WITH_DATABASE_SYSTEM

--- a/src/storage/repository_factory.cpp
+++ b/src/storage/repository_factory.cpp
@@ -1,0 +1,99 @@
+/**
+ * @file repository_factory.cpp
+ * @brief Implementation of repository factory
+ *
+ * @note This implementation is deferred to Phase 4 when individual repositories
+ *       are migrated to use pacs_database_adapter. Current repositories still
+ *       use sqlite3* directly.
+ *
+ * @see repository_factory.hpp
+ * @see Issue #607 - Phase 2: Base Repository Pattern Implementation
+ * @see Issue #610 - Phase 4: Repository Migrations (9 repositories)
+ */
+
+#include "pacs/storage/repository_factory.hpp"
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+
+#include "pacs/storage/pacs_database_adapter.hpp"
+
+// TODO(Issue #610): Uncomment these includes when repositories are migrated
+// #include "pacs/storage/annotation_repository.hpp"
+// #include "pacs/storage/job_repository.hpp"
+// #include "pacs/storage/key_image_repository.hpp"
+// #include "pacs/storage/measurement_repository.hpp"
+// #include "pacs/storage/node_repository.hpp"
+// #include "pacs/storage/prefetch_repository.hpp"
+// #include "pacs/storage/routing_repository.hpp"
+// #include "pacs/storage/sync_repository.hpp"
+// #include "pacs/storage/viewer_state_repository.hpp"
+
+namespace pacs::storage {
+
+repository_factory::repository_factory(
+    std::shared_ptr<pacs_database_adapter> db)
+    : db_(std::move(db)) {}
+
+// TODO(Issue #610): Implement these methods after repository migration
+// Currently, all repositories use sqlite3* directly and must be migrated
+// to accept std::shared_ptr<pacs_database_adapter> in their constructors.
+
+auto repository_factory::jobs() -> std::shared_ptr<job_repository> {
+    // TODO: Implement after job_repository migration
+    return nullptr;
+}
+
+auto repository_factory::annotations()
+    -> std::shared_ptr<annotation_repository> {
+    // TODO: Implement after annotation_repository migration
+    return nullptr;
+}
+
+auto repository_factory::routing_rules()
+    -> std::shared_ptr<routing_repository> {
+    // TODO: Implement after routing_repository migration
+    return nullptr;
+}
+
+auto repository_factory::nodes() -> std::shared_ptr<node_repository> {
+    // TODO: Implement after node_repository migration
+    return nullptr;
+}
+
+auto repository_factory::sync_states() -> std::shared_ptr<sync_repository> {
+    // TODO: Implement after sync_repository migration
+    return nullptr;
+}
+
+auto repository_factory::key_images()
+    -> std::shared_ptr<key_image_repository> {
+    // TODO: Implement after key_image_repository migration
+    return nullptr;
+}
+
+auto repository_factory::measurements()
+    -> std::shared_ptr<measurement_repository> {
+    // TODO: Implement after measurement_repository migration
+    return nullptr;
+}
+
+auto repository_factory::viewer_states()
+    -> std::shared_ptr<viewer_state_repository> {
+    // TODO: Implement after viewer_state_repository migration
+    return nullptr;
+}
+
+auto repository_factory::prefetch_queue()
+    -> std::shared_ptr<prefetch_repository> {
+    // TODO: Implement after prefetch_repository migration
+    return nullptr;
+}
+
+auto repository_factory::db() const
+    -> std::shared_ptr<pacs_database_adapter> {
+    return db_;
+}
+
+}  // namespace pacs::storage
+
+#endif  // PACS_WITH_DATABASE_SYSTEM

--- a/tests/storage/base_repository_test.cpp
+++ b/tests/storage/base_repository_test.cpp
@@ -1,0 +1,400 @@
+/**
+ * @file base_repository_test.cpp
+ * @brief Unit tests for base_repository template class
+ *
+ * Tests the generic repository pattern including CRUD operations,
+ * batch operations, and transaction support.
+ *
+ * @note These tests require unified_database_system to support SQLite backend.
+ *       Currently, unified_database_system only supports PostgreSQL.
+ *       Integration tests will SKIP until SQLite backend is implemented.
+ *
+ * @see Issue #607 - Phase 2: Base Repository Pattern Implementation
+ */
+
+#include <pacs/storage/base_repository.hpp>
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+
+#include <pacs/storage/pacs_database_adapter.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <filesystem>
+#include <memory>
+#include <string>
+
+using namespace pacs::storage;
+
+namespace {
+
+// =============================================================================
+// Test Entity and Repository
+// =============================================================================
+
+/**
+ * @brief Simple test entity for repository tests
+ */
+struct test_entity {
+    int64_t id{0};
+    std::string name;
+    int value{0};
+
+    auto operator==(const test_entity& other) const -> bool {
+        return id == other.id && name == other.name && value == other.value;
+    }
+};
+
+/**
+ * @brief Test repository implementation
+ */
+class test_repository : public base_repository<test_entity> {
+public:
+    explicit test_repository(std::shared_ptr<pacs_database_adapter> db)
+        : base_repository<test_entity>(db, "test_entities", "id") {}
+
+protected:
+    test_entity map_row_to_entity(const database_row& row) const override {
+        return test_entity{std::stoll(row.at("id")), row.at("name"),
+                           std::stoi(row.at("value"))};
+    }
+
+    std::map<std::string, database_value> entity_to_row(const test_entity& entity) const override {
+        return {{"name", entity.name},
+                {"value", static_cast<int64_t>(entity.value)}};
+    }
+
+    int64_t get_pk(const test_entity& entity) const override {
+        return entity.id;
+    }
+
+    bool has_pk(const test_entity& entity) const override {
+        return entity.id > 0;
+    }
+};
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+/**
+ * @brief Create test database path
+ */
+auto get_test_db_path() -> std::filesystem::path {
+    return std::filesystem::temp_directory_path() /
+           "base_repository_test.db";
+}
+
+/**
+ * @brief Clean up test database
+ */
+void cleanup_test_db() {
+    auto path = get_test_db_path();
+    std::filesystem::remove(path);
+    std::filesystem::remove(std::filesystem::path(path.string() + "-wal"));
+    std::filesystem::remove(std::filesystem::path(path.string() + "-shm"));
+}
+
+/**
+ * @brief RAII helper for test database cleanup
+ */
+struct test_db_guard {
+    test_db_guard() { cleanup_test_db(); }
+    ~test_db_guard() { cleanup_test_db(); }
+};
+
+/**
+ * @brief Check if SQLite backend is supported
+ */
+bool is_sqlite_backend_supported() {
+    pacs_database_adapter db(":memory:");
+    auto result = db.connect();
+    return result.is_ok();
+}
+
+/**
+ * @brief Skip message for unsupported SQLite backend
+ */
+constexpr const char* SQLITE_NOT_SUPPORTED_MSG =
+    "SQLite backend not yet supported by unified_database_system. "
+    "See database_system Issue for backend implementation.";
+
+/**
+ * @brief Create test table in database
+ */
+auto create_test_table(pacs_database_adapter& db) -> VoidResult {
+    auto create_sql = R"(
+        CREATE TABLE IF NOT EXISTS test_entities (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL,
+            value INTEGER DEFAULT 0
+        )
+    )";
+    return db.execute(create_sql);
+}
+
+}  // namespace
+
+// =============================================================================
+// Interface Tests (no connection required)
+// =============================================================================
+
+TEST_CASE("base_repository: construction", "[storage][repository][interface]") {
+    auto db = std::make_shared<pacs_database_adapter>(":memory:");
+    test_repository repo(db);
+
+    // Constructor should not throw
+    REQUIRE(true);
+}
+
+// =============================================================================
+// Integration Tests (require SQLite backend)
+// =============================================================================
+
+TEST_CASE("base_repository: basic CRUD operations",
+          "[storage][repository][integration]") {
+    if (!is_sqlite_backend_supported()) {
+        SKIP(SQLITE_NOT_SUPPORTED_MSG);
+    }
+
+    test_db_guard guard;
+    auto db = std::make_shared<pacs_database_adapter>(get_test_db_path());
+    REQUIRE(db->connect().is_ok());
+    REQUIRE(create_test_table(*db).is_ok());
+
+    test_repository repo(db);
+
+    SECTION("insert and find_by_id") {
+        test_entity entity{0, "test_name", 42};
+
+        auto insert_result = repo.insert(entity);
+        REQUIRE(insert_result.is_ok());
+
+        auto id = insert_result.value();
+        REQUIRE(id > 0);
+
+        auto find_result = repo.find_by_id(id);
+        REQUIRE(find_result.is_ok());
+
+        auto found = find_result.value();
+        REQUIRE(found.id == id);
+        REQUIRE(found.name == "test_name");
+        REQUIRE(found.value == 42);
+    }
+
+    SECTION("update existing entity") {
+        test_entity entity{0, "original", 10};
+        auto insert_result = repo.insert(entity);
+        REQUIRE(insert_result.is_ok());
+
+        auto id = insert_result.value();
+        test_entity updated{id, "updated", 20};
+
+        auto update_result = repo.update(updated);
+        REQUIRE(update_result.is_ok());
+
+        auto find_result = repo.find_by_id(id);
+        REQUIRE(find_result.is_ok());
+
+        auto found = find_result.value();
+        REQUIRE(found.name == "updated");
+        REQUIRE(found.value == 20);
+    }
+
+    SECTION("save with new entity (insert)") {
+        test_entity entity{0, "new_entity", 100};
+
+        auto save_result = repo.save(entity);
+        REQUIRE(save_result.is_ok());
+
+        auto id = save_result.value();
+        REQUIRE(id > 0);
+
+        auto find_result = repo.find_by_id(id);
+        REQUIRE(find_result.is_ok());
+    }
+
+    SECTION("save with existing entity (update)") {
+        test_entity entity{0, "entity", 50};
+        auto insert_result = repo.insert(entity);
+        REQUIRE(insert_result.is_ok());
+
+        auto id = insert_result.value();
+        test_entity existing{id, "modified", 60};
+
+        auto save_result = repo.save(existing);
+        REQUIRE(save_result.is_ok());
+        REQUIRE(save_result.value() == id);
+
+        auto find_result = repo.find_by_id(id);
+        REQUIRE(find_result.is_ok());
+        REQUIRE(find_result.value().name == "modified");
+    }
+
+    SECTION("remove entity") {
+        test_entity entity{0, "to_delete", 99};
+        auto insert_result = repo.insert(entity);
+        REQUIRE(insert_result.is_ok());
+
+        auto id = insert_result.value();
+
+        auto remove_result = repo.remove(id);
+        REQUIRE(remove_result.is_ok());
+
+        auto find_result = repo.find_by_id(id);
+        REQUIRE(find_result.is_err());
+    }
+}
+
+TEST_CASE("base_repository: query operations",
+          "[storage][repository][integration]") {
+    if (!is_sqlite_backend_supported()) {
+        SKIP(SQLITE_NOT_SUPPORTED_MSG);
+    }
+
+    test_db_guard guard;
+    auto db = std::make_shared<pacs_database_adapter>(get_test_db_path());
+    REQUIRE(db->connect().is_ok());
+    REQUIRE(create_test_table(*db).is_ok());
+
+    test_repository repo(db);
+
+    SECTION("find_all returns all entities") {
+        (void)repo.insert(test_entity{0, "entity1", 1});
+        (void)repo.insert(test_entity{0, "entity2", 2});
+        (void)repo.insert(test_entity{0, "entity3", 3});
+
+        auto result = repo.find_all();
+        REQUIRE(result.is_ok());
+        REQUIRE(result.value().size() == 3);
+    }
+
+    SECTION("find_all with limit") {
+        (void)repo.insert(test_entity{0, "entity1", 1});
+        (void)repo.insert(test_entity{0, "entity2", 2});
+        (void)repo.insert(test_entity{0, "entity3", 3});
+
+        auto result = repo.find_all(2);
+        REQUIRE(result.is_ok());
+        REQUIRE(result.value().size() == 2);
+    }
+
+    SECTION("find_where") {
+        (void)repo.insert(test_entity{0, "alice", 100});
+        (void)repo.insert(test_entity{0, "bob", 200});
+        (void)repo.insert(test_entity{0, "alice", 300});
+
+        auto result = repo.find_where("name", "=", "alice");
+        REQUIRE(result.is_ok());
+        REQUIRE(result.value().size() == 2);
+
+        for (const auto& entity : result.value()) {
+            REQUIRE(entity.name == "alice");
+        }
+    }
+
+    SECTION("exists") {
+        auto insert_result = repo.insert(test_entity{0, "exists_test", 42});
+        REQUIRE(insert_result.is_ok());
+
+        auto id = insert_result.value();
+
+        auto exists_result = repo.exists(id);
+        REQUIRE(exists_result.is_ok());
+        REQUIRE(exists_result.value() == true);
+
+        auto not_exists_result = repo.exists(99999);
+        REQUIRE(not_exists_result.is_ok());
+        REQUIRE(not_exists_result.value() == false);
+    }
+
+    SECTION("count") {
+        (void)repo.insert(test_entity{0, "entity1", 1});
+        (void)repo.insert(test_entity{0, "entity2", 2});
+
+        auto result = repo.count();
+        REQUIRE(result.is_ok());
+        REQUIRE(result.value() == 2);
+    }
+}
+
+TEST_CASE("base_repository: batch operations",
+          "[storage][repository][integration]") {
+    if (!is_sqlite_backend_supported()) {
+        SKIP(SQLITE_NOT_SUPPORTED_MSG);
+    }
+
+    test_db_guard guard;
+    auto db = std::make_shared<pacs_database_adapter>(get_test_db_path());
+    REQUIRE(db->connect().is_ok());
+    REQUIRE(create_test_table(*db).is_ok());
+
+    test_repository repo(db);
+
+    SECTION("insert_batch") {
+        std::vector<test_entity> entities = {
+            {0, "batch1", 1}, {0, "batch2", 2}, {0, "batch3", 3}};
+
+        auto result = repo.insert_batch(entities);
+        REQUIRE(result.is_ok());
+        REQUIRE(result.value().size() == 3);
+
+        auto count_result = repo.count();
+        REQUIRE(count_result.is_ok());
+        REQUIRE(count_result.value() == 3);
+    }
+
+    SECTION("in_transaction with success") {
+        auto result = repo.in_transaction([&]() -> VoidResult {
+            auto r1 = repo.insert(test_entity{0, "tx1", 1});
+            if (r1.is_err()) {
+                return VoidResult(r1.error());
+            }
+
+            auto r2 = repo.insert(test_entity{0, "tx2", 2});
+            if (r2.is_err()) {
+                return VoidResult(r2.error());
+            }
+
+            return kcenon::common::ok();
+        });
+
+        REQUIRE(result.is_ok());
+
+        auto count_result = repo.count();
+        REQUIRE(count_result.is_ok());
+        REQUIRE(count_result.value() == 2);
+    }
+}
+
+TEST_CASE("base_repository: error handling",
+          "[storage][repository][integration]") {
+    if (!is_sqlite_backend_supported()) {
+        SKIP(SQLITE_NOT_SUPPORTED_MSG);
+    }
+
+    test_db_guard guard;
+    auto db = std::make_shared<pacs_database_adapter>(get_test_db_path());
+    REQUIRE(db->connect().is_ok());
+    REQUIRE(create_test_table(*db).is_ok());
+
+    test_repository repo(db);
+
+    SECTION("find_by_id with non-existent id") {
+        auto result = repo.find_by_id(99999);
+        REQUIRE(result.is_err());
+    }
+
+    SECTION("update entity without valid primary key") {
+        test_entity entity{0, "no_pk", 42};
+        auto result = repo.update(entity);
+        REQUIRE(result.is_err());
+    }
+
+    SECTION("remove non-existent entity") {
+        auto result = repo.remove(99999);
+        REQUIRE(result.is_err());
+    }
+}
+
+#endif  // PACS_WITH_DATABASE_SYSTEM


### PR DESCRIPTION
## Summary
Implement generic base_repository template class for common CRUD operations using pacs_database_adapter. This foundation enables consistent data access patterns across repositories and eliminates code duplication.

## Implementation

### Core Components
- **base_repository.hpp**: Template class with CRUD interface
- **base_repository_impl.hpp**: Template method implementations  
- **repository_factory.hpp**: Factory for repository instances
- **repository_factory.cpp**: Stub implementation for Phase 4
- **base_repository_test.cpp**: Unit tests for base repository

### Features
- Generic CRUD operations (find, save, update, remove)
- Transaction support via pacs_database_adapter
- Batch operations for bulk inserts
- Query builder integration for type-safe queries
- Result<T> error handling
- Extensible design for domain-specific operations

### Technical Details
- Uses C++20 template metaprogramming
- Supports integral and string primary key types
- Maps database rows to domain entities via virtual methods
- Integrates with database_system query builder API

### Factory Implementation Note
Repository factory methods currently return `nullptr` (stub) until Phase 4 when individual repositories are migrated to use `pacs_database_adapter`. Current repositories still use `sqlite3*` directly.

## Testing
- Base repository unit tests implemented
- Tests SKIP if SQLite backend not supported by unified_database_system
- Build verified successfully

## Test Plan
- Build passes: `cmake --build build --config Release`
- Unit tests run: `./build/bin/storage_tests`
- All existing tests pass

## Related Issues
Closes #607
Part of #605 (Epic: Migrate Direct Database Access to database_system Abstraction)