### PR TITLE
docs(storage): unify cloud storage status terminology across documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 - AI service connector for external inference endpoints
 - AI result handler (SR, SEG, PR DICOM object processing)
 
-**Cloud Storage**:
-- S3 cloud storage (mock implementation for API validation)
-- Azure Blob storage (mock implementation for API validation)
+**Cloud Storage** *(Mock Implementation — Full SDK integration planned for Phase 5)*:
+- S3 cloud storage (mock in-memory client for API validation; no AWS SDK dependency)
+- Azure Blob storage (mock in-memory client for API validation; no Azure SDK dependency)
 - Hierarchical Storage Management (HSM) with three-tier storage (Hot/Warm/Cold)
 
 **Monitoring**:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -113,7 +113,7 @@ New DICOM services and SOP classes can be added without modifying existing code:
 - Service handlers implement a common interface
 - SOP classes registered in dictionary
 - Transfer syntaxes pluggable as codecs
-- Storage backends implement abstract interface
+- Storage backends implement abstract interface (File, DB, S3/Azure mock — full SDK Phase 5)
 
 ### Performance
 

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -744,15 +744,15 @@ An optional V2 implementation using `network_system::messaging_server` is availa
 
 ### IR-8: AWS SDK Integration
 
-| System | Integration Type | Purpose | Phase |
-|--------|-----------------|---------|-------|
-| **AWS SDK for C++** | Cloud Storage | S3 storage backend operations | 4 |
+| System | Integration Type | Purpose | Phase | Status |
+|--------|-----------------|---------|-------|--------|
+| **AWS SDK for C++** | Cloud Storage | S3 storage backend operations | 5 | Mock implemented (Phase 4); Full SDK planned (Phase 5) |
 
 ### IR-9: Azure SDK Integration
 
-| System | Integration Type | Purpose | Phase |
-|--------|-----------------|---------|-------|
-| **Azure SDK for C++** | Cloud Storage | Blob Storage backend operations | 4 |
+| System | Integration Type | Purpose | Phase | Status |
+|--------|-----------------|---------|-------|--------|
+| **Azure SDK for C++** | Cloud Storage | Blob Storage backend operations | 5 | Mock implemented (Phase 4); Full SDK planned (Phase 5) |
 
 ---
 

--- a/docs/VERIFICATION_REPORT.md
+++ b/docs/VERIFICATION_REPORT.md
@@ -162,8 +162,8 @@ The verification was conducted through static code analysis, documentation revie
 | monitoring_system | SRS-INT-006 | `monitoring_adapter.hpp/cpp` (508 lines) | ✅ Complete |
 | ITK/VTK | SRS-INT-007 | - | 🔜 Planned (Phase 5) |
 | Crow REST Framework | SRS-INT-008 | `web_server.hpp/cpp`, Crow integration | ✅ Complete |
-| AWS SDK | SRS-INT-009 | - | 🔜 Planned (Phase 4) |
-| Azure SDK | SRS-INT-010 | - | 🔜 Planned (Phase 4) |
+| AWS SDK | SRS-INT-009 | `s3_storage.hpp/cpp` (mock client) | ✅ Mock Implemented (Full SDK Phase 5) |
+| Azure SDK | SRS-INT-010 | `azure_blob_storage.hpp/cpp` (mock client) | ✅ Mock Implemented (Full SDK Phase 5) |
 
 **Verification Evidence:**
 - `dicom_session.hpp/cpp` (404 lines) provides high-level session management
@@ -498,7 +498,7 @@ tests/
 |----------|----------------|
 | **High** | Add JPEG compression support (Transfer Syntax 1.2.840.10008.1.2.4.50) |
 | **Medium** | Implement connection pooling for SCU operations |
-| **Low** | Cloud storage backend (S3/Azure Blob) |
+| **Low** | Cloud storage full SDK integration (S3/Azure Blob) — mock implementations complete, production SDK planned Phase 5 |
 
 > **Note:** The following have been implemented:
 > - ✅ Explicit VR Big Endian transfer syntax (Issue #126)


### PR DESCRIPTION
Closes #687

## Summary
- Standardize S3 and Azure Blob Storage terminology across all project documents
- All documents now consistently describe these as **mock implementations** (in-memory) with **full SDK integration planned for Phase 5**
- Fix incorrect Phase references (Phase 4 → Phase 5) for full SDK integration requirements

## Changes by Document

| Document | Before | After |
|----------|--------|-------|
| `VERIFICATION_REPORT.md` | AWS/Azure SDK: "Planned (Phase 4)" | "Mock Implemented (Full SDK Phase 5)" with file references |
| `PRD.md` | IR-8/IR-9: Phase 4, no status | Phase 5, explicit mock/full SDK status |
| `README.md` | "mock implementation for API validation" | "mock in-memory client; no AWS/Azure SDK dependency" + Phase 5 note in header |
| `ARCHITECTURE.md` | "Storage backends implement abstract interface" | Added "(File, DB, S3/Azure mock — full SDK Phase 5)" |
| `FEATURES.md` | Already clear (no change) | N/A |

## Unified Terminology

All documents now use this consistent pattern:
- **Current state**: Mock implementation (in-memory client, no real SDK dependency)
- **Future plan**: Full SDK integration planned for Phase 5

## Test Plan
- [x] Verified source code confirms mock status (`mock_s3_client`, `mock_azure_client`)
- [x] No document implies real cloud connectivity exists
- [x] Phase 5 SDK integration referenced in all relevant documents
- [ ] Verify markdown tables render correctly on GitHub