### PR TITLE
docs(integration): reconcile ITK adapter status with phase designation (#690)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 | **Phase 1**: Foundation | DICOM Core, Tag Dictionary, File I/O (Part 10), Transfer Syntax | ✅ Complete |
 | **Phase 2**: Network Protocol | Upper Layer Protocol (PDU), Association State Machine, DIMSE-C, Compression Codecs | ✅ Complete |
 | **Phase 3**: Core Services | Storage SCP/SCU, File Storage, Index Database, Query/Retrieve, Logging, Monitoring | ✅ Complete |
-| **Phase 4**: Advanced Services | REST API, DICOMweb, AI Integration, Client Module, Cloud Storage (mock), Security, Workflow, Annotation/Viewer | ✅ Complete |
-| **Phase 5**: Enterprise Features | Full AWS/Azure SDK, ITK/VTK, FHIR, Clustering, Connection Pooling | 🔜 Planned |
+| **Phase 4**: Advanced Services | REST API, DICOMweb, AI Integration, Client Module, Cloud Storage (mock), Security, Workflow, Annotation/Viewer, ITK Adapter (optional) | ✅ Complete |
+| **Phase 5**: Enterprise Features | Full AWS/Azure SDK, VTK Integration, FHIR, Clustering, Connection Pooling | 🔜 Planned |
 
 **Test Coverage**: 1,837+ tests passing across 128 test files
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1083,6 +1083,20 @@ storage_scp scp_via_di(logger);
 - Storage throughput (MB/s)
 - Error rates
 
+### ITK Adapter (Optional)
+
+**Purpose**: DICOM-to-ITK image conversion for medical image analysis.
+
+**Build**: Conditional compilation via `PACS_BUILD_ITK_ADAPTER` CMake option (OFF by default, requires ITK installation).
+
+**Features**:
+- DICOM dataset to ITK image conversion (`dataset_to_image<>()` template)
+- DICOM series to 3D volume reconstruction (`series_to_image()`)
+- CT Hounsfield Unit conversion (`apply_hounsfield_conversion()`)
+- Metadata extraction (spatial information, orientation, position)
+- Type aliases for common medical images (`ct_image_type`, `mr_image_type`)
+- Convenience loaders: `load_ct_series()`, `load_mr_series()`
+
 ---
 
 ## Security Features
@@ -1784,7 +1798,7 @@ pacs::Result<std::string> get_patient_name(const std::filesystem::path& path) {
 | Clustering | Multi-node PACS | Phase 5 |
 | Full AWS S3 SDK | Production AWS S3 integration (replace mock) | Phase 5 |
 | Full Azure SDK | Production Azure Blob Storage integration (replace mock) | Phase 5 |
-| ITK/VTK Integration | Advanced image processing and 3D reconstruction | Phase 5 |
+| VTK Integration | 3D visualization and advanced processing pipelines (extends existing ITK adapter) | Phase 5 |
 | FHIR Integration | Healthcare interop | Phase 5 |
 
 ---

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -732,9 +732,10 @@ An optional V2 implementation using `network_system::messaging_server` is availa
 
 ### IR-6: ITK/VTK Integration
 
-| System | Integration Type | Purpose | Phase |
-|--------|-----------------|---------|-------|
-| **ITK/VTK** | Image Processing | Advanced medical image processing and 3D reconstruction | 5 |
+| System | Integration Type | Purpose | Phase | Status |
+|--------|-----------------|---------|-------|--------|
+| **ITK** | Image Processing | DICOM-to-ITK image conversion, Hounsfield transform, series loading (conditional build via `PACS_WITH_ITK`) | 4 | ✅ Implemented |
+| **VTK** | 3D Visualization | Advanced 3D reconstruction and visualization pipelines | 5 | Planned |
 
 ### IR-7: Crow REST Framework Integration
 
@@ -814,8 +815,8 @@ The following table provides a unified overview of all development phases. This 
 | **1** | Foundation | DICOM Core: Data Elements, Data Sets, File I/O (Part 10), Tag Dictionary, Transfer Syntax | ✅ Complete |
 | **2** | Network Protocol | Upper Layer Protocol (PDU), Association State Machine, DIMSE-C basics (C-ECHO, C-STORE), Compression Codecs | ✅ Complete |
 | **3** | Core Services | Storage SCP/SCU, File Storage Backend, Index Database, Query/Retrieve (C-FIND, C-MOVE, C-GET), Logging, Monitoring | ✅ Complete |
-| **4** | Advanced Services & Production Hardening | Worklist, MPPS, DIMSE-N, TLS, REST API, DICOMweb, AI Integration, Client Module, Cloud Storage (mock), Security (RBAC, Anonymization, Digital Signatures), Workflow (Prefetch, Scheduler, Study Lock), Additional SOP Classes, Object Pools, SIMD, Annotation/Viewer | ✅ Complete |
-| **5** | Enterprise Features | Full AWS/Azure SDK, ITK/VTK, FHIR, Clustering, Connection Pooling | Planned |
+| **4** | Advanced Services & Production Hardening | Worklist, MPPS, DIMSE-N, TLS, REST API, DICOMweb, AI Integration, Client Module, Cloud Storage (mock), Security (RBAC, Anonymization, Digital Signatures), Workflow (Prefetch, Scheduler, Study Lock), Additional SOP Classes, Object Pools, SIMD, Annotation/Viewer, ITK Adapter (optional) | ✅ Complete |
+| **5** | Enterprise Features | Full AWS/Azure SDK, VTK Integration, FHIR, Clustering, Connection Pooling | Planned |
 
 **Cross-Reference**: PRD phases map to SRS requirement phases (SRS-CORE-* → Phase 1, SRS-NET-*/SRS-ENC-* → Phase 2, SRS-SVC-* → Phase 3, SRS-WF-*/SRS-SEC-*/SRS-WEB-* → Phase 4, SRS-INT-007 → Phase 5).
 
@@ -881,6 +882,7 @@ The following table provides a unified overview of all development phases. This 
 | Workflow | Auto Prefetch, Task Scheduler, Study Lock | Automated operations | ✅ Complete |
 | Monitoring | DICOM metrics, Object Pool, Health Checks | Production observability | ✅ Complete |
 | Annotation/Viewer | Annotation, Viewer State, Key Image, Measurement | Clinical data management | ✅ Complete |
+| ITK Adapter | DICOM-to-ITK image conversion (optional, `PACS_WITH_ITK`) | CT/MR series loading, Hounsfield conversion | ✅ Complete |
 
 **Dependencies**: All systems
 
@@ -892,7 +894,7 @@ The following table provides a unified overview of all development phases. This 
 |-------------|-------------|---------------------|
 | Full AWS S3 SDK | Production S3 integration | Replace mock implementation |
 | Full Azure SDK | Production Azure Blob integration | Replace mock implementation |
-| ITK/VTK Integration | Advanced image processing and 3D reconstruction | Image analysis pipeline |
+| VTK Integration | 3D reconstruction and advanced visualization pipelines (extends existing ITK adapter) | VTK rendering, volume rendering |
 | FHIR Integration | HL7 FHIR interoperability | Healthcare data exchange |
 | Clustering | Multi-node PACS deployment | Horizontal scaling |
 | Connection Pooling | Reuse DICOM associations | Reduced latency |


### PR DESCRIPTION
Closes #690

## Summary
- Adopted **Option C**: Split "ITK/VTK" into separately tracked items
- **ITK Adapter** moved to Phase 4 (already implemented: `itk_adapter.hpp/cpp`, conditional `PACS_WITH_ITK`)
- **VTK Integration** remains in Phase 5 with clarified scope (3D visualization, volume rendering)
- Added ITK Adapter feature documentation to FEATURES.md Ecosystem Integration section

## Changes

### PRD.md
| Section | Change |
|---------|--------|
| IR-6 table | Split into ITK (Phase 4, implemented) and VTK (Phase 5, planned) with Status column |
| Phase overview table | Added "ITK Adapter (optional)" to Phase 4, changed Phase 5 "ITK/VTK" to "VTK Integration" |
| Phase 4 deliverables | Added ITK Adapter row with description and acceptance criteria |
| Phase 5 deliverables | Changed "ITK/VTK Integration" to "VTK Integration" with clarified scope |

### FEATURES.md
| Section | Change |
|---------|--------|
| Ecosystem Integration | Added new "ITK Adapter (Optional)" subsection documenting existing features |
| Roadmap | Updated Phase 5 entry from "ITK/VTK" to "VTK Integration" |

### README.md
| Section | Change |
|---------|--------|
| Phase table | Phase 4 scope includes ITK Adapter, Phase 5 shows VTK only |

## Context
The ITK adapter is already fully implemented (`include/pacs/integration/itk_adapter.hpp`, `src/integration/itk_adapter.cpp`) with:
- Template DICOM-to-ITK image conversion
- DICOM series to 3D volume reconstruction
- CT Hounsfield Unit conversion
- Convenience loaders for CT/MR series

However, all documentation listed "ITK/VTK integration" as a Phase 5 planned item, creating confusion about whether this work was already done.

## Test Plan
- [x] No implemented feature listed under a future phase without clarification
- [x] Phase 5 VTK scope clearly describes what remains beyond existing ITK adapter
- [x] Documentation-only change; no build/test impact