### PR TITLE
feat(encoding): add DICOM character set registry and ISO 2022 parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,6 +766,7 @@ add_library(pacs_encoding
     src/encoding/implicit_vr_codec.cpp
     src/encoding/explicit_vr_codec.cpp
     src/encoding/explicit_vr_big_endian_codec.cpp
+    src/encoding/character_set.cpp
     src/encoding/compression/jpeg_baseline_codec.cpp
     src/encoding/compression/jpeg_lossless_codec.cpp
     src/encoding/compression/jpeg2000_codec.cpp
@@ -781,6 +782,14 @@ target_include_directories(pacs_encoding
 target_link_libraries(pacs_encoding
     PUBLIC pacs_core
 )
+
+# Link iconv for character set conversion (required on macOS, optional on Linux)
+if(NOT WIN32)
+    find_library(ICONV_LIBRARY iconv)
+    if(ICONV_LIBRARY)
+        target_link_libraries(pacs_encoding PUBLIC ${ICONV_LIBRARY})
+    endif()
+endif()
 
 # Link libjpeg-turbo for JPEG compression codecs
 if(PACS_JPEG_FOUND)
@@ -1696,6 +1705,7 @@ if(PACS_BUILD_TESTS)
         tests/encoding/compression/jpeg_ls_codec_test.cpp
         tests/encoding/compression/rle_codec_test.cpp
         tests/encoding/simd/simd_rle_test.cpp
+        tests/encoding/character_set_test.cpp
     )
     target_link_libraries(encoding_tests
         PRIVATE

--- a/include/pacs/encoding/character_set.hpp
+++ b/include/pacs/encoding/character_set.hpp
@@ -1,0 +1,217 @@
+/**
+ * @file character_set.hpp
+ * @brief DICOM Character Set registry, ISO 2022 parser, and string decoder
+ *
+ * Provides support for decoding DICOM strings encoded with CJK character sets
+ * (Korean, Japanese, Chinese) using ISO 2022 escape sequence-based code extensions
+ * as specified in DICOM PS3.5 Section 6.1 and PS3.3 Annex C.12.1.1.2.
+ *
+ * Supported character sets:
+ * - ISO-IR 6 (ASCII, default repertoire)
+ * - ISO-IR 100 (Latin-1, Western European)
+ * - ISO-IR 192 (UTF-8, Unicode)
+ * - ISO-IR 149 (Korean, KS X 1001 / EUC-KR)
+ * - ISO-IR 87 (Japanese Kanji, JIS X 0208)
+ * - ISO-IR 13 (Japanese Katakana, JIS X 0201)
+ * - ISO-IR 58 (Chinese, GB2312)
+ *
+ * @see DICOM PS3.5 Section 6.1 - Support of Character Repertoires
+ * @see DICOM PS3.3 Section C.12.1.1.2 - Specific Character Set
+ */
+
+#ifndef PACS_ENCODING_CHARACTER_SET_HPP
+#define PACS_ENCODING_CHARACTER_SET_HPP
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::encoding {
+
+/**
+ * @brief Information about a DICOM character set
+ *
+ * Maps a DICOM Defined Term (e.g., "ISO 2022 IR 149") to its encoding
+ * parameters needed for string conversion.
+ */
+struct character_set_info {
+    std::string_view defined_term;     ///< DICOM Defined Term (e.g., "ISO 2022 IR 149")
+    std::string_view description;      ///< Human-readable name (e.g., "Korean (KS X 1001)")
+    std::string_view iso_ir;           ///< ISO-IR designation (e.g., "ISO-IR 149")
+    bool uses_code_extensions;         ///< true if ISO 2022 escape sequences are used
+    std::string_view escape_sequence;  ///< Raw escape sequence bytes (empty if none)
+    std::string_view encoding_name;    ///< Platform encoding name for iconv (e.g., "EUC-KR")
+    bool is_multi_byte;               ///< true if characters can be multi-byte
+};
+
+/// @name Character Set Registry
+/// @{
+
+/**
+ * @brief Look up character set info by DICOM Defined Term.
+ * @param defined_term The DICOM Defined Term (e.g., "ISO 2022 IR 149", "ISO_IR 100")
+ * @return Pointer to character_set_info, or nullptr if not found
+ *
+ * Supports both forms: "ISO_IR 100" (without code extensions) and
+ * "ISO 2022 IR 149" (with code extensions).
+ */
+[[nodiscard]] const character_set_info* find_character_set(
+    std::string_view defined_term) noexcept;
+
+/**
+ * @brief Look up character set info by ISO-IR number.
+ * @param iso_ir_number The ISO-IR number (e.g., 149, 87, 100)
+ * @return Pointer to character_set_info, or nullptr if not found
+ */
+[[nodiscard]] const character_set_info* find_character_set_by_ir(
+    int iso_ir_number) noexcept;
+
+/**
+ * @brief Get the default character set (ISO-IR 6, ASCII).
+ * @return Reference to the ASCII character set info
+ */
+[[nodiscard]] const character_set_info& default_character_set() noexcept;
+
+/**
+ * @brief Get all registered character sets.
+ * @return Vector of pointers to all registered character_set_info entries
+ */
+[[nodiscard]] std::vector<const character_set_info*> all_character_sets() noexcept;
+
+/// @}
+
+/// @name Specific Character Set Parsing
+/// @{
+
+/**
+ * @brief Parsed representation of a multi-valued Specific Character Set.
+ *
+ * DICOM Specific Character Set (0008,0005) can be multi-valued with
+ * backslash separators. The first value is the default character set
+ * for G0, and subsequent values define character sets used via
+ * ISO 2022 escape sequences.
+ *
+ * Example: "\\ISO 2022 IR 149" means:
+ * - Component 0: empty → ASCII (ISO-IR 6) default
+ * - Component 1: ISO 2022 IR 149 → Korean
+ */
+struct specific_character_set {
+    /// Character set for default (G0) repertoire
+    const character_set_info* default_set;
+
+    /// Additional character sets activated by escape sequences
+    std::vector<const character_set_info*> extension_sets;
+
+    /// Whether this uses ISO 2022 code extensions
+    [[nodiscard]] bool uses_extensions() const noexcept;
+
+    /// Whether this is a single-byte-only configuration
+    [[nodiscard]] bool is_single_byte_only() const noexcept;
+
+    /// Check if UTF-8 is the active character set
+    [[nodiscard]] bool is_utf8() const noexcept;
+};
+
+/**
+ * @brief Parse a Specific Character Set (0008,0005) value.
+ * @param value The raw attribute value (e.g., "\\ISO 2022 IR 149")
+ * @return Parsed specific_character_set with resolved character set pointers
+ *
+ * Handles multi-valued strings separated by backslash ('\\').
+ * Empty first component defaults to ISO-IR 6 (ASCII).
+ * Unknown Defined Terms are skipped with a warning.
+ */
+[[nodiscard]] specific_character_set parse_specific_character_set(
+    std::string_view value);
+
+/// @}
+
+/// @name ISO 2022 Escape Sequence Detection
+/// @{
+
+/**
+ * @brief A text segment with its associated character set.
+ *
+ * Represents a contiguous portion of a DICOM string that uses
+ * a single character encoding. The decoder splits strings at
+ * escape sequence boundaries into these segments.
+ */
+struct text_segment {
+    std::string_view text;                 ///< The raw bytes of this segment
+    const character_set_info* charset;     ///< The character set for this segment
+};
+
+/**
+ * @brief Split a string into segments by ISO 2022 escape sequences.
+ * @param text The raw DICOM string bytes
+ * @param scs The parsed Specific Character Set configuration
+ * @return Vector of text segments, each with its character set
+ *
+ * Scans for ESC (0x1B) bytes, matches escape sequences against
+ * the configured character sets, and splits the text into segments.
+ * Segments between escape sequences inherit the previous character set.
+ */
+[[nodiscard]] std::vector<text_segment> split_by_escape_sequences(
+    std::string_view text,
+    const specific_character_set& scs);
+
+/// @}
+
+/// @name String Decoding
+/// @{
+
+/**
+ * @brief Decode a DICOM string to UTF-8 using the given character set.
+ * @param text The raw DICOM string bytes
+ * @param scs The Specific Character Set configuration
+ * @return UTF-8 encoded string
+ *
+ * This is the main entry point for character set conversion. It:
+ * 1. Checks if conversion is needed (UTF-8 passthrough)
+ * 2. Splits text by escape sequences (if ISO 2022)
+ * 3. Converts each segment to UTF-8
+ * 4. Concatenates the results
+ *
+ * If conversion fails for any segment, the raw bytes are passed through.
+ */
+[[nodiscard]] std::string decode_to_utf8(
+    std::string_view text,
+    const specific_character_set& scs);
+
+/**
+ * @brief Decode a single segment from a specific encoding to UTF-8.
+ * @param text The raw bytes in the source encoding
+ * @param charset The character set of the source bytes
+ * @return UTF-8 encoded string
+ *
+ * Uses platform iconv for encoding conversion. Falls back to
+ * raw bytes if conversion fails.
+ */
+[[nodiscard]] std::string convert_to_utf8(
+    std::string_view text,
+    const character_set_info& charset);
+
+/**
+ * @brief Decode a Person Name (PN) value to UTF-8.
+ * @param pn_value The raw PN value (may contain '=' component group separators)
+ * @param scs The Specific Character Set configuration
+ * @return UTF-8 encoded Person Name string
+ *
+ * PN values have up to three component groups separated by '=':
+ * - Alphabetic (single-byte)
+ * - Ideographic (multi-byte, e.g., kanji/hangul)
+ * - Phonetic (single-byte, e.g., romaji/jamo)
+ *
+ * Each component group is decoded independently.
+ */
+[[nodiscard]] std::string decode_person_name(
+    std::string_view pn_value,
+    const specific_character_set& scs);
+
+/// @}
+
+}  // namespace pacs::encoding
+
+#endif  // PACS_ENCODING_CHARACTER_SET_HPP

--- a/src/encoding/character_set.cpp
+++ b/src/encoding/character_set.cpp
@@ -1,0 +1,537 @@
+/**
+ * @file character_set.cpp
+ * @brief Implementation of DICOM Character Set registry, ISO 2022 parser, and decoder
+ */
+
+#include "pacs/encoding/character_set.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <iconv.h>
+#endif
+
+namespace pacs::encoding {
+
+// =============================================================================
+// Character Set Registry
+// =============================================================================
+
+namespace {
+
+// Escape sequence constants (raw bytes including ESC = 0x1B)
+constexpr char ESC = '\x1B';
+
+// Korean: ESC $ ) C
+constexpr std::string_view esc_ir_149{"\x1B\x24\x29\x43", 4};
+
+// Japanese Kanji: ESC $ B
+constexpr std::string_view esc_ir_87{"\x1B\x24\x42", 3};
+
+// Japanese Katakana: ESC ( J
+constexpr std::string_view esc_ir_13{"\x1B\x28\x4A", 3};
+
+// Chinese GB2312: ESC $ ) A
+constexpr std::string_view esc_ir_58{"\x1B\x24\x29\x41", 4};
+
+// ASCII return: ESC ( B
+constexpr std::string_view esc_ir_6{"\x1B\x28\x42", 3};
+
+// Latin-1: ESC - A
+constexpr std::string_view esc_ir_100{"\x1B\x2D\x41", 3};
+
+/// Static registry of supported character sets
+const std::array<character_set_info, 8> charset_registry = {{
+    {
+        "ISO_IR 6",             // defined_term
+        "ASCII (Default)",      // description
+        "ISO-IR 6",             // iso_ir
+        false,                  // uses_code_extensions
+        {},                     // escape_sequence (none for default)
+        "ASCII",                // encoding_name
+        false                   // is_multi_byte
+    },
+    {
+        "ISO_IR 100",
+        "Latin-1 (Western European)",
+        "ISO-IR 100",
+        false,
+        {},
+        "ISO-8859-1",
+        false
+    },
+    {
+        "ISO_IR 192",
+        "UTF-8 (Unicode)",
+        "ISO-IR 192",
+        false,
+        {},
+        "UTF-8",
+        true
+    },
+    {
+        "ISO 2022 IR 6",
+        "ASCII (Default, with extensions)",
+        "ISO-IR 6",
+        true,
+        esc_ir_6,
+        "ASCII",
+        false
+    },
+    {
+        "ISO 2022 IR 100",
+        "Latin-1 (with extensions)",
+        "ISO-IR 100",
+        true,
+        esc_ir_100,
+        "ISO-8859-1",
+        false
+    },
+    {
+        "ISO 2022 IR 149",
+        "Korean (KS X 1001)",
+        "ISO-IR 149",
+        true,
+        esc_ir_149,
+        "EUC-KR",
+        true
+    },
+    {
+        "ISO 2022 IR 87",
+        "Japanese Kanji (JIS X 0208)",
+        "ISO-IR 87",
+        true,
+        esc_ir_87,
+        "ISO-2022-JP",
+        true
+    },
+    {
+        "ISO 2022 IR 13",
+        "Japanese Katakana (JIS X 0201)",
+        "ISO-IR 13",
+        true,
+        esc_ir_13,
+        "JIS_X0201",
+        false
+    },
+}};
+
+// GB2312 is separate because it shares the same pattern as Korean
+const character_set_info charset_ir_58 = {
+    "ISO 2022 IR 58",
+    "Chinese (GB2312)",
+    "ISO-IR 58",
+    true,
+    esc_ir_58,
+    "GB2312",
+    true
+};
+
+const character_set_info* find_in_registry(std::string_view term) noexcept {
+    for (const auto& entry : charset_registry) {
+        if (entry.defined_term == term) {
+            return &entry;
+        }
+    }
+    if (charset_ir_58.defined_term == term) {
+        return &charset_ir_58;
+    }
+    return nullptr;
+}
+
+/// Map ISO-IR number to Defined Term for lookup
+const character_set_info* find_by_ir_number(int ir_number) noexcept {
+    switch (ir_number) {
+        case 6: return find_in_registry("ISO_IR 6");
+        case 100: return find_in_registry("ISO_IR 100");
+        case 192: return find_in_registry("ISO_IR 192");
+        case 149: return find_in_registry("ISO 2022 IR 149");
+        case 87: return find_in_registry("ISO 2022 IR 87");
+        case 13: return find_in_registry("ISO 2022 IR 13");
+        case 58: return &charset_ir_58;
+        default: return nullptr;
+    }
+}
+
+/// Find character set by its escape sequence
+const character_set_info* find_by_escape_sequence(
+    std::string_view text, size_t pos,
+    const specific_character_set& scs) noexcept {
+    // Check extension sets first (more specific)
+    for (const auto* cs : scs.extension_sets) {
+        if (cs && !cs->escape_sequence.empty()) {
+            auto esc_len = cs->escape_sequence.size();
+            if (pos + esc_len <= text.size() &&
+                text.substr(pos, esc_len) == cs->escape_sequence) {
+                return cs;
+            }
+        }
+    }
+    // Check ASCII return sequence
+    if (pos + esc_ir_6.size() <= text.size() &&
+        text.substr(pos, esc_ir_6.size()) == esc_ir_6) {
+        return scs.default_set;
+    }
+    return nullptr;
+}
+
+#ifdef _WIN32
+
+// Windows: use MultiByteToWideChar + WideCharToMultiByte
+std::string iconv_convert(std::string_view input,
+                          const character_set_info& charset) {
+    // Determine Windows code page
+    UINT code_page = CP_ACP;
+    if (charset.encoding_name == "EUC-KR") {
+        code_page = 949;
+    } else if (charset.encoding_name == "ISO-2022-JP") {
+        code_page = 50220;
+    } else if (charset.encoding_name == "GB2312") {
+        code_page = 936;
+    } else if (charset.encoding_name == "ISO-8859-1") {
+        code_page = 28591;
+    } else if (charset.encoding_name == "JIS_X0201") {
+        code_page = 50222;
+    } else if (charset.encoding_name == "ASCII" ||
+               charset.encoding_name == "UTF-8") {
+        return std::string(input);
+    }
+
+    // Convert to wide char
+    int wide_len = MultiByteToWideChar(
+        code_page, 0, input.data(), static_cast<int>(input.size()),
+        nullptr, 0);
+    if (wide_len <= 0) {
+        return std::string(input);  // fallback
+    }
+
+    std::wstring wide(static_cast<size_t>(wide_len), L'\0');
+    MultiByteToWideChar(
+        code_page, 0, input.data(), static_cast<int>(input.size()),
+        wide.data(), wide_len);
+
+    // Convert wide char to UTF-8
+    int utf8_len = WideCharToMultiByte(
+        CP_UTF8, 0, wide.data(), wide_len, nullptr, 0, nullptr, nullptr);
+    if (utf8_len <= 0) {
+        return std::string(input);  // fallback
+    }
+
+    std::string result(static_cast<size_t>(utf8_len), '\0');
+    WideCharToMultiByte(
+        CP_UTF8, 0, wide.data(), wide_len,
+        result.data(), utf8_len, nullptr, nullptr);
+
+    return result;
+}
+
+#else
+
+// POSIX: use iconv
+std::string iconv_convert(std::string_view input,
+                          const character_set_info& charset) {
+    if (charset.encoding_name == "ASCII" ||
+        charset.encoding_name == "UTF-8") {
+        return std::string(input);
+    }
+
+    iconv_t cd = iconv_open("UTF-8", charset.encoding_name.data());
+    if (cd == reinterpret_cast<iconv_t>(-1)) {
+        // Encoding not supported on this platform, return raw bytes
+        return std::string(input);
+    }
+
+    // iconv requires non-const input pointer
+    std::string input_copy(input);
+    char* in_ptr = input_copy.data();
+    size_t in_left = input_copy.size();
+
+    // Allocate output buffer (UTF-8 can be up to 4x the input size)
+    size_t out_size = input.size() * 4 + 4;
+    std::string output(out_size, '\0');
+    char* out_ptr = output.data();
+    size_t out_left = out_size;
+
+    size_t result = iconv(cd, &in_ptr, &in_left, &out_ptr, &out_left);
+    iconv_close(cd);
+
+    if (result == static_cast<size_t>(-1)) {
+        // Conversion failed, return raw bytes
+        return std::string(input);
+    }
+
+    output.resize(out_size - out_left);
+    return output;
+}
+
+#endif
+
+}  // anonymous namespace
+
+// =============================================================================
+// Public Registry Functions
+// =============================================================================
+
+const character_set_info* find_character_set(
+    std::string_view defined_term) noexcept {
+    return find_in_registry(defined_term);
+}
+
+const character_set_info* find_character_set_by_ir(
+    int iso_ir_number) noexcept {
+    return find_by_ir_number(iso_ir_number);
+}
+
+const character_set_info& default_character_set() noexcept {
+    // ISO_IR 6 (ASCII) is always the first entry
+    return charset_registry[0];
+}
+
+std::vector<const character_set_info*> all_character_sets() noexcept {
+    std::vector<const character_set_info*> result;
+    result.reserve(charset_registry.size() + 1);
+    for (const auto& entry : charset_registry) {
+        result.push_back(&entry);
+    }
+    result.push_back(&charset_ir_58);
+    return result;
+}
+
+// =============================================================================
+// Specific Character Set Parsing
+// =============================================================================
+
+bool specific_character_set::uses_extensions() const noexcept {
+    return !extension_sets.empty();
+}
+
+bool specific_character_set::is_single_byte_only() const noexcept {
+    if (default_set && default_set->is_multi_byte) {
+        return false;
+    }
+    for (const auto* cs : extension_sets) {
+        if (cs && cs->is_multi_byte) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool specific_character_set::is_utf8() const noexcept {
+    return default_set && default_set->defined_term == "ISO_IR 192";
+}
+
+specific_character_set parse_specific_character_set(std::string_view value) {
+    specific_character_set result;
+    result.default_set = &default_character_set();
+
+    if (value.empty()) {
+        return result;
+    }
+
+    // Split by backslash
+    std::vector<std::string_view> components;
+    size_t start = 0;
+    while (start <= value.size()) {
+        size_t pos = value.find('\\', start);
+        if (pos == std::string_view::npos) {
+            components.push_back(value.substr(start));
+            break;
+        }
+        components.push_back(value.substr(start, pos - start));
+        start = pos + 1;
+    }
+
+    if (components.empty()) {
+        return result;
+    }
+
+    // First component: default character set
+    auto first = components[0];
+    // Trim whitespace
+    while (!first.empty() && first.front() == ' ') first.remove_prefix(1);
+    while (!first.empty() && first.back() == ' ') first.remove_suffix(1);
+
+    if (!first.empty()) {
+        const auto* cs = find_in_registry(first);
+        if (cs) {
+            result.default_set = cs;
+        }
+    }
+    // Empty first component: ASCII default (already set)
+
+    // Remaining components: extension character sets
+    for (size_t i = 1; i < components.size(); ++i) {
+        auto term = components[i];
+        while (!term.empty() && term.front() == ' ') term.remove_prefix(1);
+        while (!term.empty() && term.back() == ' ') term.remove_suffix(1);
+
+        if (!term.empty()) {
+            const auto* cs = find_in_registry(term);
+            if (cs) {
+                result.extension_sets.push_back(cs);
+            }
+        }
+    }
+
+    return result;
+}
+
+// =============================================================================
+// ISO 2022 Escape Sequence Handling
+// =============================================================================
+
+std::vector<text_segment> split_by_escape_sequences(
+    std::string_view text,
+    const specific_character_set& scs) {
+
+    std::vector<text_segment> segments;
+
+    if (text.empty()) {
+        return segments;
+    }
+
+    // If no extensions, the entire text uses the default charset
+    if (!scs.uses_extensions()) {
+        segments.push_back({text, scs.default_set});
+        return segments;
+    }
+
+    const character_set_info* current_charset = scs.default_set;
+    size_t segment_start = 0;
+
+    for (size_t i = 0; i < text.size(); ++i) {
+        if (text[i] == ESC) {
+            // Try to match an escape sequence
+            const auto* new_charset = find_by_escape_sequence(text, i, scs);
+            if (new_charset) {
+                // Emit the segment before this escape sequence
+                if (i > segment_start) {
+                    segments.push_back({
+                        text.substr(segment_start, i - segment_start),
+                        current_charset
+                    });
+                }
+
+                // Skip the escape sequence
+                size_t esc_len = new_charset->escape_sequence.empty()
+                    ? esc_ir_6.size()  // ASCII return
+                    : new_charset->escape_sequence.size();
+                i += esc_len - 1;  // -1 because loop increments
+                segment_start = i + 1;
+                current_charset = new_charset;
+            }
+        }
+    }
+
+    // Emit the remaining segment
+    if (segment_start < text.size()) {
+        segments.push_back({
+            text.substr(segment_start),
+            current_charset
+        });
+    }
+
+    return segments;
+}
+
+// =============================================================================
+// String Decoding
+// =============================================================================
+
+std::string convert_to_utf8(
+    std::string_view text,
+    const character_set_info& charset) {
+
+    if (text.empty()) {
+        return {};
+    }
+
+    // ASCII and UTF-8 need no conversion
+    if (charset.encoding_name == "ASCII" ||
+        charset.encoding_name == "UTF-8") {
+        return std::string(text);
+    }
+
+    return iconv_convert(text, charset);
+}
+
+std::string decode_to_utf8(
+    std::string_view text,
+    const specific_character_set& scs) {
+
+    if (text.empty()) {
+        return {};
+    }
+
+    // Fast path: UTF-8 passthrough
+    if (scs.is_utf8()) {
+        return std::string(text);
+    }
+
+    // Fast path: single-byte charset without extensions
+    if (!scs.uses_extensions()) {
+        return convert_to_utf8(text, *scs.default_set);
+    }
+
+    // ISO 2022: split by escape sequences and convert each segment
+    auto segments = split_by_escape_sequences(text, scs);
+
+    std::string result;
+    result.reserve(text.size() * 2);
+
+    for (const auto& seg : segments) {
+        if (seg.charset) {
+            result += convert_to_utf8(seg.text, *seg.charset);
+        } else {
+            result.append(seg.text);
+        }
+    }
+
+    return result;
+}
+
+std::string decode_person_name(
+    std::string_view pn_value,
+    const specific_character_set& scs) {
+
+    if (pn_value.empty()) {
+        return {};
+    }
+
+    // Split by '=' into component groups
+    // (Alphabetic=Ideographic=Phonetic)
+    std::string result;
+    result.reserve(pn_value.size() * 2);
+
+    size_t start = 0;
+    bool first = true;
+
+    while (start <= pn_value.size()) {
+        size_t eq_pos = pn_value.find('=', start);
+        std::string_view group;
+        if (eq_pos == std::string_view::npos) {
+            group = pn_value.substr(start);
+            start = pn_value.size() + 1;
+        } else {
+            group = pn_value.substr(start, eq_pos - start);
+            start = eq_pos + 1;
+        }
+
+        if (!first) {
+            result += '=';
+        }
+        first = false;
+
+        // Decode each component group independently
+        result += decode_to_utf8(group, scs);
+    }
+
+    return result;
+}
+
+}  // namespace pacs::encoding

--- a/tests/encoding/character_set_test.cpp
+++ b/tests/encoding/character_set_test.cpp
@@ -1,0 +1,356 @@
+/**
+ * @file character_set_test.cpp
+ * @brief Unit tests for DICOM character set registry, ISO 2022 parser, and decoder
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "pacs/encoding/character_set.hpp"
+
+#include <cstring>
+
+using namespace pacs::encoding;
+
+// =============================================================================
+// Character Set Registry Tests
+// =============================================================================
+
+TEST_CASE("Character set registry lookup", "[encoding][charset]") {
+    SECTION("Find ASCII (ISO_IR 6)") {
+        const auto* cs = find_character_set("ISO_IR 6");
+        REQUIRE(cs != nullptr);
+        CHECK(cs->defined_term == "ISO_IR 6");
+        CHECK(cs->encoding_name == "ASCII");
+        CHECK_FALSE(cs->uses_code_extensions);
+        CHECK_FALSE(cs->is_multi_byte);
+    }
+
+    SECTION("Find Latin-1 (ISO_IR 100)") {
+        const auto* cs = find_character_set("ISO_IR 100");
+        REQUIRE(cs != nullptr);
+        CHECK(cs->defined_term == "ISO_IR 100");
+        CHECK(cs->encoding_name == "ISO-8859-1");
+        CHECK_FALSE(cs->uses_code_extensions);
+        CHECK_FALSE(cs->is_multi_byte);
+    }
+
+    SECTION("Find UTF-8 (ISO_IR 192)") {
+        const auto* cs = find_character_set("ISO_IR 192");
+        REQUIRE(cs != nullptr);
+        CHECK(cs->defined_term == "ISO_IR 192");
+        CHECK(cs->encoding_name == "UTF-8");
+        CHECK_FALSE(cs->uses_code_extensions);
+        CHECK(cs->is_multi_byte);
+    }
+
+    SECTION("Find Korean (ISO 2022 IR 149)") {
+        const auto* cs = find_character_set("ISO 2022 IR 149");
+        REQUIRE(cs != nullptr);
+        CHECK(cs->defined_term == "ISO 2022 IR 149");
+        CHECK(cs->encoding_name == "EUC-KR");
+        CHECK(cs->uses_code_extensions);
+        CHECK(cs->is_multi_byte);
+        CHECK_FALSE(cs->escape_sequence.empty());
+    }
+
+    SECTION("Find Japanese Kanji (ISO 2022 IR 87)") {
+        const auto* cs = find_character_set("ISO 2022 IR 87");
+        REQUIRE(cs != nullptr);
+        CHECK(cs->defined_term == "ISO 2022 IR 87");
+        CHECK(cs->encoding_name == "ISO-2022-JP");
+        CHECK(cs->uses_code_extensions);
+        CHECK(cs->is_multi_byte);
+    }
+
+    SECTION("Find Japanese Katakana (ISO 2022 IR 13)") {
+        const auto* cs = find_character_set("ISO 2022 IR 13");
+        REQUIRE(cs != nullptr);
+        CHECK(cs->defined_term == "ISO 2022 IR 13");
+        CHECK(cs->uses_code_extensions);
+        CHECK_FALSE(cs->is_multi_byte);
+    }
+
+    SECTION("Find Chinese GB2312 (ISO 2022 IR 58)") {
+        const auto* cs = find_character_set("ISO 2022 IR 58");
+        REQUIRE(cs != nullptr);
+        CHECK(cs->defined_term == "ISO 2022 IR 58");
+        CHECK(cs->encoding_name == "GB2312");
+        CHECK(cs->uses_code_extensions);
+        CHECK(cs->is_multi_byte);
+    }
+
+    SECTION("Unknown character set returns nullptr") {
+        CHECK(find_character_set("UNKNOWN") == nullptr);
+        CHECK(find_character_set("ISO_IR 999") == nullptr);
+        CHECK(find_character_set("") == nullptr);
+    }
+
+    SECTION("Find by ISO-IR number") {
+        CHECK(find_character_set_by_ir(6) != nullptr);
+        CHECK(find_character_set_by_ir(100) != nullptr);
+        CHECK(find_character_set_by_ir(192) != nullptr);
+        CHECK(find_character_set_by_ir(149) != nullptr);
+        CHECK(find_character_set_by_ir(87) != nullptr);
+        CHECK(find_character_set_by_ir(13) != nullptr);
+        CHECK(find_character_set_by_ir(58) != nullptr);
+        CHECK(find_character_set_by_ir(999) == nullptr);
+    }
+}
+
+TEST_CASE("Default character set", "[encoding][charset]") {
+    const auto& cs = default_character_set();
+    CHECK(cs.defined_term == "ISO_IR 6");
+    CHECK(cs.encoding_name == "ASCII");
+}
+
+TEST_CASE("All character sets enumeration", "[encoding][charset]") {
+    auto all = all_character_sets();
+    CHECK(all.size() == 9);  // 8 in array + GB2312
+
+    // Verify all entries are non-null
+    for (const auto* cs : all) {
+        REQUIRE(cs != nullptr);
+        CHECK_FALSE(cs->defined_term.empty());
+        CHECK_FALSE(cs->encoding_name.empty());
+    }
+}
+
+// =============================================================================
+// Specific Character Set Parsing Tests
+// =============================================================================
+
+TEST_CASE("Parse Specific Character Set", "[encoding][charset]") {
+    SECTION("Empty value defaults to ASCII") {
+        auto scs = parse_specific_character_set("");
+        REQUIRE(scs.default_set != nullptr);
+        CHECK(scs.default_set->defined_term == "ISO_IR 6");
+        CHECK(scs.extension_sets.empty());
+        CHECK_FALSE(scs.uses_extensions());
+    }
+
+    SECTION("Single value: ISO_IR 100 (Latin-1)") {
+        auto scs = parse_specific_character_set("ISO_IR 100");
+        REQUIRE(scs.default_set != nullptr);
+        CHECK(scs.default_set->defined_term == "ISO_IR 100");
+        CHECK(scs.extension_sets.empty());
+    }
+
+    SECTION("Single value: ISO_IR 192 (UTF-8)") {
+        auto scs = parse_specific_character_set("ISO_IR 192");
+        CHECK(scs.is_utf8());
+        CHECK_FALSE(scs.uses_extensions());
+    }
+
+    SECTION("Multi-valued: empty + Korean") {
+        // "\\ISO 2022 IR 149" means: default ASCII + Korean extension
+        auto scs = parse_specific_character_set("\\ISO 2022 IR 149");
+        REQUIRE(scs.default_set != nullptr);
+        CHECK(scs.default_set->defined_term == "ISO_IR 6");  // empty = ASCII
+        REQUIRE(scs.extension_sets.size() == 1);
+        CHECK(scs.extension_sets[0]->defined_term == "ISO 2022 IR 149");
+        CHECK(scs.uses_extensions());
+    }
+
+    SECTION("Multi-valued: empty + Japanese Kanji") {
+        auto scs = parse_specific_character_set("\\ISO 2022 IR 87");
+        CHECK(scs.default_set->defined_term == "ISO_IR 6");
+        REQUIRE(scs.extension_sets.size() == 1);
+        CHECK(scs.extension_sets[0]->defined_term == "ISO 2022 IR 87");
+    }
+
+    SECTION("Multi-valued: empty + Chinese") {
+        auto scs = parse_specific_character_set("\\ISO 2022 IR 58");
+        REQUIRE(scs.extension_sets.size() == 1);
+        CHECK(scs.extension_sets[0]->defined_term == "ISO 2022 IR 58");
+    }
+
+    SECTION("Multi-valued: Korean + Japanese (multiple extensions)") {
+        auto scs = parse_specific_character_set(
+            "\\ISO 2022 IR 149\\ISO 2022 IR 87");
+        CHECK(scs.default_set->defined_term == "ISO_IR 6");
+        REQUIRE(scs.extension_sets.size() == 2);
+        CHECK(scs.extension_sets[0]->defined_term == "ISO 2022 IR 149");
+        CHECK(scs.extension_sets[1]->defined_term == "ISO 2022 IR 87");
+    }
+
+    SECTION("Unknown extension is skipped") {
+        auto scs = parse_specific_character_set("\\UNKNOWN_CHARSET");
+        CHECK(scs.default_set->defined_term == "ISO_IR 6");
+        CHECK(scs.extension_sets.empty());
+    }
+
+    SECTION("is_single_byte_only") {
+        auto ascii_only = parse_specific_character_set("ISO_IR 6");
+        CHECK(ascii_only.is_single_byte_only());
+
+        auto latin1 = parse_specific_character_set("ISO_IR 100");
+        CHECK(latin1.is_single_byte_only());
+
+        auto korean = parse_specific_character_set("\\ISO 2022 IR 149");
+        CHECK_FALSE(korean.is_single_byte_only());
+
+        auto utf8 = parse_specific_character_set("ISO_IR 192");
+        CHECK_FALSE(utf8.is_single_byte_only());
+    }
+}
+
+// =============================================================================
+// ISO 2022 Escape Sequence Splitting Tests
+// =============================================================================
+
+TEST_CASE("Split by escape sequences", "[encoding][charset]") {
+    SECTION("No escape sequences returns single segment") {
+        auto scs = parse_specific_character_set("ISO_IR 100");
+        auto segments = split_by_escape_sequences("Hello World", scs);
+        REQUIRE(segments.size() == 1);
+        CHECK(segments[0].text == "Hello World");
+    }
+
+    SECTION("Empty text returns no segments") {
+        auto scs = parse_specific_character_set("\\ISO 2022 IR 149");
+        auto segments = split_by_escape_sequences("", scs);
+        CHECK(segments.empty());
+    }
+
+    SECTION("Text without ESC bytes returns single segment") {
+        auto scs = parse_specific_character_set("\\ISO 2022 IR 149");
+        auto segments = split_by_escape_sequences("ASCII text", scs);
+        REQUIRE(segments.size() == 1);
+        CHECK(segments[0].text == "ASCII text");
+    }
+
+    SECTION("Korean escape sequence splits text") {
+        auto scs = parse_specific_character_set("\\ISO 2022 IR 149");
+
+        // Construct: "ABC" + ESC $ ) C + <korean_bytes> + ESC ( B + "DEF"
+        std::string input = "ABC";
+        input += std::string("\x1B\x24\x29\x43", 4);  // ESC $ ) C
+        input += "\xC8\xAB";  // Korean bytes (홍 in EUC-KR)
+        input += std::string("\x1B\x28\x42", 3);      // ESC ( B (return to ASCII)
+        input += "DEF";
+
+        auto segments = split_by_escape_sequences(input, scs);
+        REQUIRE(segments.size() == 3);
+
+        CHECK(segments[0].text == "ABC");
+        CHECK(segments[0].charset->defined_term == "ISO_IR 6");
+
+        // Korean segment
+        CHECK(segments[1].text.size() == 2);
+        CHECK(segments[1].charset->defined_term == "ISO 2022 IR 149");
+
+        CHECK(segments[2].text == "DEF");
+    }
+}
+
+// =============================================================================
+// String Decoding Tests
+// =============================================================================
+
+TEST_CASE("UTF-8 passthrough", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("ISO_IR 192");
+
+    std::string utf8_text = "Hello \xED\x99\x8D";  // "Hello 홍" in UTF-8
+    auto result = decode_to_utf8(utf8_text, scs);
+    CHECK(result == utf8_text);
+}
+
+TEST_CASE("ASCII passthrough", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("");
+    auto result = decode_to_utf8("Hello World", scs);
+    CHECK(result == "Hello World");
+}
+
+TEST_CASE("Empty string decoding", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("\\ISO 2022 IR 149");
+    auto result = decode_to_utf8("", scs);
+    CHECK(result.empty());
+}
+
+TEST_CASE("Latin-1 decoding", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("ISO_IR 100");
+
+    // Latin-1: e-acute = 0xE9
+    std::string latin1_text = "caf\xE9";
+    auto result = decode_to_utf8(latin1_text, scs);
+
+    // UTF-8 encoding of e-acute: 0xC3 0xA9
+    CHECK(result == "caf\xC3\xA9");
+}
+
+TEST_CASE("Person Name decoding", "[encoding][charset]") {
+    SECTION("Simple ASCII PN") {
+        auto scs = parse_specific_character_set("");
+        auto result = decode_person_name("Smith^John", scs);
+        CHECK(result == "Smith^John");
+    }
+
+    SECTION("PN with component groups") {
+        auto scs = parse_specific_character_set("");
+        auto result = decode_person_name(
+            "Smith^John=Smith^John=Smith^John", scs);
+        CHECK(result == "Smith^John=Smith^John=Smith^John");
+    }
+
+    SECTION("Empty PN") {
+        auto scs = parse_specific_character_set("");
+        auto result = decode_person_name("", scs);
+        CHECK(result.empty());
+    }
+}
+
+TEST_CASE("convert_to_utf8 with ASCII", "[encoding][charset]") {
+    const auto& ascii = default_character_set();
+    auto result = convert_to_utf8("Hello", ascii);
+    CHECK(result == "Hello");
+}
+
+TEST_CASE("convert_to_utf8 with empty input", "[encoding][charset]") {
+    const auto& ascii = default_character_set();
+    auto result = convert_to_utf8("", ascii);
+    CHECK(result.empty());
+}
+
+// =============================================================================
+// Escape Sequence Constant Verification
+// =============================================================================
+
+TEST_CASE("Escape sequence format verification", "[encoding][charset]") {
+    SECTION("Korean ESC sequence starts with 0x1B") {
+        const auto* cs = find_character_set("ISO 2022 IR 149");
+        REQUIRE(cs != nullptr);
+        REQUIRE(cs->escape_sequence.size() == 4);
+        CHECK(cs->escape_sequence[0] == '\x1B');  // ESC
+        CHECK(cs->escape_sequence[1] == '\x24');  // $
+        CHECK(cs->escape_sequence[2] == '\x29');  // )
+        CHECK(cs->escape_sequence[3] == '\x43');  // C
+    }
+
+    SECTION("Japanese Kanji ESC sequence") {
+        const auto* cs = find_character_set("ISO 2022 IR 87");
+        REQUIRE(cs != nullptr);
+        REQUIRE(cs->escape_sequence.size() == 3);
+        CHECK(cs->escape_sequence[0] == '\x1B');  // ESC
+        CHECK(cs->escape_sequence[1] == '\x24');  // $
+        CHECK(cs->escape_sequence[2] == '\x42');  // B
+    }
+
+    SECTION("Chinese GB2312 ESC sequence") {
+        const auto* cs = find_character_set("ISO 2022 IR 58");
+        REQUIRE(cs != nullptr);
+        REQUIRE(cs->escape_sequence.size() == 4);
+        CHECK(cs->escape_sequence[0] == '\x1B');  // ESC
+        CHECK(cs->escape_sequence[1] == '\x24');  // $
+        CHECK(cs->escape_sequence[2] == '\x29');  // )
+        CHECK(cs->escape_sequence[3] == '\x41');  // A
+    }
+
+    SECTION("Japanese Katakana ESC sequence") {
+        const auto* cs = find_character_set("ISO 2022 IR 13");
+        REQUIRE(cs != nullptr);
+        REQUIRE(cs->escape_sequence.size() == 3);
+        CHECK(cs->escape_sequence[0] == '\x1B');  // ESC
+        CHECK(cs->escape_sequence[1] == '\x28');  // (
+        CHECK(cs->escape_sequence[2] == '\x4A');  // J
+    }
+}


### PR DESCRIPTION
Closes #703

## Summary
- Add character set registry with 9 DICOM character set entries (ASCII, Latin-1, UTF-8, Korean EUC-KR, Japanese Kanji/Katakana, Chinese GB2312, ISO 2022 extension variants)
- Implement Specific Character Set (0008,0005) multi-value parser for backslash-separated defined terms
- Implement ISO 2022 escape sequence splitter for CJK code extension switching
- Add platform-native encoding conversion via iconv (POSIX) and Win32 API (Windows)
- Add Person Name (PN) VR decoder with component group handling
- Add comprehensive Catch2 unit tests: 13 test cases, 147 assertions covering registry lookup, parsing, escape sequence splitting, and string decoding
- Link iconv library on macOS/non-glibc Linux for character set conversion

## Test Plan
- [x] Verify all 13 character set test cases pass (encoding_tests [charset])
- [x] Verify existing 144 encoding tests remain unaffected (no regressions)
- [x] Verify Latin-1 to UTF-8 conversion produces correct bytes (cafe test)
- [x] Verify ISO 2022 escape sequence splitting correctly segments Korean text
- [x] Verify cross-platform build (iconv on POSIX, Win32 API on Windows)