### PR TITLE
fix(encoding): handle ISO-2022-JP stateful encoding and complete CJK test coverage

### DIFF
--- a/src/encoding/character_set.cpp
+++ b/src/encoding/character_set.cpp
@@ -201,9 +201,20 @@ std::string iconv_convert(std::string_view input,
         return std::string(input);
     }
 
+    // ISO-2022-JP is stateful: code page 50220 expects escape sequences.
+    // Re-wrap raw JIS bytes with ESC $ B ... ESC ( B for proper decoding.
+    std::string wrapped_input;
+    if (charset.encoding_name == "ISO-2022-JP") {
+        wrapped_input.append(charset.escape_sequence);
+        wrapped_input.append(input);
+        wrapped_input.append(esc_ir_6);
+    }
+    const auto& actual_data = (charset.encoding_name == "ISO-2022-JP")
+        ? std::string_view(wrapped_input) : input;
+
     // Convert to wide char
     int wide_len = MultiByteToWideChar(
-        code_page, 0, input.data(), static_cast<int>(input.size()),
+        code_page, 0, actual_data.data(), static_cast<int>(actual_data.size()),
         nullptr, 0);
     if (wide_len <= 0) {
         return std::string(input);  // fallback
@@ -211,7 +222,7 @@ std::string iconv_convert(std::string_view input,
 
     std::wstring wide(static_cast<size_t>(wide_len), L'\0');
     MultiByteToWideChar(
-        code_page, 0, input.data(), static_cast<int>(input.size()),
+        code_page, 0, actual_data.data(), static_cast<int>(actual_data.size()),
         wide.data(), wide_len);
 
     // Convert wide char to UTF-8
@@ -239,6 +250,19 @@ std::string iconv_convert(std::string_view input,
         return std::string(input);
     }
 
+    // ISO-2022-JP is a stateful encoding: iconv expects escape sequences
+    // in the input. Since split_by_escape_sequences strips them, we must
+    // re-wrap the raw JIS bytes before calling iconv.
+    std::string wrapped_input;
+    if (charset.encoding_name == "ISO-2022-JP") {
+        wrapped_input.append(charset.escape_sequence);
+        wrapped_input.append(input);
+        wrapped_input.append(esc_ir_6);
+    }
+    const auto& actual_input = (charset.encoding_name == "ISO-2022-JP")
+        ? std::string_view(wrapped_input)
+        : input;
+
     iconv_t cd = iconv_open("UTF-8", charset.encoding_name.data());
     if (cd == reinterpret_cast<iconv_t>(-1)) {
         // Encoding not supported on this platform, return raw bytes
@@ -246,12 +270,12 @@ std::string iconv_convert(std::string_view input,
     }
 
     // iconv requires non-const input pointer
-    std::string input_copy(input);
-    char* in_ptr = input_copy.data();
-    size_t in_left = input_copy.size();
+    std::string input_buf(actual_input);
+    char* in_ptr = input_buf.data();
+    size_t in_left = input_buf.size();
 
     // Allocate output buffer (UTF-8 can be up to 4x the input size)
-    size_t out_size = input.size() * 4 + 4;
+    size_t out_size = actual_input.size() * 4 + 4;
     std::string output(out_size, '\0');
     char* out_ptr = output.data();
     size_t out_left = out_size;
@@ -317,6 +341,23 @@ std::string iconv_reverse_convert(std::string_view utf8_input,
         code_page, 0, wide.data(), wide_len,
         result.data(), target_len, nullptr, nullptr);
 
+    // ISO-2022-JP: Windows code page 50220 includes escape sequences in output.
+    // Strip them since encode_from_utf8() adds its own.
+    if (charset.encoding_name == "ISO-2022-JP" && result.size() >= 6) {
+        auto esc_prefix = charset.escape_sequence;
+        auto esc_suffix = esc_ir_6;
+        bool has_prefix = (result.size() >= esc_prefix.size() &&
+            std::string_view(result).substr(0, esc_prefix.size()) == esc_prefix);
+        bool has_suffix = (result.size() >= esc_suffix.size() &&
+            std::string_view(result).substr(
+                result.size() - esc_suffix.size()) == esc_suffix);
+        if (has_prefix && has_suffix) {
+            result = result.substr(
+                esc_prefix.size(),
+                result.size() - esc_prefix.size() - esc_suffix.size());
+        }
+    }
+
     return result;
 }
 
@@ -351,6 +392,24 @@ std::string iconv_reverse_convert(std::string_view utf8_input,
     }
 
     output.resize(out_size - out_left);
+
+    // ISO-2022-JP is stateful: iconv output includes escape sequences
+    // (ESC $ B ... ESC ( B). Since encode_from_utf8() adds its own escape
+    // sequences, strip the iconv-generated ones to avoid duplication.
+    if (charset.encoding_name == "ISO-2022-JP" && output.size() >= 6) {
+        auto esc_prefix = charset.escape_sequence;
+        auto esc_suffix = esc_ir_6;
+        bool has_prefix = (output.size() >= esc_prefix.size() &&
+            output.substr(0, esc_prefix.size()) == esc_prefix);
+        bool has_suffix = (output.size() >= esc_suffix.size() &&
+            output.substr(output.size() - esc_suffix.size()) == esc_suffix);
+        if (has_prefix && has_suffix) {
+            output = output.substr(
+                esc_prefix.size(),
+                output.size() - esc_prefix.size() - esc_suffix.size());
+        }
+    }
+
     return output;
 }
 

--- a/tests/encoding/character_set_test.cpp
+++ b/tests/encoding/character_set_test.cpp
@@ -414,6 +414,72 @@ TEST_CASE("Latin-1 round-trip encode/decode", "[encoding][charset]") {
     CHECK(encoded == latin1_raw);
 }
 
+TEST_CASE("Japanese Kanji decoding", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("\\ISO 2022 IR 87");
+
+    // Build raw DICOM string: "Yamada" + ESC $ B + JIS(山田) + ESC ( B + "Taro"
+    // 山 in JIS X 0208 = 0x3B 0x33, 田 = 0x45 0x44
+    std::string raw_input = "Yamada";
+    raw_input += std::string("\x1B\x24\x42", 3);  // ESC $ B
+    raw_input += "\x3B\x33\x45\x44";              // 山田 in JIS
+    raw_input += std::string("\x1B\x28\x42", 3);  // ESC ( B
+    raw_input += "Taro";
+
+    auto utf8 = decode_to_utf8(raw_input, scs);
+    // Should contain "Yamada" + UTF-8(山田) + "Taro"
+    CHECK(utf8.find("Yamada") == 0);
+    CHECK(utf8.find("Taro") != std::string::npos);
+    // UTF-8 for 山 = E5 B1 B1, 田 = E7 94 B0
+    CHECK(utf8.find("\xE5\xB1\xB1\xE7\x94\xB0") != std::string::npos);
+}
+
+TEST_CASE("Chinese GB2312 decoding", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("\\ISO 2022 IR 58");
+
+    // Build raw DICOM string: "Wang" + ESC $ ) A + GB2312(王五) + ESC ( B + "Wu"
+    // 王 in GB2312 = 0xCD 0xF5, 五 = 0xCE 0xE5
+    std::string raw_input = "Wang";
+    raw_input += std::string("\x1B\x24\x29\x41", 4);  // ESC $ ) A
+    raw_input += "\xCD\xF5\xCE\xE5";                  // 王五 in GB2312
+    raw_input += std::string("\x1B\x28\x42", 3);       // ESC ( B
+    raw_input += "Wu";
+
+    auto utf8 = decode_to_utf8(raw_input, scs);
+    // Should contain "Wang" + UTF-8(王五) + "Wu"
+    CHECK(utf8.find("Wang") == 0);
+    CHECK(utf8.find("Wu") != std::string::npos);
+    // UTF-8 for 王 = E7 8E 8B, 五 = E4 BA 94
+    CHECK(utf8.find("\xE7\x8E\x8B\xE4\xBA\x94") != std::string::npos);
+}
+
+TEST_CASE("Person Name with mixed character sets", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("\\ISO 2022 IR 149");
+
+    // Build PN: "Hong^GilDong" = alphabetic + ESC $ ) C + <EUC-KR 홍^길동> + ESC ( B
+    std::string alphabetic = "Hong^GilDong";
+
+    std::string ideographic;
+    ideographic += std::string("\x1B\x24\x29\x43", 4);  // ESC $ ) C
+    ideographic += "\xC8\xAB";                            // 홍 in EUC-KR
+    ideographic += "^";
+    ideographic += "\xB1\xE6\xB5\xBF";                   // 길동 in EUC-KR
+    ideographic += std::string("\x1B\x28\x42", 3);        // ESC ( B
+
+    std::string pn_raw = alphabetic + "=" + ideographic;
+
+    auto result = decode_person_name(pn_raw, scs);
+    // Alphabetic group should be unchanged
+    CHECK(result.find("Hong^GilDong") == 0);
+    // Should have = separator
+    CHECK(result.find('=') != std::string::npos);
+    // Ideographic group should contain UTF-8 Korean
+    // UTF-8 for 홍 = ED 99 8D
+    auto eq_pos = result.find('=');
+    REQUIRE(eq_pos != std::string::npos);
+    auto ideographic_utf8 = result.substr(eq_pos + 1);
+    CHECK_FALSE(ideographic_utf8.empty());
+}
+
 TEST_CASE("Korean round-trip encode/decode", "[encoding][charset]") {
     auto scs = parse_specific_character_set("\\ISO 2022 IR 149");
 
@@ -440,4 +506,45 @@ TEST_CASE("Korean round-trip encode/decode", "[encoding][charset]") {
     // Round-trip decode should match original UTF-8
     auto round_trip_utf8 = decode_to_utf8(re_encoded, scs);
     CHECK(round_trip_utf8 == utf8);
+}
+
+TEST_CASE("Japanese round-trip encode/decode", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("\\ISO 2022 IR 87");
+
+    // UTF-8 text with mixed ASCII and Japanese
+    // 山田 in UTF-8: E5 B1 B1 E7 94 B0
+    std::string utf8_input = "Yamada\xE5\xB1\xB1\xE7\x94\xB0Taro";
+
+    // Encode to ISO 2022 with JIS escape sequences
+    auto encoded = encode_from_utf8(utf8_input, scs);
+    // Should contain Japanese Kanji escape sequence ESC $ B
+    CHECK(encoded.find("\x1B\x24\x42") != std::string::npos);
+    // And ASCII return ESC ( B
+    CHECK(encoded.find("\x1B\x28\x42") != std::string::npos);
+    // ASCII parts should be preserved
+    CHECK(encoded.find("Yamada") == 0);
+    CHECK(encoded.find("Taro") != std::string::npos);
+
+    // Decode back to UTF-8: round-trip must produce identical result
+    auto round_trip = decode_to_utf8(encoded, scs);
+    CHECK(round_trip == utf8_input);
+}
+
+TEST_CASE("Chinese round-trip encode/decode", "[encoding][charset]") {
+    auto scs = parse_specific_character_set("\\ISO 2022 IR 58");
+
+    // UTF-8 text with mixed ASCII and Chinese
+    // 王五 in UTF-8: E7 8E 8B E4 BA 94
+    std::string utf8_input = "Wang\xE7\x8E\x8B\xE4\xBA\x94Wu";
+
+    // Encode to ISO 2022 with GB2312 escape sequences
+    auto encoded = encode_from_utf8(utf8_input, scs);
+    // Should contain Chinese escape sequence ESC $ ) A
+    CHECK(encoded.find("\x1B\x24\x29\x41") != std::string::npos);
+    // And ASCII return ESC ( B
+    CHECK(encoded.find("\x1B\x28\x42") != std::string::npos);
+
+    // Decode back to UTF-8: round-trip must produce identical result
+    auto round_trip = decode_to_utf8(encoded, scs);
+    CHECK(round_trip == utf8_input);
 }


### PR DESCRIPTION
Closes #700

## Summary
- Fix ISO-2022-JP (JIS X 0208) decode/encode: wrap raw JIS bytes with escape sequences before iconv calls (stateful encoding requires ESC $ B prefix), strip iconv-generated escape sequences from encode output to prevent duplication
- Add Japanese Kanji decode test: verify ESC $ B + JIS bytes correctly decode to UTF-8 (山田)
- Add Chinese GB2312 decode test: verify ESC $ ) A + GB2312 bytes correctly decode to UTF-8 (王五)
- Add mixed-charset Person Name test: verify PN with ASCII alphabetic + Korean ideographic component groups
- Add Japanese and Chinese round-trip encode/decode tests: verify encode(decode(raw)) cycle integrity
- Applied same fix to both POSIX (iconv) and Windows (MultiByteToWideChar) code paths

Part of #700 (completes all remaining acceptance criteria)
Related PRs: #705 (Phase A), #706 (Phase B+C)

## Test Plan
- [x] 26 charset unit tests pass (179 assertions) - up from 21 tests/161 assertions
- [x] 83 core unit tests pass (1103 assertions)
- [x] Japanese Kanji (IR 87) decode: raw JIS bytes → UTF-8 山田
- [x] Chinese GB2312 (IR 58) decode: raw GB2312 bytes → UTF-8 王五
- [x] Japanese round-trip: UTF-8 → ISO 2022 → UTF-8 identical
- [x] Chinese round-trip: UTF-8 → ISO 2022 → UTF-8 identical
- [x] Mixed charset PN: ASCII alphabetic + Korean ideographic component groups
- [x] Korean round-trip still passes (regression check)
- [x] Cross-platform CI: Ubuntu, macOS, Windows