### PR TITLE
feat(services): add Storage Commitment foundation types and SOP class registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1758,6 +1758,7 @@ if(PACS_BUILD_TESTS)
         tests/services/worklist_scu_test.cpp
         tests/services/mpps_scp_test.cpp
         tests/services/mpps_scu_test.cpp
+        tests/services/storage_commitment_types_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/core/dicom_tag_constants.hpp
+++ b/include/pacs/core/dicom_tag_constants.hpp
@@ -209,6 +209,18 @@ inline constexpr dicom_tag referenced_sop_class_uid{0x0008, 0x1150};
 /// Referenced SOP Instance UID (in Sequence)
 inline constexpr dicom_tag referenced_sop_instance_uid{0x0008, 0x1155};
 
+/// Transaction UID — identifies a Storage Commitment transaction (PS3.4 J.3)
+inline constexpr dicom_tag transaction_uid{0x0008, 0x1195};
+
+/// Failure Reason — reason code for commitment failure (PS3.4 Table J.3-2)
+inline constexpr dicom_tag failure_reason{0x0008, 0x1197};
+
+/// Failed SOP Sequence — instances that failed commitment (PS3.4 J.3)
+inline constexpr dicom_tag failed_sop_sequence{0x0008, 0x1198};
+
+/// Referenced SOP Sequence — instances in commitment request/success (PS3.4 J.3)
+inline constexpr dicom_tag referenced_sop_sequence{0x0008, 0x1199};
+
 // ============================================================================
 // Patient Module (Group 0x0010)
 // ============================================================================

--- a/include/pacs/services/sop_class_registry.hpp
+++ b/include/pacs/services/sop_class_registry.hpp
@@ -29,14 +29,15 @@ namespace pacs::services {
  * @brief Category of SOP Class
  */
 enum class sop_class_category {
-    storage,            ///< Storage Service Class
-    query_retrieve,     ///< Query/Retrieve Service Class
-    worklist,           ///< Modality Worklist Service Class
-    mpps,               ///< Modality Performed Procedure Step
-    verification,       ///< Verification Service Class
-    print,              ///< Print Management Service Class
-    media,              ///< Media Storage Service Class
-    other               ///< Other service classes
+    storage,              ///< Storage Service Class
+    query_retrieve,       ///< Query/Retrieve Service Class
+    worklist,             ///< Modality Worklist Service Class
+    mpps,                 ///< Modality Performed Procedure Step
+    storage_commitment,   ///< Storage Commitment Push Model Service Class
+    verification,         ///< Verification Service Class
+    print,                ///< Print Management Service Class
+    media,                ///< Media Storage Service Class
+    other                 ///< Other service classes
 };
 
 /**

--- a/include/pacs/services/storage_commitment_types.hpp
+++ b/include/pacs/services/storage_commitment_types.hpp
@@ -1,0 +1,155 @@
+/**
+ * @file storage_commitment_types.hpp
+ * @brief Data types for DICOM Storage Commitment Push Model Service
+ *
+ * Defines the shared data structures used by both the Storage Commitment
+ * SCP and SCU implementations, as specified in DICOM PS3.4 Annex J.
+ *
+ * @see DICOM PS3.4 Annex J - Storage Commitment Push Model Service Class
+ * @see DICOM PS3.4 Table J.3-1 - Storage Commitment Request
+ */
+
+#ifndef PACS_SERVICES_STORAGE_COMMITMENT_TYPES_HPP
+#define PACS_SERVICES_STORAGE_COMMITMENT_TYPES_HPP
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace pacs::services {
+
+// =============================================================================
+// Storage Commitment SOP Class UIDs
+// =============================================================================
+
+/// Storage Commitment Push Model SOP Class UID (PS3.4 Table J.3-1)
+inline constexpr std::string_view storage_commitment_push_model_sop_class_uid =
+    "1.2.840.10008.1.20.1";
+
+/// Storage Commitment Push Model SOP Instance UID (Well-Known)
+inline constexpr std::string_view storage_commitment_push_model_sop_instance_uid =
+    "1.2.840.10008.1.20.1.1";
+
+// =============================================================================
+// Action and Event Type IDs
+// =============================================================================
+
+/// N-ACTION: Request Storage Commitment (Action Type ID = 1)
+inline constexpr uint16_t storage_commitment_action_type_request = 1;
+
+/// N-EVENT-REPORT: Storage Commitment Request Successful (Event Type ID = 1)
+inline constexpr uint16_t storage_commitment_event_type_success = 1;
+
+/// N-EVENT-REPORT: Storage Commitment Request Complete - Failures Exist (Event Type ID = 2)
+inline constexpr uint16_t storage_commitment_event_type_failure = 2;
+
+// =============================================================================
+// SOP Reference
+// =============================================================================
+
+/**
+ * @brief Reference to a SOP Instance in a commitment request
+ *
+ * Corresponds to items in the Referenced SOP Sequence (0008,1199)
+ * or Failed SOP Sequence (0008,1198).
+ */
+struct sop_reference {
+    std::string sop_class_uid;      ///< Referenced SOP Class UID (0008,1150)
+    std::string sop_instance_uid;   ///< Referenced SOP Instance UID (0008,1155)
+};
+
+// =============================================================================
+// Commitment Failure Reasons
+// =============================================================================
+
+/**
+ * @brief Failure reason codes for Storage Commitment
+ *
+ * As defined in DICOM PS3.4 Table J.3-2 (Failure Reason values).
+ * These codes appear in the Failure Reason (0008,1197) attribute
+ * within the Failed SOP Sequence.
+ */
+enum class commitment_failure_reason : uint16_t {
+    /// General processing failure
+    processing_failure = 0x0110,
+
+    /// Referenced SOP Instance not found in storage
+    no_such_object_instance = 0x0112,
+
+    /// Storage resource limitation (e.g., disk full)
+    resource_limitation = 0x0213,
+
+    /// Referenced SOP Class not supported by SCP
+    referenced_sop_class_not_supported = 0x0122,
+
+    /// SOP Class / Instance UID mismatch
+    class_instance_conflict = 0x0119,
+
+    /// Duplicate Transaction UID
+    duplicate_transaction_uid = 0xA770
+};
+
+/**
+ * @brief Convert failure reason to human-readable string
+ * @param reason The failure reason code
+ * @return Description string
+ */
+[[nodiscard]] inline std::string_view
+to_string(commitment_failure_reason reason) noexcept {
+    switch (reason) {
+        case commitment_failure_reason::processing_failure:
+            return "Processing failure";
+        case commitment_failure_reason::no_such_object_instance:
+            return "No such object instance";
+        case commitment_failure_reason::resource_limitation:
+            return "Resource limitation";
+        case commitment_failure_reason::referenced_sop_class_not_supported:
+            return "Referenced SOP Class not supported";
+        case commitment_failure_reason::class_instance_conflict:
+            return "Class/Instance conflict";
+        case commitment_failure_reason::duplicate_transaction_uid:
+            return "Duplicate Transaction UID";
+    }
+    return "Unknown failure reason";
+}
+
+// =============================================================================
+// Commitment Result
+// =============================================================================
+
+/**
+ * @brief Result of a Storage Commitment verification
+ *
+ * Contains the per-instance success/failure status after the SCP
+ * has verified storage of the requested SOP Instances.
+ */
+struct commitment_result {
+    /// Transaction UID identifying this commitment request
+    std::string transaction_uid;
+
+    /// Successfully committed SOP Instance references
+    std::vector<sop_reference> success_references;
+
+    /// Failed SOP Instance references with failure reasons
+    std::vector<std::pair<sop_reference, commitment_failure_reason>> failed_references;
+
+    /// Timestamp when verification was completed
+    std::chrono::system_clock::time_point timestamp;
+
+    /// Whether all instances were successfully committed
+    [[nodiscard]] bool all_successful() const noexcept {
+        return failed_references.empty() && !success_references.empty();
+    }
+
+    /// Total number of instances in this result
+    [[nodiscard]] std::size_t total_instances() const noexcept {
+        return success_references.size() + failed_references.size();
+    }
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_STORAGE_COMMITMENT_TYPES_HPP

--- a/src/services/sop_class_registry.cpp
+++ b/src/services/sop_class_registry.cpp
@@ -4,6 +4,7 @@
  */
 
 #include "pacs/services/sop_class_registry.hpp"
+#include "pacs/services/storage_commitment_types.hpp"
 #include "pacs/services/sop_classes/dx_storage.hpp"
 #include "pacs/services/sop_classes/nm_storage.hpp"
 #include "pacs/services/sop_classes/pet_storage.hpp"
@@ -805,6 +806,19 @@ void sop_class_registry::register_other_sop_classes() {
             "1.2.840.10008.1.1",
             "Verification SOP Class",
             sop_class_category::verification,
+            modality_type::other,
+            false,
+            false
+        }
+    );
+
+    // Storage Commitment Push Model SOP Class (PS3.4 Annex J)
+    registry_.emplace(
+        std::string(storage_commitment_push_model_sop_class_uid),
+        sop_class_info{
+            storage_commitment_push_model_sop_class_uid,
+            "Storage Commitment Push Model",
+            sop_class_category::storage_commitment,
             modality_type::other,
             false,
             false

--- a/tests/services/storage_commitment_types_test.cpp
+++ b/tests/services/storage_commitment_types_test.cpp
@@ -1,0 +1,180 @@
+/**
+ * @file storage_commitment_types_test.cpp
+ * @brief Unit tests for Storage Commitment types and SOP class registration
+ */
+
+#include <pacs/services/storage_commitment_types.hpp>
+#include <pacs/services/sop_class_registry.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::core;
+
+// ============================================================================
+// SOP Reference Tests
+// ============================================================================
+
+TEST_CASE("sop_reference construction", "[services][storage_commitment]") {
+    SECTION("default construction") {
+        sop_reference ref;
+        CHECK(ref.sop_class_uid.empty());
+        CHECK(ref.sop_instance_uid.empty());
+    }
+
+    SECTION("value construction") {
+        sop_reference ref{
+            "1.2.840.10008.5.1.4.1.1.2",
+            "1.2.3.4.5.6.7.8.9"
+        };
+        CHECK(ref.sop_class_uid == "1.2.840.10008.5.1.4.1.1.2");
+        CHECK(ref.sop_instance_uid == "1.2.3.4.5.6.7.8.9");
+    }
+}
+
+// ============================================================================
+// Commitment Failure Reason Tests
+// ============================================================================
+
+TEST_CASE("commitment_failure_reason values match DICOM standard",
+          "[services][storage_commitment]") {
+    // PS3.4 Table J.3-2 failure reason codes
+    CHECK(static_cast<uint16_t>(commitment_failure_reason::processing_failure) == 0x0110);
+    CHECK(static_cast<uint16_t>(commitment_failure_reason::no_such_object_instance) == 0x0112);
+    CHECK(static_cast<uint16_t>(commitment_failure_reason::resource_limitation) == 0x0213);
+    CHECK(static_cast<uint16_t>(commitment_failure_reason::referenced_sop_class_not_supported) == 0x0122);
+    CHECK(static_cast<uint16_t>(commitment_failure_reason::class_instance_conflict) == 0x0119);
+    CHECK(static_cast<uint16_t>(commitment_failure_reason::duplicate_transaction_uid) == 0xA770);
+}
+
+TEST_CASE("commitment_failure_reason to_string", "[services][storage_commitment]") {
+    CHECK(to_string(commitment_failure_reason::processing_failure) == "Processing failure");
+    CHECK(to_string(commitment_failure_reason::no_such_object_instance) == "No such object instance");
+    CHECK(to_string(commitment_failure_reason::resource_limitation) == "Resource limitation");
+    CHECK(to_string(commitment_failure_reason::referenced_sop_class_not_supported)
+          == "Referenced SOP Class not supported");
+    CHECK(to_string(commitment_failure_reason::class_instance_conflict)
+          == "Class/Instance conflict");
+    CHECK(to_string(commitment_failure_reason::duplicate_transaction_uid)
+          == "Duplicate Transaction UID");
+}
+
+// ============================================================================
+// Commitment Result Tests
+// ============================================================================
+
+TEST_CASE("commitment_result", "[services][storage_commitment]") {
+    SECTION("empty result") {
+        commitment_result result;
+        CHECK_FALSE(result.all_successful());
+        CHECK(result.total_instances() == 0);
+    }
+
+    SECTION("all successful") {
+        commitment_result result;
+        result.transaction_uid = "1.2.3.4";
+        result.success_references.push_back({"1.2.840.10008.5.1.4.1.1.2", "1.1.1"});
+        result.success_references.push_back({"1.2.840.10008.5.1.4.1.1.2", "1.1.2"});
+        result.timestamp = std::chrono::system_clock::now();
+
+        CHECK(result.all_successful());
+        CHECK(result.total_instances() == 2);
+    }
+
+    SECTION("partial failure") {
+        commitment_result result;
+        result.transaction_uid = "1.2.3.5";
+        result.success_references.push_back({"1.2.840.10008.5.1.4.1.1.2", "1.1.1"});
+        result.failed_references.push_back({
+            {"1.2.840.10008.5.1.4.1.1.2", "1.1.2"},
+            commitment_failure_reason::no_such_object_instance
+        });
+
+        CHECK_FALSE(result.all_successful());
+        CHECK(result.total_instances() == 2);
+    }
+
+    SECTION("all failed") {
+        commitment_result result;
+        result.transaction_uid = "1.2.3.6";
+        result.failed_references.push_back({
+            {"1.2.840.10008.5.1.4.1.1.2", "1.1.1"},
+            commitment_failure_reason::processing_failure
+        });
+
+        CHECK_FALSE(result.all_successful());
+        CHECK(result.total_instances() == 1);
+    }
+}
+
+// ============================================================================
+// SOP Class UID Constants Tests
+// ============================================================================
+
+TEST_CASE("storage commitment SOP class UIDs", "[services][storage_commitment]") {
+    CHECK(storage_commitment_push_model_sop_class_uid == "1.2.840.10008.1.20.1");
+    CHECK(storage_commitment_push_model_sop_instance_uid == "1.2.840.10008.1.20.1.1");
+}
+
+TEST_CASE("storage commitment action/event type IDs", "[services][storage_commitment]") {
+    CHECK(storage_commitment_action_type_request == 1);
+    CHECK(storage_commitment_event_type_success == 1);
+    CHECK(storage_commitment_event_type_failure == 2);
+}
+
+// ============================================================================
+// SOP Class Registry Tests
+// ============================================================================
+
+TEST_CASE("storage commitment registered in SOP class registry",
+          "[services][storage_commitment]") {
+    auto& registry = sop_class_registry::instance();
+
+    SECTION("SOP class is registered and supported") {
+        CHECK(registry.is_supported(storage_commitment_push_model_sop_class_uid));
+    }
+
+    SECTION("SOP class info is correct") {
+        const auto* info = registry.get_info(storage_commitment_push_model_sop_class_uid);
+        REQUIRE(info != nullptr);
+        CHECK(info->uid == "1.2.840.10008.1.20.1");
+        CHECK(info->name == "Storage Commitment Push Model");
+        CHECK(info->category == sop_class_category::storage_commitment);
+        CHECK(info->modality == modality_type::other);
+        CHECK_FALSE(info->is_retired);
+        CHECK_FALSE(info->supports_multiframe);
+    }
+
+    SECTION("category query returns storage commitment SOP class") {
+        auto classes = registry.get_by_category(sop_class_category::storage_commitment);
+        REQUIRE(classes.size() == 1);
+        CHECK(classes[0] == "1.2.840.10008.1.20.1");
+    }
+
+    SECTION("not classified as storage SOP class") {
+        CHECK_FALSE(is_storage_sop_class(storage_commitment_push_model_sop_class_uid));
+    }
+}
+
+// ============================================================================
+// DICOM Tag Constants Tests
+// ============================================================================
+
+TEST_CASE("storage commitment DICOM tag constants", "[services][storage_commitment]") {
+    // Transaction UID (0008,1195)
+    CHECK(tags::transaction_uid.group() == 0x0008);
+    CHECK(tags::transaction_uid.element() == 0x1195);
+
+    // Failure Reason (0008,1197)
+    CHECK(tags::failure_reason.group() == 0x0008);
+    CHECK(tags::failure_reason.element() == 0x1197);
+
+    // Failed SOP Sequence (0008,1198)
+    CHECK(tags::failed_sop_sequence.group() == 0x0008);
+    CHECK(tags::failed_sop_sequence.element() == 0x1198);
+
+    // Referenced SOP Sequence (0008,1199)
+    CHECK(tags::referenced_sop_sequence.group() == 0x0008);
+    CHECK(tags::referenced_sop_sequence.element() == 0x1199);
+}


### PR DESCRIPTION
Closes #708
Part of #701

## Summary
- Define shared data types for Storage Commitment Push Model (PS3.4 Annex J):
  - `sop_reference`: SOP Class/Instance UID pair for commitment requests
  - `commitment_failure_reason`: DICOM-standard failure codes (PS3.4 Table J.3-2)
  - `commitment_result`: aggregated verification results with success/failure lists
- Register Storage Commitment Push Model SOP Class (`1.2.840.10008.1.20.1`) in the SOP class registry
- Add `storage_commitment` category to `sop_class_category` enum
- Add DICOM tag constants: Transaction UID (0008,1195), Failure Reason (0008,1197), Failed SOP Sequence (0008,1198), Referenced SOP Sequence (0008,1199)

## Test Plan
- [x] `sop_reference` default and value construction verified
- [x] `commitment_failure_reason` enum values match DICOM PS3.4 Table J.3-2
- [x] `commitment_failure_reason` to_string for all values
- [x] `commitment_result` all_successful() and total_instances() for empty, success, partial, and all-failed scenarios
- [x] SOP class UID and instance UID constants verified
- [x] Action/event type ID constants verified
- [x] SOP class registry: is_supported, get_info, get_by_category for storage_commitment
- [x] Storage commitment not classified as storage SOP class
- [x] DICOM tag constants group/element values verified
- [x] All 459 existing services tests still pass (7537 assertions)