### PR TITLE
feat(storage): complete repository_factory migration for all 10 repositories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1843,6 +1843,7 @@ if(PACS_BUILD_TESTS)
             tests/storage/pacs_database_adapter_test.cpp
             tests/storage/base_repository_test.cpp
             tests/storage/commitment_repository_test.cpp
+            tests/storage/repository_factory_test.cpp
             # Annotation & Measurement API integration tests (Issue #545, #584)
             tests/integration/annotation_api_test.cpp
             tests/integration/measurement_api_test.cpp

--- a/src/storage/repository_factory.cpp
+++ b/src/storage/repository_factory.cpp
@@ -7,6 +7,7 @@
  * @see repository_factory.hpp
  * @see Issue #607 - Phase 2: Base Repository Pattern Implementation
  * @see Issue #610 - Phase 4: Repository Migrations (9 repositories)
+ * @see Issue #716 - Complete repository_factory migration for remaining 6
  */
 
 #include "pacs/storage/repository_factory.hpp"
@@ -15,30 +16,22 @@
 
 #include "pacs/storage/pacs_database_adapter.hpp"
 
-// Migrated repositories (Issue #610)
+#include "pacs/storage/annotation_repository.hpp"
+#include "pacs/storage/commitment_repository.hpp"
 #include "pacs/storage/job_repository.hpp"
 #include "pacs/storage/key_image_repository.hpp"
 #include "pacs/storage/measurement_repository.hpp"
-#include "pacs/storage/commitment_repository.hpp"
-
-// TODO(Issue #610): Uncomment these includes when remaining repositories are
-// migrated
-// #include "pacs/storage/annotation_repository.hpp"
-// #include "pacs/storage/node_repository.hpp"
-// #include "pacs/storage/prefetch_repository.hpp"
-// #include "pacs/storage/routing_repository.hpp"
-// #include "pacs/storage/sync_repository.hpp"
-// #include "pacs/storage/viewer_state_repository.hpp"
+#include "pacs/storage/node_repository.hpp"
+#include "pacs/storage/prefetch_repository.hpp"
+#include "pacs/storage/routing_repository.hpp"
+#include "pacs/storage/sync_repository.hpp"
+#include "pacs/storage/viewer_state_repository.hpp"
 
 namespace pacs::storage {
 
 repository_factory::repository_factory(
     std::shared_ptr<pacs_database_adapter> db)
     : db_(std::move(db)) {}
-
-// TODO(Issue #610): Implement these methods after repository migration
-// Currently, all repositories use sqlite3* directly and must be migrated
-// to accept std::shared_ptr<pacs_database_adapter> in their constructors.
 
 auto repository_factory::jobs() -> std::shared_ptr<job_repository> {
     if (!jobs_) {
@@ -49,24 +42,32 @@ auto repository_factory::jobs() -> std::shared_ptr<job_repository> {
 
 auto repository_factory::annotations()
     -> std::shared_ptr<annotation_repository> {
-    // TODO: Implement after annotation_repository migration
-    return nullptr;
+    if (!annotations_) {
+        annotations_ = std::make_shared<annotation_repository>(db_);
+    }
+    return annotations_;
 }
 
 auto repository_factory::routing_rules()
     -> std::shared_ptr<routing_repository> {
-    // TODO: Implement after routing_repository migration
-    return nullptr;
+    if (!routing_rules_) {
+        routing_rules_ = std::make_shared<routing_repository>(db_);
+    }
+    return routing_rules_;
 }
 
 auto repository_factory::nodes() -> std::shared_ptr<node_repository> {
-    // TODO: Implement after node_repository migration
-    return nullptr;
+    if (!nodes_) {
+        nodes_ = std::make_shared<node_repository>(db_);
+    }
+    return nodes_;
 }
 
 auto repository_factory::sync_states() -> std::shared_ptr<sync_repository> {
-    // TODO: Implement after sync_repository migration
-    return nullptr;
+    if (!sync_states_) {
+        sync_states_ = std::make_shared<sync_repository>(db_);
+    }
+    return sync_states_;
 }
 
 auto repository_factory::key_images()
@@ -87,14 +88,18 @@ auto repository_factory::measurements()
 
 auto repository_factory::viewer_states()
     -> std::shared_ptr<viewer_state_repository> {
-    // TODO: Implement after viewer_state_repository migration
-    return nullptr;
+    if (!viewer_states_) {
+        viewer_states_ = std::make_shared<viewer_state_repository>(db_);
+    }
+    return viewer_states_;
 }
 
 auto repository_factory::prefetch_queue()
     -> std::shared_ptr<prefetch_repository> {
-    // TODO: Implement after prefetch_repository migration
-    return nullptr;
+    if (!prefetch_queue_) {
+        prefetch_queue_ = std::make_shared<prefetch_repository>(db_);
+    }
+    return prefetch_queue_;
 }
 
 auto repository_factory::commitments()

--- a/tests/storage/repository_factory_test.cpp
+++ b/tests/storage/repository_factory_test.cpp
@@ -1,0 +1,155 @@
+/**
+ * @file repository_factory_test.cpp
+ * @brief Unit tests for repository_factory class
+ *
+ * Verifies that all 10 repositories are lazily initialized and return
+ * valid (non-null) instances from the factory.
+ *
+ * @see Issue #716 - Complete repository_factory migration
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <pacs/storage/repository_factory.hpp>
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+
+#include <pacs/storage/migration_runner.hpp>
+#include <pacs/storage/pacs_database_adapter.hpp>
+
+using namespace pacs::storage;
+
+namespace {
+
+bool is_sqlite_backend_supported() {
+    pacs_database_adapter db(":memory:");
+    auto result = db.connect();
+    return result.is_ok();
+}
+
+class test_database {
+public:
+    test_database() {
+        db_ = std::make_shared<pacs_database_adapter>(":memory:");
+        auto conn_result = db_->connect();
+        if (conn_result.is_err()) {
+            throw std::runtime_error(
+                "Failed to connect: " + conn_result.error().message);
+        }
+        migration_runner runner;
+        auto result = runner.run_migrations(*db_);
+        if (result.is_err()) {
+            throw std::runtime_error(
+                "Migration failed: " + result.error().message);
+        }
+    }
+
+    [[nodiscard]] auto get() const noexcept
+        -> std::shared_ptr<pacs_database_adapter> {
+        return db_;
+    }
+
+private:
+    std::shared_ptr<pacs_database_adapter> db_;
+};
+
+}  // namespace
+
+// ============================================================================
+// Factory Construction
+// ============================================================================
+
+TEST_CASE("repository_factory returns shared db adapter",
+          "[storage][repository_factory]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+    test_database tdb;
+    repository_factory factory(tdb.get());
+
+    CHECK(factory.db() == tdb.get());
+}
+
+// ============================================================================
+// All repositories return non-null
+// ============================================================================
+
+TEST_CASE("repository_factory returns non-null for all repositories",
+          "[storage][repository_factory]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+    test_database tdb;
+    repository_factory factory(tdb.get());
+
+    SECTION("jobs") { CHECK(factory.jobs() != nullptr); }
+    SECTION("annotations") { CHECK(factory.annotations() != nullptr); }
+    SECTION("routing_rules") { CHECK(factory.routing_rules() != nullptr); }
+    SECTION("nodes") { CHECK(factory.nodes() != nullptr); }
+    SECTION("sync_states") { CHECK(factory.sync_states() != nullptr); }
+    SECTION("key_images") { CHECK(factory.key_images() != nullptr); }
+    SECTION("measurements") { CHECK(factory.measurements() != nullptr); }
+    SECTION("viewer_states") { CHECK(factory.viewer_states() != nullptr); }
+    SECTION("prefetch_queue") { CHECK(factory.prefetch_queue() != nullptr); }
+    SECTION("commitments") { CHECK(factory.commitments() != nullptr); }
+}
+
+// ============================================================================
+// Lazy initialization returns same instance
+// ============================================================================
+
+TEST_CASE("repository_factory caches instances on repeated calls",
+          "[storage][repository_factory]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+    test_database tdb;
+    repository_factory factory(tdb.get());
+
+    SECTION("jobs returns same pointer") {
+        auto first = factory.jobs();
+        auto second = factory.jobs();
+        CHECK(first == second);
+    }
+
+    SECTION("annotations returns same pointer") {
+        auto first = factory.annotations();
+        auto second = factory.annotations();
+        CHECK(first == second);
+    }
+
+    SECTION("routing_rules returns same pointer") {
+        auto first = factory.routing_rules();
+        auto second = factory.routing_rules();
+        CHECK(first == second);
+    }
+
+    SECTION("nodes returns same pointer") {
+        auto first = factory.nodes();
+        auto second = factory.nodes();
+        CHECK(first == second);
+    }
+
+    SECTION("sync_states returns same pointer") {
+        auto first = factory.sync_states();
+        auto second = factory.sync_states();
+        CHECK(first == second);
+    }
+
+    SECTION("viewer_states returns same pointer") {
+        auto first = factory.viewer_states();
+        auto second = factory.viewer_states();
+        CHECK(first == second);
+    }
+
+    SECTION("prefetch_queue returns same pointer") {
+        auto first = factory.prefetch_queue();
+        auto second = factory.prefetch_queue();
+        CHECK(first == second);
+    }
+}
+
+#endif  // PACS_WITH_DATABASE_SYSTEM


### PR DESCRIPTION
Closes #716

## Summary
- Enable lazy initialization for the remaining 6 repositories (`annotation`, `routing`, `node`, `sync`, `viewer_state`, `prefetch`) that previously returned `nullptr` from `repository_factory`
- All 10 repositories now return valid instances via the shared `pacs_database_adapter`
- Add unit tests verifying non-null returns and instance caching behavior

## Changes

### `src/storage/repository_factory.cpp`
- Uncomment 6 repository header includes (`annotation_repository.hpp`, `node_repository.hpp`, `prefetch_repository.hpp`, `routing_repository.hpp`, `sync_repository.hpp`, `viewer_state_repository.hpp`)
- Replace `nullptr` returns with lazy-initialized `std::make_shared<T>(db_)` calls matching the existing pattern used by `job_repository`, `key_image_repository`, `measurement_repository`, and `commitment_repository`
- Remove all `TODO(Issue #610)` comments
- Sort includes alphabetically

### `tests/storage/repository_factory_test.cpp` (new)
- Test that `repository_factory::db()` returns the injected adapter
- Test all 10 repository accessors return non-null instances
- Test lazy-initialization caching (same pointer on repeated calls)

### `CMakeLists.txt`
- Add `repository_factory_test.cpp` to `storage_tests` target

## Context
All 6 repositories already had their `pacs_database_adapter` migration completed in prior issues (#650, #651). The constructors accepting `std::shared_ptr<pacs_database_adapter>` were already implemented in the `#ifdef PACS_WITH_DATABASE_SYSTEM` sections. This PR simply wires them into the factory.

## Test Plan
- [x] All 3 new `repository_factory` tests pass
- [x] All 161 existing storage tests pass
- [x] Full test suite: 1733 unit + 87 integration tests pass (7 pre-existing `dicom_server_v2` failures unrelated to this change)
- [x] Build succeeds with no new warnings