### PR TITLE
feat(services): add MR Image IOD Validator (PS3.3 Section A.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -986,6 +986,7 @@ add_library(pacs_services
     src/services/sop_classes/seg_storage.cpp
     src/services/sop_classes/sr_storage.cpp
     src/services/sop_classes/ct_storage.cpp
+    src/services/sop_classes/mr_storage.cpp
     src/services/validation/us_iod_validator.cpp
     src/services/validation/dx_iod_validator.cpp
     src/services/validation/mg_iod_validator.cpp
@@ -995,6 +996,7 @@ add_library(pacs_services
     src/services/validation/seg_iod_validator.cpp
     src/services/validation/sr_iod_validator.cpp
     src/services/validation/ct_iod_validator.cpp
+    src/services/validation/mr_iod_validator.cpp
     src/services/cache/query_cache.cpp
     src/services/cache/database_cursor.cpp
     src/services/cache/query_result_stream.cpp
@@ -1780,6 +1782,7 @@ if(PACS_BUILD_TESTS)
         tests/services/sr_storage_test.cpp
         tests/services/ct_storage_test.cpp
         tests/services/ct_iod_validator_test.cpp
+        tests/services/mr_iod_validator_test.cpp
         tests/services/cache/simple_lru_cache_test.cpp
         tests/services/cache/query_cache_test.cpp
         tests/services/cache/streaming_query_test.cpp

--- a/include/pacs/services/sop_classes/mr_storage.hpp
+++ b/include/pacs/services/sop_classes/mr_storage.hpp
@@ -1,0 +1,64 @@
+/**
+ * @file mr_storage.hpp
+ * @brief MR Image Storage SOP Classes
+ *
+ * Provides SOP Class definitions and utilities for Magnetic Resonance (MR)
+ * image storage. Supports both standard MR Image Storage and Enhanced MR
+ * Image Storage.
+ *
+ * @see DICOM PS3.4 Section B - Storage Service Class
+ * @see DICOM PS3.3 Section A.4 - MR Image IOD
+ * @see Issue #718 - Add MR Image IOD Validator
+ */
+
+#ifndef PACS_SERVICES_SOP_CLASSES_MR_STORAGE_HPP
+#define PACS_SERVICES_SOP_CLASSES_MR_STORAGE_HPP
+
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::services::sop_classes {
+
+// =============================================================================
+// MR Storage SOP Class UIDs
+// =============================================================================
+
+/// MR Image Storage SOP Class UID
+inline constexpr std::string_view mr_image_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.4";
+
+/// Enhanced MR Image Storage SOP Class UID
+inline constexpr std::string_view enhanced_mr_image_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.4.1";
+
+// =============================================================================
+// MR SOP Class Utilities
+// =============================================================================
+
+/**
+ * @brief Get all MR Storage SOP Class UIDs
+ * @return Vector of MR Storage SOP Class UIDs
+ */
+[[nodiscard]] std::vector<std::string> get_mr_storage_sop_classes();
+
+/**
+ * @brief Check if a SOP Class UID is an MR Storage SOP Class
+ * @param uid The SOP Class UID to check
+ * @return true if this is an MR storage SOP class
+ */
+[[nodiscard]] bool is_mr_storage_sop_class(std::string_view uid) noexcept;
+
+/**
+ * @brief Check if photometric interpretation is valid for MR
+ *
+ * MR images are always grayscale (MONOCHROME1 or MONOCHROME2).
+ *
+ * @param value The photometric interpretation string
+ * @return true if valid for MR images
+ */
+[[nodiscard]] bool is_valid_mr_photometric(std::string_view value) noexcept;
+
+}  // namespace pacs::services::sop_classes
+
+#endif  // PACS_SERVICES_SOP_CLASSES_MR_STORAGE_HPP

--- a/include/pacs/services/validation/mr_iod_validator.hpp
+++ b/include/pacs/services/validation/mr_iod_validator.hpp
@@ -1,0 +1,285 @@
+/**
+ * @file mr_iod_validator.hpp
+ * @brief MR Image IOD Validator
+ *
+ * Provides validation for MR Image Information Object Definitions
+ * as specified in DICOM PS3.3 Section A.4 (MR Image IOD).
+ *
+ * MR images include Frame of Reference for spatial registration and
+ * MR-specific acquisition parameters (MagneticFieldStrength, EchoTime,
+ * RepetitionTime, ScanningSequence, etc.).
+ *
+ * @see DICOM PS3.3 Section A.4 - MR Image IOD
+ * @see DICOM PS3.3 Table A.4-1 - MR Image IOD Modules
+ * @see Issue #718 - Add MR Image IOD Validator
+ */
+
+#ifndef PACS_SERVICES_VALIDATION_MR_IOD_VALIDATOR_HPP
+#define PACS_SERVICES_VALIDATION_MR_IOD_VALIDATOR_HPP
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/core/dicom_tag.hpp"
+#include "pacs/services/validation/us_iod_validator.hpp"  // Reuse validation types
+
+#include <string>
+#include <vector>
+
+namespace pacs::services::validation {
+
+// =============================================================================
+// MR-Specific DICOM Tags (not in core tag constants)
+// =============================================================================
+
+namespace mr_tags {
+
+/// Scanning Sequence (0018,0020) - Type 1
+/// Identifies the type of MR data acquisition sequence: SE, IR, GR, EP, RM
+inline constexpr core::dicom_tag scanning_sequence{0x0018, 0x0020};
+
+/// Sequence Variant (0018,0021) - Type 1
+/// Variant of the scanning sequence: SK, MTC, SS, TRSS, SP, MP, OSP, NONE
+inline constexpr core::dicom_tag sequence_variant{0x0018, 0x0021};
+
+/// Scan Options (0018,0022) - Type 2
+/// Additional scan parameters: PER, RG, CG, PPG, FC, PFF, PFP, SP, FS
+inline constexpr core::dicom_tag scan_options{0x0018, 0x0022};
+
+/// MR Acquisition Type (0018,0023) - Type 2
+/// Identifies the spatial data encoding scheme: 2D or 3D
+inline constexpr core::dicom_tag mr_acquisition_type{0x0018, 0x0023};
+
+/// Repetition Time (0018,0080) - Type 2C
+/// Time in ms between successive pulse sequences
+inline constexpr core::dicom_tag repetition_time{0x0018, 0x0080};
+
+/// Echo Time (0018,0081) - Type 2
+/// Time in ms between the middle of the excitation pulse and peak of echo
+inline constexpr core::dicom_tag echo_time{0x0018, 0x0081};
+
+/// Echo Train Length (0018,0091) - Type 2
+/// Number of echoes in a multi-echo acquisition
+inline constexpr core::dicom_tag echo_train_length{0x0018, 0x0091};
+
+/// Inversion Time (0018,0082) - Type 2C
+/// Time in ms between the inversion and excitation pulses
+inline constexpr core::dicom_tag inversion_time{0x0018, 0x0082};
+
+/// Magnetic Field Strength (0018,0087) - Type 2
+/// Nominal field strength of MR magnet in Tesla
+inline constexpr core::dicom_tag magnetic_field_strength{0x0018, 0x0087};
+
+/// Spacing Between Slices (0018,0088) - Type 2
+/// Distance between adjacent slices in mm
+inline constexpr core::dicom_tag spacing_between_slices{0x0018, 0x0088};
+
+/// Number of Phase Encoding Steps (0018,0089) - Type 2
+inline constexpr core::dicom_tag number_of_phase_encoding_steps{0x0018, 0x0089};
+
+/// Percent Sampling (0018,0093) - Type 2
+inline constexpr core::dicom_tag percent_sampling{0x0018, 0x0093};
+
+/// Percent Phase Field of View (0018,0094) - Type 2
+inline constexpr core::dicom_tag percent_phase_fov{0x0018, 0x0094};
+
+/// Pixel Bandwidth (0018,0095) - Type 2
+inline constexpr core::dicom_tag pixel_bandwidth{0x0018, 0x0095};
+
+/// Flip Angle (0018,1314) - Type 2
+/// Steady state angle in degrees
+inline constexpr core::dicom_tag flip_angle{0x0018, 0x1314};
+
+/// SAR (Specific Absorption Rate) (0018,1316) - Type 2
+inline constexpr core::dicom_tag sar{0x0018, 0x1316};
+
+/// Slice Thickness (0018,0050) - Type 2
+inline constexpr core::dicom_tag slice_thickness{0x0018, 0x0050};
+
+/// Image Position (Patient) (0020,0032)
+inline constexpr core::dicom_tag image_position_patient{0x0020, 0x0032};
+
+/// Image Orientation (Patient) (0020,0037)
+inline constexpr core::dicom_tag image_orientation_patient{0x0020, 0x0037};
+
+}  // namespace mr_tags
+
+// =============================================================================
+// MR Validation Options
+// =============================================================================
+
+/**
+ * @brief Options for MR IOD validation
+ */
+struct mr_validation_options {
+    /// Check Type 1 (required) attributes
+    bool check_type1 = true;
+
+    /// Check Type 2 (required, can be empty) attributes
+    bool check_type2 = true;
+
+    /// Check Type 1C/2C (conditionally required) attributes
+    bool check_conditional = true;
+
+    /// Validate pixel data consistency (rows, columns, bits)
+    bool validate_pixel_data = true;
+
+    /// Validate MR-specific acquisition parameters
+    bool validate_mr_params = true;
+
+    /// Strict mode - treat warnings as errors
+    bool strict_mode = false;
+};
+
+// =============================================================================
+// MR IOD Validator
+// =============================================================================
+
+/**
+ * @brief Validator for MR Image IODs
+ *
+ * Validates DICOM datasets against the MR Image IOD specification
+ * (PS3.3 Section A.4).
+ *
+ * ## Validated Modules (PS3.3 Table A.4-1)
+ *
+ * ### Mandatory Modules
+ * - Patient Module (M)
+ * - General Study Module (M)
+ * - General Series Module (M)
+ * - Frame of Reference Module (M)
+ * - General Equipment Module (M)
+ * - General Image Module (M)
+ * - Image Pixel Module (M)
+ * - MR Image Module (M)
+ * - SOP Common Module (M)
+ *
+ * @example
+ * @code
+ * mr_iod_validator validator;
+ * auto result = validator.validate(dataset);
+ *
+ * if (!result.is_valid) {
+ *     for (const auto& finding : result.findings) {
+ *         std::cerr << finding.message << "\n";
+ *     }
+ * }
+ * @endcode
+ */
+class mr_iod_validator {
+public:
+    /**
+     * @brief Construct validator with default options
+     */
+    mr_iod_validator() = default;
+
+    /**
+     * @brief Construct validator with custom options
+     * @param options Validation options
+     */
+    explicit mr_iod_validator(const mr_validation_options& options);
+
+    /**
+     * @brief Validate a DICOM dataset against MR IOD
+     * @param dataset The dataset to validate
+     * @return Validation result with all findings
+     */
+    [[nodiscard]] validation_result validate(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Quick check if dataset has minimum required MR attributes
+     * @param dataset The dataset to check
+     * @return true if all Type 1 attributes are present
+     */
+    [[nodiscard]] bool quick_check(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Get the validation options
+     */
+    [[nodiscard]] const mr_validation_options& options() const noexcept;
+
+    /**
+     * @brief Set validation options
+     */
+    void set_options(const mr_validation_options& options);
+
+private:
+    // Module validation methods
+    void validate_patient_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_study_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_series_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_frame_of_reference_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_equipment_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_mr_image_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_image_pixel_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_sop_common_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    // Attribute validation helpers
+    void check_type1_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_type2_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_modality(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void check_pixel_data_consistency(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    mr_validation_options options_;
+};
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+/**
+ * @brief Validate an MR dataset with default options
+ * @param dataset The dataset to validate
+ * @return Validation result
+ */
+[[nodiscard]] validation_result validate_mr_iod(
+    const core::dicom_dataset& dataset);
+
+/**
+ * @brief Quick check if a dataset is a valid MR image
+ * @param dataset The dataset to check
+ * @return true if the dataset passes basic MR IOD validation
+ */
+[[nodiscard]] bool is_valid_mr_dataset(const core::dicom_dataset& dataset);
+
+}  // namespace pacs::services::validation
+
+#endif  // PACS_SERVICES_VALIDATION_MR_IOD_VALIDATOR_HPP

--- a/src/services/sop_classes/mr_storage.cpp
+++ b/src/services/sop_classes/mr_storage.cpp
@@ -1,0 +1,28 @@
+/**
+ * @file mr_storage.cpp
+ * @brief Implementation of MR Image Storage SOP Class utilities
+ *
+ * @see Issue #718 - Add MR Image IOD Validator
+ */
+
+#include "pacs/services/sop_classes/mr_storage.hpp"
+
+namespace pacs::services::sop_classes {
+
+std::vector<std::string> get_mr_storage_sop_classes() {
+    return {
+        std::string(mr_image_storage_uid),
+        std::string(enhanced_mr_image_storage_uid),
+    };
+}
+
+bool is_mr_storage_sop_class(std::string_view uid) noexcept {
+    return uid == mr_image_storage_uid ||
+           uid == enhanced_mr_image_storage_uid;
+}
+
+bool is_valid_mr_photometric(std::string_view value) noexcept {
+    return value == "MONOCHROME1" || value == "MONOCHROME2";
+}
+
+}  // namespace pacs::services::sop_classes

--- a/src/services/validation/mr_iod_validator.cpp
+++ b/src/services/validation/mr_iod_validator.cpp
@@ -1,0 +1,480 @@
+/**
+ * @file mr_iod_validator.cpp
+ * @brief Implementation of MR Image IOD Validator
+ *
+ * @see DICOM PS3.3 Section A.4 - MR Image IOD
+ * @see Issue #718 - Add MR Image IOD Validator
+ */
+
+#include "pacs/services/validation/mr_iod_validator.hpp"
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/services/sop_classes/mr_storage.hpp"
+
+namespace pacs::services::validation {
+
+using namespace pacs::core;
+
+// =============================================================================
+// mr_iod_validator Implementation
+// =============================================================================
+
+mr_iod_validator::mr_iod_validator(const mr_validation_options& options)
+    : options_(options) {}
+
+validation_result mr_iod_validator::validate(
+    const dicom_dataset& dataset) const {
+    validation_result result;
+    result.is_valid = true;
+
+    // Validate mandatory modules (PS3.3 Table A.4-1)
+    if (options_.check_type1 || options_.check_type2) {
+        validate_patient_module(dataset, result.findings);
+        validate_general_study_module(dataset, result.findings);
+        validate_general_series_module(dataset, result.findings);
+        validate_frame_of_reference_module(dataset, result.findings);
+        validate_general_equipment_module(dataset, result.findings);
+        validate_sop_common_module(dataset, result.findings);
+    }
+
+    if (options_.validate_mr_params) {
+        validate_mr_image_module(dataset, result.findings);
+    }
+
+    if (options_.validate_pixel_data) {
+        validate_image_pixel_module(dataset, result.findings);
+    }
+
+    // Determine overall validity
+    for (const auto& finding : result.findings) {
+        if (finding.severity == validation_severity::error) {
+            result.is_valid = false;
+            break;
+        }
+        if (options_.strict_mode &&
+            finding.severity == validation_severity::warning) {
+            result.is_valid = false;
+            break;
+        }
+    }
+
+    return result;
+}
+
+bool mr_iod_validator::quick_check(const dicom_dataset& dataset) const {
+    // Check only Type 1 required attributes for quick validation
+
+    // General Study Module Type 1
+    if (!dataset.contains(tags::study_instance_uid)) return false;
+
+    // General Series Module Type 1
+    if (!dataset.contains(tags::modality)) return false;
+    if (!dataset.contains(tags::series_instance_uid)) return false;
+
+    // Check modality is MR
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "MR") return false;
+
+    // Frame of Reference Module Type 1
+    if (!dataset.contains(tags::frame_of_reference_uid)) return false;
+
+    // MR Image Module Type 1
+    if (!dataset.contains(mr_tags::scanning_sequence)) return false;
+    if (!dataset.contains(mr_tags::sequence_variant)) return false;
+
+    // Image Pixel Module Type 1
+    if (!dataset.contains(tags::samples_per_pixel)) return false;
+    if (!dataset.contains(tags::photometric_interpretation)) return false;
+    if (!dataset.contains(tags::rows)) return false;
+    if (!dataset.contains(tags::columns)) return false;
+    if (!dataset.contains(tags::bits_allocated)) return false;
+    if (!dataset.contains(tags::bits_stored)) return false;
+    if (!dataset.contains(tags::high_bit)) return false;
+    if (!dataset.contains(tags::pixel_representation)) return false;
+    if (!dataset.contains(tags::pixel_data)) return false;
+
+    // SOP Common Module Type 1
+    if (!dataset.contains(tags::sop_class_uid)) return false;
+    if (!dataset.contains(tags::sop_instance_uid)) return false;
+
+    return true;
+}
+
+const mr_validation_options& mr_iod_validator::options() const noexcept {
+    return options_;
+}
+
+void mr_iod_validator::set_options(const mr_validation_options& options) {
+    options_ = options;
+}
+
+// =============================================================================
+// Module Validation Methods
+// =============================================================================
+
+void mr_iod_validator::validate_patient_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Patient Module - All attributes are Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::patient_name, "PatientName",
+                              findings);
+        check_type2_attribute(dataset, tags::patient_id, "PatientID",
+                              findings);
+        check_type2_attribute(dataset, tags::patient_birth_date,
+                              "PatientBirthDate", findings);
+        check_type2_attribute(dataset, tags::patient_sex, "PatientSex",
+                              findings);
+    }
+}
+
+void mr_iod_validator::validate_general_study_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::study_instance_uid,
+                              "StudyInstanceUID", findings);
+    }
+
+    // Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::study_date, "StudyDate",
+                              findings);
+        check_type2_attribute(dataset, tags::study_time, "StudyTime",
+                              findings);
+        check_type2_attribute(dataset, tags::referring_physician_name,
+                              "ReferringPhysicianName", findings);
+        check_type2_attribute(dataset, tags::study_id, "StudyID", findings);
+        check_type2_attribute(dataset, tags::accession_number,
+                              "AccessionNumber", findings);
+    }
+}
+
+void mr_iod_validator::validate_general_series_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::modality, "Modality", findings);
+        check_type1_attribute(dataset, tags::series_instance_uid,
+                              "SeriesInstanceUID", findings);
+
+        // Modality must be "MR"
+        check_modality(dataset, findings);
+    }
+
+    // Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::series_number, "SeriesNumber",
+                              findings);
+    }
+}
+
+void mr_iod_validator::validate_frame_of_reference_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Frame of Reference UID is Type 1 for MR
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::frame_of_reference_uid,
+                              "FrameOfReferenceUID", findings);
+    }
+
+    // Position Reference Indicator is Type 2
+    if (options_.check_type2) {
+        constexpr dicom_tag position_reference_indicator{0x0020, 0x1040};
+        check_type2_attribute(dataset, position_reference_indicator,
+                              "PositionReferenceIndicator", findings);
+    }
+}
+
+void mr_iod_validator::validate_general_equipment_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Manufacturer is Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::manufacturer, "Manufacturer",
+                              findings);
+    }
+}
+
+void mr_iod_validator::validate_mr_image_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // MR Image Module (PS3.3 Section C.8.3.1)
+
+    // Type 1 attributes
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::image_type, "ImageType",
+                              findings);
+        check_type1_attribute(dataset, mr_tags::scanning_sequence,
+                              "ScanningSequence", findings);
+        check_type1_attribute(dataset, mr_tags::sequence_variant,
+                              "SequenceVariant", findings);
+    }
+
+    // Type 2 attributes specific to MR Image Module
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, mr_tags::scan_options, "ScanOptions",
+                              findings);
+        check_type2_attribute(dataset, mr_tags::mr_acquisition_type,
+                              "MRAcquisitionType", findings);
+        check_type2_attribute(dataset, mr_tags::echo_time, "EchoTime",
+                              findings);
+        check_type2_attribute(dataset, mr_tags::echo_train_length,
+                              "EchoTrainLength", findings);
+        check_type2_attribute(dataset, mr_tags::magnetic_field_strength,
+                              "MagneticFieldStrength", findings);
+    }
+
+    // Type 2C - RepetitionTime is required if ImageType Value 1 is ORIGINAL
+    if (options_.check_conditional) {
+        if (dataset.contains(tags::image_type)) {
+            auto image_type = dataset.get_string(tags::image_type);
+            if (image_type.find("ORIGINAL") != std::string::npos &&
+                !dataset.contains(mr_tags::repetition_time)) {
+                findings.push_back(
+                    {validation_severity::warning, mr_tags::repetition_time,
+                     "RepetitionTime (0018,0080) missing - required when "
+                     "ImageType Value 1 is ORIGINAL",
+                     "MR-WARN-001"});
+            }
+        }
+
+        // InversionTime is Type 2C - required if ScanningSequence contains IR
+        if (dataset.contains(mr_tags::scanning_sequence)) {
+            auto seq = dataset.get_string(mr_tags::scanning_sequence);
+            if (seq.find("IR") != std::string::npos &&
+                !dataset.contains(mr_tags::inversion_time)) {
+                findings.push_back(
+                    {validation_severity::warning, mr_tags::inversion_time,
+                     "InversionTime (0018,0082) missing - required when "
+                     "ScanningSequence contains IR",
+                     "MR-WARN-002"});
+            }
+        }
+
+        // SliceThickness informational check
+        if (!dataset.contains(mr_tags::slice_thickness)) {
+            findings.push_back(
+                {validation_severity::info, mr_tags::slice_thickness,
+                 "SliceThickness (0018,0050) not present - slice geometry "
+                 "information unavailable",
+                 "MR-INFO-001"});
+        }
+
+        // Image Position (Patient) is Type 1C - required if
+        // Frame of Reference Module is present
+        if (dataset.contains(tags::frame_of_reference_uid) &&
+            !dataset.contains(mr_tags::image_position_patient)) {
+            findings.push_back(
+                {validation_severity::warning,
+                 mr_tags::image_position_patient,
+                 "ImagePositionPatient (0020,0032) missing - required when "
+                 "Frame of Reference is present",
+                 "MR-WARN-003"});
+        }
+
+        // Image Orientation (Patient) is Type 1C
+        if (dataset.contains(tags::frame_of_reference_uid) &&
+            !dataset.contains(mr_tags::image_orientation_patient)) {
+            findings.push_back(
+                {validation_severity::warning,
+                 mr_tags::image_orientation_patient,
+                 "ImageOrientationPatient (0020,0037) missing - required when "
+                 "Frame of Reference is present",
+                 "MR-WARN-004"});
+        }
+    }
+}
+
+void mr_iod_validator::validate_image_pixel_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1 attributes
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::samples_per_pixel,
+                              "SamplesPerPixel", findings);
+        check_type1_attribute(dataset, tags::photometric_interpretation,
+                              "PhotometricInterpretation", findings);
+        check_type1_attribute(dataset, tags::rows, "Rows", findings);
+        check_type1_attribute(dataset, tags::columns, "Columns", findings);
+        check_type1_attribute(dataset, tags::bits_allocated, "BitsAllocated",
+                              findings);
+        check_type1_attribute(dataset, tags::bits_stored, "BitsStored",
+                              findings);
+        check_type1_attribute(dataset, tags::high_bit, "HighBit", findings);
+        check_type1_attribute(dataset, tags::pixel_representation,
+                              "PixelRepresentation", findings);
+        check_type1_attribute(dataset, tags::pixel_data, "PixelData",
+                              findings);
+    }
+
+    // Validate pixel data consistency
+    if (options_.validate_pixel_data) {
+        check_pixel_data_consistency(dataset, findings);
+    }
+}
+
+void mr_iod_validator::validate_sop_common_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::sop_class_uid, "SOPClassUID",
+                              findings);
+        check_type1_attribute(dataset, tags::sop_instance_uid,
+                              "SOPInstanceUID", findings);
+    }
+
+    // Validate SOP Class UID is an MR storage class
+    if (dataset.contains(tags::sop_class_uid)) {
+        auto sop_class = dataset.get_string(tags::sop_class_uid);
+        if (!sop_classes::is_mr_storage_sop_class(sop_class)) {
+            findings.push_back(
+                {validation_severity::error, tags::sop_class_uid,
+                 "SOPClassUID is not a recognized MR Storage SOP Class: " +
+                     sop_class,
+                 "MR-ERR-001"});
+        }
+    }
+}
+
+// =============================================================================
+// Attribute Validation Helpers
+// =============================================================================
+
+void mr_iod_validator::check_type1_attribute(
+    const dicom_dataset& dataset, dicom_tag tag, std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tag)) {
+        findings.push_back(
+            {validation_severity::error, tag,
+             std::string("Type 1 attribute missing: ") + std::string(name) +
+                 " (" + tag.to_string() + ")",
+             "MR-TYPE1-MISSING"});
+    } else {
+        // Type 1 must have a value (cannot be empty)
+        auto value = dataset.get_string(tag);
+        if (value.empty()) {
+            findings.push_back(
+                {validation_severity::error, tag,
+                 std::string("Type 1 attribute has empty value: ") +
+                     std::string(name) + " (" + tag.to_string() + ")",
+                 "MR-TYPE1-EMPTY"});
+        }
+    }
+}
+
+void mr_iod_validator::check_type2_attribute(
+    const dicom_dataset& dataset, dicom_tag tag, std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 2 must be present but can be empty
+    if (!dataset.contains(tag)) {
+        findings.push_back(
+            {validation_severity::warning, tag,
+             std::string("Type 2 attribute missing: ") + std::string(name) +
+                 " (" + tag.to_string() + ")",
+             "MR-TYPE2-MISSING"});
+    }
+}
+
+void mr_iod_validator::check_modality(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tags::modality)) {
+        return;  // Already reported as Type 1 missing
+    }
+
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "MR") {
+        findings.push_back(
+            {validation_severity::error, tags::modality,
+             "Modality must be 'MR' for MR images, found: " + modality,
+             "MR-ERR-002"});
+    }
+}
+
+void mr_iod_validator::check_pixel_data_consistency(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Check BitsStored <= BitsAllocated
+    auto bits_allocated =
+        dataset.get_numeric<uint16_t>(tags::bits_allocated);
+    auto bits_stored = dataset.get_numeric<uint16_t>(tags::bits_stored);
+    auto high_bit = dataset.get_numeric<uint16_t>(tags::high_bit);
+
+    if (bits_allocated && bits_stored) {
+        if (*bits_stored > *bits_allocated) {
+            findings.push_back(
+                {validation_severity::error, tags::bits_stored,
+                 "BitsStored (" + std::to_string(*bits_stored) +
+                     ") exceeds BitsAllocated (" +
+                     std::to_string(*bits_allocated) + ")",
+                 "MR-ERR-003"});
+        }
+    }
+
+    // Check HighBit == BitsStored - 1
+    if (bits_stored && high_bit) {
+        if (*high_bit != *bits_stored - 1) {
+            findings.push_back(
+                {validation_severity::warning, tags::high_bit,
+                 "HighBit (" + std::to_string(*high_bit) +
+                     ") should typically be BitsStored - 1 (" +
+                     std::to_string(*bits_stored - 1) + ")",
+                 "MR-WARN-005"});
+        }
+    }
+
+    // MR images must be grayscale (MONOCHROME1 or MONOCHROME2)
+    if (dataset.contains(tags::photometric_interpretation)) {
+        auto photometric =
+            dataset.get_string(tags::photometric_interpretation);
+        if (!sop_classes::is_valid_mr_photometric(photometric)) {
+            findings.push_back(
+                {validation_severity::error,
+                 tags::photometric_interpretation,
+                 "MR images must use MONOCHROME1 or MONOCHROME2, found: " +
+                     photometric,
+                 "MR-ERR-004"});
+        }
+    }
+
+    // MR images must have SamplesPerPixel = 1
+    auto samples = dataset.get_numeric<uint16_t>(tags::samples_per_pixel);
+    if (samples && *samples != 1) {
+        findings.push_back(
+            {validation_severity::error, tags::samples_per_pixel,
+             "MR images require SamplesPerPixel = 1, found: " +
+                 std::to_string(*samples),
+             "MR-ERR-005"});
+    }
+}
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+validation_result validate_mr_iod(const dicom_dataset& dataset) {
+    mr_iod_validator validator;
+    return validator.validate(dataset);
+}
+
+bool is_valid_mr_dataset(const dicom_dataset& dataset) {
+    mr_iod_validator validator;
+    return validator.quick_check(dataset);
+}
+
+}  // namespace pacs::services::validation

--- a/tests/services/mr_iod_validator_test.cpp
+++ b/tests/services/mr_iod_validator_test.cpp
@@ -1,0 +1,663 @@
+/**
+ * @file mr_iod_validator_test.cpp
+ * @brief Unit tests for MR Image IOD Validator
+ *
+ * @see DICOM PS3.3 Section A.4 - MR Image IOD
+ * @see Issue #718 - Add MR Image IOD Validator
+ */
+
+#include <pacs/services/validation/mr_iod_validator.hpp>
+#include <pacs/services/sop_classes/mr_storage.hpp>
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_element.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services::validation;
+using namespace pacs::services::sop_classes;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+// ============================================================================
+// Test Fixtures - Helper Functions
+// ============================================================================
+
+namespace {
+
+/// Helper to create a minimal valid MR dataset
+dicom_dataset create_minimal_mr_dataset() {
+    dicom_dataset ds;
+
+    // Patient Module (Type 2)
+    ds.set_string(tags::patient_name, vr_type::PN, "Test^Patient");
+    ds.set_string(tags::patient_id, vr_type::LO, "MR12345");
+    ds.set_string(tags::patient_birth_date, vr_type::DA, "19700101");
+    ds.set_string(tags::patient_sex, vr_type::CS, "M");
+
+    // General Study Module
+    ds.set_string(tags::study_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9");
+    ds.set_string(tags::study_date, vr_type::DA, "20240101");
+    ds.set_string(tags::study_time, vr_type::TM, "120000");
+    ds.set_string(tags::referring_physician_name, vr_type::PN,
+                  "Dr^Referring");
+    ds.set_string(tags::study_id, vr_type::SH, "STUDY001");
+    ds.set_string(tags::accession_number, vr_type::SH, "ACC001");
+
+    // General Series Module
+    ds.set_string(tags::modality, vr_type::CS, "MR");
+    ds.set_string(tags::series_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.1");
+    ds.set_string(tags::series_number, vr_type::IS, "1");
+
+    // Frame of Reference Module (Type 1 for MR)
+    ds.set_string(tags::frame_of_reference_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.3");
+    constexpr dicom_tag position_reference_indicator{0x0020, 0x1040};
+    ds.set_string(position_reference_indicator, vr_type::LO, "");
+
+    // General Equipment Module
+    ds.set_string(tags::manufacturer, vr_type::LO, "TestManufacturer");
+
+    // Image Pixel Module
+    ds.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 1);
+    ds.set_string(tags::photometric_interpretation, vr_type::CS,
+                  "MONOCHROME2");
+    ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 256);
+    ds.set_numeric<uint16_t>(tags::columns, vr_type::US, 256);
+    ds.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 16);
+    ds.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 12);
+    ds.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 11);
+    ds.set_numeric<uint16_t>(tags::pixel_representation, vr_type::US, 0);
+
+    // Pixel Data (minimal placeholder)
+    std::vector<uint8_t> pixel_data(100, 0);
+    ds.insert(dicom_element(tags::pixel_data, vr_type::OW, pixel_data));
+
+    // MR Image Module
+    ds.set_string(tags::image_type, vr_type::CS, "ORIGINAL\\PRIMARY");
+    ds.set_string(mr_tags::scanning_sequence, vr_type::CS, "SE");
+    ds.set_string(mr_tags::sequence_variant, vr_type::CS, "NONE");
+    ds.set_string(mr_tags::scan_options, vr_type::CS, "");
+    ds.set_string(mr_tags::mr_acquisition_type, vr_type::CS, "2D");
+    ds.set_string(mr_tags::repetition_time, vr_type::DS, "500");
+    ds.set_string(mr_tags::echo_time, vr_type::DS, "15");
+    ds.set_string(mr_tags::echo_train_length, vr_type::IS, "1");
+    ds.set_string(mr_tags::magnetic_field_strength, vr_type::DS, "1.5");
+    ds.set_string(mr_tags::slice_thickness, vr_type::DS, "5.0");
+    ds.set_string(mr_tags::image_position_patient, vr_type::DS,
+                  "0.0\\0.0\\0.0");
+    ds.set_string(mr_tags::image_orientation_patient, vr_type::DS,
+                  "1.0\\0.0\\0.0\\0.0\\1.0\\0.0");
+
+    // SOP Common Module
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  std::string(mr_image_storage_uid));
+    ds.set_string(tags::sop_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.2");
+
+    return ds;
+}
+
+}  // namespace
+
+// ============================================================================
+// MR IOD Validator Basic Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator validates minimal valid dataset",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+    auto dataset = create_minimal_mr_dataset();
+
+    auto result = validator.validate(dataset);
+
+    CHECK(result.is_valid);
+    CHECK_FALSE(result.has_errors());
+}
+
+TEST_CASE("mr_iod_validator detects missing Type 1 attributes",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+    auto dataset = create_minimal_mr_dataset();
+
+    SECTION("missing StudyInstanceUID") {
+        dataset.remove(tags::study_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+        CHECK(result.has_errors());
+    }
+
+    SECTION("missing Modality") {
+        dataset.remove(tags::modality);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SeriesInstanceUID") {
+        dataset.remove(tags::series_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing FrameOfReferenceUID") {
+        dataset.remove(tags::frame_of_reference_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPClassUID") {
+        dataset.remove(tags::sop_class_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPInstanceUID") {
+        dataset.remove(tags::sop_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing Rows") {
+        dataset.remove(tags::rows);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing ImageType") {
+        dataset.remove(tags::image_type);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing ScanningSequence") {
+        dataset.remove(mr_tags::scanning_sequence);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SequenceVariant") {
+        dataset.remove(mr_tags::sequence_variant);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// Type 2 Attribute Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator detects missing Type 2 attributes",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+    auto dataset = create_minimal_mr_dataset();
+
+    SECTION("missing PatientName generates warning") {
+        dataset.remove(tags::patient_name);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing StudyDate generates warning") {
+        dataset.remove(tags::study_date);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing EchoTime generates warning") {
+        dataset.remove(mr_tags::echo_time);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing MagneticFieldStrength generates warning") {
+        dataset.remove(mr_tags::magnetic_field_strength);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing MRAcquisitionType generates warning") {
+        dataset.remove(mr_tags::mr_acquisition_type);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing Manufacturer generates warning") {
+        dataset.remove(tags::manufacturer);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+}
+
+// ============================================================================
+// Modality Validation Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator checks modality value",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+    auto dataset = create_minimal_mr_dataset();
+
+    SECTION("wrong modality - CT") {
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-ERR-002") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK(found_modality_error);
+    }
+
+    SECTION("wrong modality - US") {
+        dataset.set_string(tags::modality, vr_type::CS, "US");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// SOP Class UID Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator checks SOP Class UID",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+    auto dataset = create_minimal_mr_dataset();
+
+    SECTION("standard MR Image Storage is valid") {
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(mr_image_storage_uid));
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+    }
+
+    SECTION("Enhanced MR Image Storage is valid") {
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(enhanced_mr_image_storage_uid));
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+    }
+
+    SECTION("non-MR SOP Class is invalid") {
+        // CT SOP Class
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          "1.2.840.10008.5.1.4.1.1.2");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-ERR-001") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK(found_sop_error);
+    }
+}
+
+// ============================================================================
+// Pixel Data Consistency Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator checks pixel data consistency",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+    auto dataset = create_minimal_mr_dataset();
+
+    SECTION("BitsStored exceeds BitsAllocated") {
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 20);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-ERR-003") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK(found_bits_error);
+    }
+
+    SECTION("wrong HighBit generates warning") {
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 15);
+        auto result = validator.validate(dataset);
+        CHECK(result.has_warnings());
+
+        bool found_highbit_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-WARN-005") {
+                found_highbit_warning = true;
+                break;
+            }
+        }
+        CHECK(found_highbit_warning);
+    }
+
+    SECTION("non-grayscale SamplesPerPixel is invalid") {
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 3);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_samples_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-ERR-005") {
+                found_samples_error = true;
+                break;
+            }
+        }
+        CHECK(found_samples_error);
+    }
+
+    SECTION("RGB photometric interpretation is invalid for MR") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "RGB");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-ERR-004") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK(found_photometric_error);
+    }
+}
+
+// ============================================================================
+// MR-Specific Conditional Attribute Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator checks MR-specific conditional attributes",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+    auto dataset = create_minimal_mr_dataset();
+
+    SECTION("missing SliceThickness generates info") {
+        dataset.remove(mr_tags::slice_thickness);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_thickness_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-INFO-001") {
+                found_thickness_info = true;
+                break;
+            }
+        }
+        CHECK(found_thickness_info);
+    }
+
+    SECTION("missing RepetitionTime with ORIGINAL ImageType generates "
+            "warning") {
+        dataset.remove(mr_tags::repetition_time);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+
+        bool found_rt_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-WARN-001") {
+                found_rt_warning = true;
+                break;
+            }
+        }
+        CHECK(found_rt_warning);
+    }
+
+    SECTION("missing RepetitionTime with DERIVED ImageType is acceptable") {
+        dataset.set_string(tags::image_type, vr_type::CS,
+                          "DERIVED\\SECONDARY");
+        dataset.remove(mr_tags::repetition_time);
+        auto result = validator.validate(dataset);
+
+        bool found_rt_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-WARN-001") {
+                found_rt_warning = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_rt_warning);
+    }
+
+    SECTION("missing InversionTime with IR ScanningSequence generates "
+            "warning") {
+        dataset.set_string(mr_tags::scanning_sequence, vr_type::CS, "IR");
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+
+        bool found_it_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-WARN-002") {
+                found_it_warning = true;
+                break;
+            }
+        }
+        CHECK(found_it_warning);
+    }
+
+    SECTION("InversionTime present with IR ScanningSequence is fine") {
+        dataset.set_string(mr_tags::scanning_sequence, vr_type::CS, "IR");
+        dataset.set_string(mr_tags::inversion_time, vr_type::DS, "2500");
+        auto result = validator.validate(dataset);
+
+        bool found_it_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-WARN-002") {
+                found_it_warning = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_it_warning);
+    }
+
+    SECTION("missing ImagePositionPatient with FrameOfReference generates "
+            "warning") {
+        dataset.remove(mr_tags::image_position_patient);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+
+        bool found_position_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-WARN-003") {
+                found_position_warning = true;
+                break;
+            }
+        }
+        CHECK(found_position_warning);
+    }
+
+    SECTION("missing ImageOrientationPatient with FrameOfReference generates "
+            "warning") {
+        dataset.remove(mr_tags::image_orientation_patient);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+
+        bool found_orientation_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-WARN-004") {
+                found_orientation_warning = true;
+                break;
+            }
+        }
+        CHECK(found_orientation_warning);
+    }
+}
+
+// ============================================================================
+// Quick Check Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator quick_check works correctly",
+          "[services][mr][validator]") {
+    mr_iod_validator validator;
+
+    SECTION("valid dataset passes quick check") {
+        auto dataset = create_minimal_mr_dataset();
+        CHECK(validator.quick_check(dataset));
+    }
+
+    SECTION("invalid modality fails quick check") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing required attribute fails quick check") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.remove(tags::rows);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing FrameOfReferenceUID fails quick check") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.remove(tags::frame_of_reference_uid);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing PixelData fails quick check") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.remove(tags::pixel_data);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing ScanningSequence fails quick check") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.remove(mr_tags::scanning_sequence);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing SequenceVariant fails quick check") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.remove(mr_tags::sequence_variant);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+}
+
+// ============================================================================
+// Custom Options Tests
+// ============================================================================
+
+TEST_CASE("mr_iod_validator with custom options",
+          "[services][mr][validator]") {
+
+    SECTION("strict mode treats warnings as errors") {
+        mr_validation_options options;
+        options.strict_mode = true;
+
+        mr_iod_validator validator(options);
+        auto dataset = create_minimal_mr_dataset();
+
+        // Remove a Type 2 attribute to get a warning
+        dataset.remove(tags::patient_name);
+
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("can disable MR parameter validation") {
+        mr_validation_options options;
+        options.validate_mr_params = false;
+
+        mr_iod_validator validator(options);
+        auto dataset = create_minimal_mr_dataset();
+        dataset.remove(tags::image_type);
+
+        auto result = validator.validate(dataset);
+        // ImageType is checked by MR Image Module; disabling MR params
+        // skips that module
+        CHECK(result.findings.size() >= 0);
+    }
+
+    SECTION("can disable pixel data validation") {
+        mr_validation_options options;
+        options.validate_pixel_data = false;
+
+        mr_iod_validator validator(options);
+        auto dataset = create_minimal_mr_dataset();
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 20);
+
+        auto result = validator.validate(dataset);
+        // Should not have pixel data errors when validation is disabled
+        bool found_pixel_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "MR-ERR-003") {
+                found_pixel_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_pixel_error);
+    }
+
+    SECTION("options getter returns current options") {
+        mr_validation_options options;
+        options.strict_mode = true;
+        options.validate_mr_params = false;
+
+        mr_iod_validator validator(options);
+        CHECK(validator.options().strict_mode);
+        CHECK_FALSE(validator.options().validate_mr_params);
+    }
+
+    SECTION("set_options updates options") {
+        mr_iod_validator validator;
+        CHECK_FALSE(validator.options().strict_mode);
+
+        mr_validation_options new_options;
+        new_options.strict_mode = true;
+        validator.set_options(new_options);
+
+        CHECK(validator.options().strict_mode);
+    }
+}
+
+// ============================================================================
+// Convenience Function Tests
+// ============================================================================
+
+TEST_CASE("validate_mr_iod convenience function",
+          "[services][mr][validator]") {
+    auto dataset = create_minimal_mr_dataset();
+    auto result = validate_mr_iod(dataset);
+    CHECK(result.is_valid);
+}
+
+TEST_CASE("is_valid_mr_dataset convenience function",
+          "[services][mr][validator]") {
+    SECTION("valid dataset") {
+        auto dataset = create_minimal_mr_dataset();
+        CHECK(is_valid_mr_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - wrong modality") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(is_valid_mr_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - missing pixel data") {
+        auto dataset = create_minimal_mr_dataset();
+        dataset.remove(tags::pixel_data);
+        CHECK_FALSE(is_valid_mr_dataset(dataset));
+    }
+}


### PR DESCRIPTION
Closes #718

## Summary
- Add MR Image Storage SOP Class definitions (`mr_storage.hpp/cpp`) with standard and Enhanced MR UIDs
- Implement `mr_iod_validator` following the established IOD validator pattern for 9 mandatory modules per PS3.3 Table A.4-1
- Validate MR-specific attributes: ScanningSequence (Type 1), SequenceVariant (Type 1), EchoTime, MagneticFieldStrength, RepetitionTime (Type 2C), InversionTime (Type 2C for IR sequences)
- Add comprehensive test suite with 74 assertions across 11 test cases

## Test Plan
- [x] All 74 MR IOD validator test assertions pass
- [x] Existing CT IOD validator tests (64 assertions) unaffected
- [x] Full project builds successfully
- [ ] Manual verification with real MR DICOM datasets