### PR TITLE
feat(services): implement N-GET SCP/SCU service (#720)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -974,6 +974,8 @@ add_library(pacs_services
     src/services/worklist_scu.cpp
     src/services/mpps_scp.cpp
     src/services/mpps_scu.cpp
+    src/services/n_get_scp.cpp
+    src/services/n_get_scu.cpp
     src/services/storage_commitment_scp.cpp
     src/services/storage_commitment_scu.cpp
     src/services/sop_class_registry.cpp
@@ -1765,6 +1767,8 @@ if(PACS_BUILD_TESTS)
         tests/services/worklist_scu_test.cpp
         tests/services/mpps_scp_test.cpp
         tests/services/mpps_scu_test.cpp
+        tests/services/n_get_scp_test.cpp
+        tests/services/n_get_scu_test.cpp
         tests/services/storage_commitment_types_test.cpp
         tests/services/storage_commitment_scp_test.cpp
         tests/services/storage_commitment_scu_test.cpp

--- a/include/pacs/core/result.hpp
+++ b/include/pacs/core/result.hpp
@@ -180,6 +180,13 @@ namespace error_codes {
     constexpr int worklist_handler_not_set = service_base - 80;
     constexpr int worklist_unexpected_command = service_base - 81;
 
+    // N-GET service errors (-882 to -886)
+    constexpr int n_get_handler_not_set = service_base - 82;
+    constexpr int n_get_unexpected_command = service_base - 83;
+    constexpr int n_get_instance_not_found = service_base - 84;
+    constexpr int n_get_context_not_accepted = service_base - 85;
+    constexpr int n_get_missing_uid = service_base - 86;
+
     // General service errors (-890 to -899)
     constexpr int association_not_established = service_base - 90;
     constexpr int file_not_found_service = service_base - 91;

--- a/include/pacs/services/n_get_scp.hpp
+++ b/include/pacs/services/n_get_scp.hpp
@@ -1,0 +1,213 @@
+/**
+ * @file n_get_scp.hpp
+ * @brief DICOM N-GET SCP service for attribute retrieval
+ *
+ * This file provides the n_get_scp class for handling N-GET-RQ messages
+ * to retrieve attributes from managed SOP Instances (e.g., MPPS status).
+ *
+ * @see DICOM PS3.7 Section 10.1.2 - N-GET Service
+ * @see Issue #720 - Implement N-GET SCP/SCU service
+ */
+
+#ifndef PACS_SERVICES_N_GET_SCP_HPP
+#define PACS_SERVICES_N_GET_SCP_HPP
+
+#include "scp_service.hpp"
+
+#include <atomic>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace pacs::services {
+
+// =============================================================================
+// Handler Types
+// =============================================================================
+
+/**
+ * @brief N-GET handler function type
+ *
+ * Called when an N-GET request is received to retrieve attributes from
+ * a managed SOP Instance.
+ *
+ * The handler should:
+ * 1. Look up the SOP Instance by its UID
+ * 2. If attribute_tags is empty, return all attributes
+ * 3. If attribute_tags is not empty, return only the requested attributes
+ * 4. Return the dataset containing the requested attributes
+ *
+ * @param sop_class_uid The SOP Class UID of the instance
+ * @param sop_instance_uid The SOP Instance UID to look up
+ * @param attribute_tags Tags to retrieve (empty = all attributes)
+ * @return Dataset containing the requested attributes, or error
+ */
+using n_get_handler = std::function<network::Result<core::dicom_dataset>(
+    const std::string& sop_class_uid,
+    const std::string& sop_instance_uid,
+    const std::vector<core::dicom_tag>& attribute_tags)>;
+
+// =============================================================================
+// N-GET SCP Class
+// =============================================================================
+
+/**
+ * @brief N-GET SCP service for attribute retrieval from managed SOP Instances
+ *
+ * The N-GET SCP (Service Class Provider) responds to N-GET-RQ messages
+ * by looking up the requested SOP Instance and returning its attributes.
+ *
+ * ## N-GET Message Flow
+ *
+ * ```
+ * SCU (Client)                          SCP (Server)
+ *  |                                     |
+ *  |  N-GET-RQ                           |
+ *  |  +-----------------------------+    |
+ *  |  | RequestedSOPClass: MPPS     |    |
+ *  |  | RequestedSOPInstance: UID   |    |
+ *  |  | AttributeIdentifierList    |    |
+ *  |  +-----------------------------+    |
+ *  |----------------------------------->|
+ *  |                                     |
+ *  |                            Look up  |
+ *  |                            instance |
+ *  |                                     |
+ *  |  N-GET-RSP + Dataset                |
+ *  |<-----------------------------------|
+ * ```
+ *
+ * @example Usage
+ * @code
+ * n_get_scp scp;
+ *
+ * scp.set_handler([&store](const auto& sop_class, const auto& uid,
+ *                          const auto& tags) {
+ *     auto instance = store.lookup(uid);
+ *     if (!instance) {
+ *         return pacs_error<dicom_dataset>(...);
+ *     }
+ *     if (tags.empty()) {
+ *         return instance->dataset();
+ *     }
+ *     return instance->filter_attributes(tags);
+ * });
+ *
+ * auto result = scp.handle_message(association, context_id, request);
+ * @endcode
+ */
+class n_get_scp final : public scp_service {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct N-GET SCP with optional logger
+     *
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit n_get_scp(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~n_get_scp() override = default;
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    /**
+     * @brief Set the N-GET handler function
+     *
+     * The handler is called for each N-GET request to retrieve attributes
+     * from a managed SOP Instance.
+     *
+     * @param handler The N-GET handler function
+     */
+    void set_handler(n_get_handler handler);
+
+    /**
+     * @brief Add a SOP Class UID that this SCP supports
+     *
+     * N-GET can be used with multiple SOP Classes (e.g., MPPS, Printer).
+     * By default, no SOP Classes are registered. Call this method to add
+     * supported SOP Classes.
+     *
+     * @param sop_class_uid The SOP Class UID to support
+     */
+    void add_supported_sop_class(std::string sop_class_uid);
+
+    // =========================================================================
+    // scp_service Interface Implementation
+    // =========================================================================
+
+    /**
+     * @brief Get supported SOP Class UIDs
+     *
+     * @return Vector of registered SOP Class UIDs
+     */
+    [[nodiscard]] std::vector<std::string> supported_sop_classes() const override;
+
+    /**
+     * @brief Handle an incoming N-GET-RQ message
+     *
+     * @param assoc The association on which the message was received
+     * @param context_id The presentation context ID
+     * @param request The incoming N-GET-RQ message
+     * @return Success or error
+     */
+    [[nodiscard]] network::Result<std::monostate> handle_message(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request) override;
+
+    /**
+     * @brief Get the service name
+     *
+     * @return "N-GET SCP"
+     */
+    [[nodiscard]] std::string_view service_name() const noexcept override;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    /**
+     * @brief Get total number of N-GET requests processed
+     */
+    [[nodiscard]] size_t gets_processed() const noexcept;
+
+    /**
+     * @brief Reset statistics counters
+     */
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    /**
+     * @brief Send N-GET response
+     */
+    [[nodiscard]] network::Result<std::monostate> send_n_get_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_class_uid,
+        const std::string& sop_instance_uid,
+        network::dimse::status_code status,
+        core::dicom_dataset* dataset = nullptr);
+
+    // =========================================================================
+    // Member Variables
+    // =========================================================================
+
+    n_get_handler handler_;
+    std::vector<std::string> supported_sop_classes_;
+
+    std::atomic<size_t> gets_processed_{0};
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_N_GET_SCP_HPP

--- a/include/pacs/services/n_get_scu.hpp
+++ b/include/pacs/services/n_get_scu.hpp
@@ -1,0 +1,207 @@
+/**
+ * @file n_get_scu.hpp
+ * @brief DICOM N-GET SCU service for attribute retrieval
+ *
+ * This file provides the n_get_scu class for querying remote SCPs
+ * to retrieve attributes from managed SOP Instances.
+ *
+ * @see DICOM PS3.7 Section 10.1.2 - N-GET Service
+ * @see Issue #720 - Implement N-GET SCP/SCU service
+ */
+
+#ifndef PACS_SERVICES_N_GET_SCU_HPP
+#define PACS_SERVICES_N_GET_SCU_HPP
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/core/dicom_tag.hpp"
+#include "pacs/di/ilogger.hpp"
+#include "pacs/network/association.hpp"
+#include "pacs/network/dimse/dimse_message.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::services {
+
+// =============================================================================
+// N-GET SCU Data Structures
+// =============================================================================
+
+/**
+ * @brief Result of an N-GET operation
+ *
+ * Contains the retrieved attributes and status information.
+ */
+struct n_get_result {
+    /// DIMSE status code (0x0000 = success)
+    uint16_t status{0};
+
+    /// Retrieved attributes from the SOP Instance
+    core::dicom_dataset attributes;
+
+    /// Error comment from the SCP (if any)
+    std::string error_comment;
+
+    /// Time taken for the operation
+    std::chrono::milliseconds elapsed{0};
+
+    /// Check if the operation was successful
+    [[nodiscard]] bool is_success() const noexcept {
+        return status == 0x0000;
+    }
+
+    /// Check if this was a warning status
+    [[nodiscard]] bool is_warning() const noexcept {
+        return (status & 0xF000) == 0xB000;
+    }
+
+    /// Check if this was an error status
+    [[nodiscard]] bool is_error() const noexcept {
+        return !is_success() && !is_warning();
+    }
+};
+
+/**
+ * @brief Configuration for N-GET SCU service
+ */
+struct n_get_scu_config {
+    /// Timeout for receiving DIMSE response
+    std::chrono::milliseconds timeout{30000};
+};
+
+// =============================================================================
+// N-GET SCU Class
+// =============================================================================
+
+/**
+ * @brief N-GET SCU service for querying SOP Instance attributes
+ *
+ * The N-GET SCU (Service Class User) sends N-GET-RQ messages to remote
+ * SCPs to retrieve attributes from managed SOP Instances.
+ *
+ * ## N-GET Message Flow
+ *
+ * ```
+ * SCU (Client)                          SCP (Server)
+ *  |                                     |
+ *  |  N-GET-RQ                           |
+ *  |  +-----------------------------+    |
+ *  |  | RequestedSOPClass: MPPS     |    |
+ *  |  | RequestedSOPInstance: UID   |    |
+ *  |  | AttributeIdentifierList    |    |
+ *  |  +-----------------------------+    |
+ *  |----------------------------------->|
+ *  |                                     |
+ *  |  N-GET-RSP + Dataset                |
+ *  |<-----------------------------------|
+ * ```
+ *
+ * @example Usage
+ * @code
+ * n_get_scu scu;
+ *
+ * // Get all attributes
+ * auto result = scu.get(assoc, mpps_sop_class_uid, instance_uid);
+ *
+ * // Get specific attributes
+ * std::vector<dicom_tag> tags = {tags::patient_name, tags::patient_id};
+ * auto result = scu.get(assoc, mpps_sop_class_uid, instance_uid, tags);
+ *
+ * if (result.is_ok() && result.value().is_success()) {
+ *     auto& attrs = result.value().attributes;
+ *     auto name = attrs.get_string(tags::patient_name);
+ * }
+ * @endcode
+ */
+class n_get_scu {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct N-GET SCU with default configuration
+     *
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit n_get_scu(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    /**
+     * @brief Construct N-GET SCU with custom configuration
+     *
+     * @param config Configuration options
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit n_get_scu(const n_get_scu_config& config,
+                       std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~n_get_scu() = default;
+
+    // Non-copyable, non-movable (due to atomic members)
+    n_get_scu(const n_get_scu&) = delete;
+    n_get_scu& operator=(const n_get_scu&) = delete;
+    n_get_scu(n_get_scu&&) = delete;
+    n_get_scu& operator=(n_get_scu&&) = delete;
+
+    // =========================================================================
+    // N-GET Operation
+    // =========================================================================
+
+    /**
+     * @brief Retrieve attributes from a managed SOP Instance
+     *
+     * Sends an N-GET-RQ and returns the retrieved attributes.
+     *
+     * @param assoc The established association to use
+     * @param sop_class_uid The SOP Class UID of the instance
+     * @param sop_instance_uid The SOP Instance UID to query
+     * @param attribute_tags Tags to retrieve (empty = all attributes)
+     * @return Result containing n_get_result, or error
+     */
+    [[nodiscard]] network::Result<n_get_result> get(
+        network::association& assoc,
+        std::string_view sop_class_uid,
+        std::string_view sop_instance_uid,
+        const std::vector<core::dicom_tag>& attribute_tags = {});
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    /**
+     * @brief Get the number of N-GET operations performed
+     */
+    [[nodiscard]] size_t gets_performed() const noexcept;
+
+    /**
+     * @brief Reset statistics counters to zero
+     */
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    /**
+     * @brief Get the next message ID for DIMSE operations
+     */
+    [[nodiscard]] uint16_t next_message_id() noexcept;
+
+    // =========================================================================
+    // Private Members
+    // =========================================================================
+
+    std::shared_ptr<di::ILogger> logger_;
+    n_get_scu_config config_;
+    std::atomic<uint16_t> message_id_counter_{1};
+    std::atomic<size_t> gets_performed_{0};
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_N_GET_SCU_HPP

--- a/src/services/n_get_scp.cpp
+++ b/src/services/n_get_scp.cpp
@@ -1,0 +1,163 @@
+/**
+ * @file n_get_scp.cpp
+ * @brief Implementation of the N-GET SCP service
+ *
+ * @see DICOM PS3.7 Section 10.1.2 - N-GET Service
+ * @see Issue #720 - Implement N-GET SCP/SCU service
+ */
+
+#include "pacs/services/n_get_scp.hpp"
+
+#include "pacs/core/result.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+n_get_scp::n_get_scp(std::shared_ptr<di::ILogger> logger)
+    : scp_service(std::move(logger)) {}
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+void n_get_scp::set_handler(n_get_handler handler) {
+    handler_ = std::move(handler);
+}
+
+void n_get_scp::add_supported_sop_class(std::string sop_class_uid) {
+    supported_sop_classes_.push_back(std::move(sop_class_uid));
+}
+
+// =============================================================================
+// scp_service Interface Implementation
+// =============================================================================
+
+std::vector<std::string> n_get_scp::supported_sop_classes() const {
+    return supported_sop_classes_;
+}
+
+network::Result<std::monostate> n_get_scp::handle_message(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Verify command type is N-GET-RQ
+    if (request.command() != command_field::n_get_rq) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::n_get_unexpected_command,
+            "Unexpected command for N-GET SCP: " +
+            std::string(to_string(request.command())));
+    }
+
+    // Verify we have a handler configured
+    if (!handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::n_get_handler_not_set,
+            "No N-GET handler configured");
+    }
+
+    // Extract Requested SOP Class UID
+    auto sop_class_uid = request.requested_sop_class_uid();
+    if (sop_class_uid.empty()) {
+        return send_n_get_response(
+            assoc, context_id, request.message_id(),
+            "", "", status_error_missing_attribute);
+    }
+
+    // Verify the SOP Class is supported
+    if (!supports_sop_class(sop_class_uid)) {
+        return send_n_get_response(
+            assoc, context_id, request.message_id(),
+            sop_class_uid, "", status_refused_sop_class_not_supported);
+    }
+
+    // Extract Requested SOP Instance UID
+    auto sop_instance_uid = request.requested_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        return send_n_get_response(
+            assoc, context_id, request.message_id(),
+            sop_class_uid, "", status_error_missing_attribute);
+    }
+
+    // Extract Attribute Identifier List (empty = all attributes)
+    auto attribute_tags = request.attribute_identifier_list();
+
+    logger_->debug("N-GET request for instance: " + sop_instance_uid +
+                   " (attributes requested: " +
+                   (attribute_tags.empty() ? "all" :
+                    std::to_string(attribute_tags.size())) + ")");
+
+    // Call the handler to retrieve attributes
+    auto result = handler_(sop_class_uid, sop_instance_uid, attribute_tags);
+    if (result.is_err()) {
+        logger_->warn("N-GET handler failed for instance: " + sop_instance_uid +
+                       " - " + result.error().message);
+        return send_n_get_response(
+            assoc, context_id, request.message_id(),
+            sop_class_uid, sop_instance_uid,
+            status_error_invalid_object_instance);
+    }
+
+    // Update statistics
+    ++gets_processed_;
+
+    // Send success response with dataset
+    auto dataset = std::move(result.value());
+    return send_n_get_response(
+        assoc, context_id, request.message_id(),
+        sop_class_uid, sop_instance_uid,
+        status_success, &dataset);
+}
+
+std::string_view n_get_scp::service_name() const noexcept {
+    return "N-GET SCP";
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t n_get_scp::gets_processed() const noexcept {
+    return gets_processed_.load();
+}
+
+void n_get_scp::reset_statistics() noexcept {
+    gets_processed_ = 0;
+}
+
+// =============================================================================
+// Private Implementation
+// =============================================================================
+
+network::Result<std::monostate> n_get_scp::send_n_get_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_class_uid,
+    const std::string& sop_instance_uid,
+    network::dimse::status_code status,
+    core::dicom_dataset* dataset) {
+
+    using namespace network::dimse;
+
+    // Create N-GET response using factory function
+    auto response = make_n_get_rsp(
+        message_id, sop_class_uid, sop_instance_uid, status);
+
+    // Attach dataset if provided (successful responses include attributes)
+    if (dataset != nullptr) {
+        response.set_dataset(std::move(*dataset));
+    }
+
+    // Send the response
+    return assoc.send_dimse(context_id, response);
+}
+
+}  // namespace pacs::services

--- a/src/services/n_get_scu.cpp
+++ b/src/services/n_get_scu.cpp
@@ -1,0 +1,169 @@
+/**
+ * @file n_get_scu.cpp
+ * @brief Implementation of the N-GET SCU service
+ *
+ * @see DICOM PS3.7 Section 10.1.2 - N-GET Service
+ * @see Issue #720 - Implement N-GET SCP/SCU service
+ */
+
+#include "pacs/services/n_get_scu.hpp"
+
+#include "pacs/core/result.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+n_get_scu::n_get_scu(std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()) {}
+
+n_get_scu::n_get_scu(const n_get_scu_config& config,
+                     std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()),
+      config_(config) {}
+
+// =============================================================================
+// N-GET Operation
+// =============================================================================
+
+network::Result<n_get_result> n_get_scu::get(
+    network::association& assoc,
+    std::string_view sop_class_uid,
+    std::string_view sop_instance_uid,
+    const std::vector<core::dicom_tag>& attribute_tags) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    // Verify association is established
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<n_get_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    // Validate UIDs
+    if (sop_class_uid.empty()) {
+        return pacs::pacs_error<n_get_result>(
+            pacs::error_codes::n_get_missing_uid,
+            "SOP Class UID is required for N-GET");
+    }
+
+    if (sop_instance_uid.empty()) {
+        return pacs::pacs_error<n_get_result>(
+            pacs::error_codes::n_get_missing_uid,
+            "SOP Instance UID is required for N-GET");
+    }
+
+    // Get accepted presentation context
+    auto context_id = assoc.accepted_context_id(sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<n_get_result>(
+            pacs::error_codes::n_get_context_not_accepted,
+            "No accepted presentation context for SOP Class: " +
+            std::string(sop_class_uid));
+    }
+
+    // Build N-GET request using factory function
+    auto request = make_n_get_rq(
+        next_message_id(), sop_class_uid, sop_instance_uid, attribute_tags);
+
+    logger_->debug("Sending N-GET request for instance: " +
+                   std::string(sop_instance_uid) +
+                   " (attributes: " +
+                   (attribute_tags.empty() ? "all" :
+                    std::to_string(attribute_tags.size())) + ")");
+
+    // Send the request
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-GET: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    // Receive the response
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-GET response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    // Verify it's an N-GET response
+    if (response.command() != command_field::n_get_rsp) {
+        return pacs::pacs_error<n_get_result>(
+            pacs::error_codes::n_get_unexpected_command,
+            "Expected N-GET-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    // Build result
+    n_get_result result;
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = elapsed;
+
+    // Extract error comment if present
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(
+            tag_error_comment);
+    }
+
+    // Extract dataset (returned attributes) if present
+    if (response.has_dataset()) {
+        auto dataset_result = response.dataset();
+        if (dataset_result.is_ok()) {
+            result.attributes = dataset_result.value().get();
+        }
+    }
+
+    // Update statistics
+    gets_performed_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-GET successful for instance: " +
+                      std::string(sop_instance_uid));
+    } else {
+        logger_->warn("N-GET returned status 0x" +
+                      std::to_string(result.status) +
+                      " for instance: " + std::string(sop_instance_uid));
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t n_get_scu::gets_performed() const noexcept {
+    return gets_performed_.load(std::memory_order_relaxed);
+}
+
+void n_get_scu::reset_statistics() noexcept {
+    gets_performed_.store(0, std::memory_order_relaxed);
+}
+
+// =============================================================================
+// Private Implementation
+// =============================================================================
+
+uint16_t n_get_scu::next_message_id() noexcept {
+    uint16_t id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    if (id == 0) {
+        id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    }
+    return id;
+}
+
+}  // namespace pacs::services

--- a/tests/services/n_get_scp_test.cpp
+++ b/tests/services/n_get_scp_test.cpp
@@ -1,0 +1,241 @@
+/**
+ * @file n_get_scp_test.cpp
+ * @brief Unit tests for N-GET SCP service
+ *
+ * @see DICOM PS3.7 Section 10.1.2 - N-GET Service
+ * @see Issue #720 - Implement N-GET SCP/SCU service
+ */
+
+#include <pacs/services/n_get_scp.hpp>
+#include <pacs/services/mpps_scp.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+
+// ============================================================================
+// n_get_scp Construction Tests
+// ============================================================================
+
+TEST_CASE("n_get_scp construction", "[services][n_get]") {
+    n_get_scp scp;
+
+    SECTION("service name is correct") {
+        CHECK(scp.service_name() == "N-GET SCP");
+    }
+
+    SECTION("no SOP classes supported by default") {
+        auto classes = scp.supported_sop_classes();
+        CHECK(classes.empty());
+    }
+
+    SECTION("initial statistics are zero") {
+        CHECK(scp.gets_processed() == 0);
+    }
+}
+
+// ============================================================================
+// SOP Class Registration Tests
+// ============================================================================
+
+TEST_CASE("n_get_scp SOP class registration", "[services][n_get]") {
+    n_get_scp scp;
+
+    SECTION("can register MPPS SOP Class") {
+        scp.add_supported_sop_class(std::string(mpps_sop_class_uid));
+
+        auto classes = scp.supported_sop_classes();
+        REQUIRE(classes.size() == 1);
+        CHECK(classes[0] == mpps_sop_class_uid);
+    }
+
+    SECTION("can register multiple SOP Classes") {
+        scp.add_supported_sop_class(std::string(mpps_sop_class_uid));
+        scp.add_supported_sop_class("1.2.840.10008.5.1.1.1");  // Basic Film Session
+
+        auto classes = scp.supported_sop_classes();
+        CHECK(classes.size() == 2);
+    }
+
+    SECTION("supports registered SOP Class") {
+        scp.add_supported_sop_class(std::string(mpps_sop_class_uid));
+        CHECK(scp.supports_sop_class(mpps_sop_class_uid));
+    }
+
+    SECTION("does not support unregistered SOP Classes") {
+        scp.add_supported_sop_class(std::string(mpps_sop_class_uid));
+
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.1.1"));
+        CHECK_FALSE(scp.supports_sop_class(""));
+    }
+}
+
+// ============================================================================
+// Handler Configuration Tests
+// ============================================================================
+
+TEST_CASE("n_get_scp handler configuration", "[services][n_get]") {
+    n_get_scp scp;
+
+    SECTION("can set handler") {
+        bool handler_called = false;
+        scp.set_handler([&handler_called](
+            const std::string& /*sop_class*/,
+            const std::string& /*sop_instance*/,
+            const std::vector<dicom_tag>& /*tags*/) {
+            handler_called = true;
+            return Result<dicom_dataset>{dicom_dataset{}};
+        });
+
+        // Handler is stored but not called without a real association
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set handler with attribute filtering") {
+        scp.set_handler([](const std::string& /*sop_class*/,
+                           const std::string& /*sop_instance*/,
+                           const std::vector<dicom_tag>& tags) {
+            dicom_dataset ds;
+            if (tags.empty()) {
+                // Return all attributes
+                ds.set_string(tags::patient_name, pacs::encoding::vr_type::PN,
+                              "Test^Patient");
+                ds.set_string(tags::patient_id, pacs::encoding::vr_type::LO,
+                              "12345");
+            }
+            return Result<dicom_dataset>{std::move(ds)};
+        });
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("n_get_scp statistics", "[services][n_get]") {
+    n_get_scp scp;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scp.gets_processed() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        scp.reset_statistics();
+        CHECK(scp.gets_processed() == 0);
+    }
+}
+
+// ============================================================================
+// scp_service Base Class Tests
+// ============================================================================
+
+TEST_CASE("n_get_scp is a scp_service", "[services][n_get]") {
+    std::unique_ptr<scp_service> base_ptr = std::make_unique<n_get_scp>();
+
+    CHECK(base_ptr->service_name() == "N-GET SCP");
+    CHECK(base_ptr->supported_sop_classes().empty());
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple n_get_scp instances are independent", "[services][n_get]") {
+    n_get_scp scp1;
+    n_get_scp scp2;
+
+    scp1.add_supported_sop_class(std::string(mpps_sop_class_uid));
+
+    CHECK(scp1.supported_sop_classes().size() == 1);
+    CHECK(scp2.supported_sop_classes().empty());
+
+    CHECK(scp1.service_name() == scp2.service_name());
+    CHECK(scp1.gets_processed() == scp2.gets_processed());
+}
+
+// ============================================================================
+// N-GET Command Field Tests
+// ============================================================================
+
+TEST_CASE("N-GET command fields", "[services][n_get]") {
+    SECTION("N-GET command field values") {
+        CHECK(static_cast<uint16_t>(command_field::n_get_rq) == 0x0110);
+        CHECK(static_cast<uint16_t>(command_field::n_get_rsp) == 0x8110);
+    }
+
+    SECTION("N-GET request is a request") {
+        CHECK(is_request(command_field::n_get_rq));
+        CHECK(is_response(command_field::n_get_rsp));
+    }
+
+    SECTION("N-GET is a DIMSE-N command") {
+        CHECK(is_dimse_n(command_field::n_get_rq));
+        CHECK(is_dimse_n(command_field::n_get_rsp));
+    }
+}
+
+// ============================================================================
+// N-GET Factory Function Tests
+// ============================================================================
+
+TEST_CASE("make_n_get_rq factory function", "[services][n_get]") {
+    SECTION("creates request with correct fields") {
+        auto msg = make_n_get_rq(
+            42, mpps_sop_class_uid, "1.2.3.4.5.6.7.8", {});
+
+        CHECK(msg.command() == command_field::n_get_rq);
+        CHECK(msg.message_id() == 42);
+        CHECK(msg.requested_sop_class_uid() == mpps_sop_class_uid);
+        CHECK(msg.requested_sop_instance_uid() == "1.2.3.4.5.6.7.8");
+    }
+
+    SECTION("creates request with attribute tags") {
+        std::vector<dicom_tag> tags = {
+            tags::patient_name,
+            tags::patient_id
+        };
+        auto msg = make_n_get_rq(
+            1, mpps_sop_class_uid, "1.2.3.4", tags);
+
+        auto retrieved_tags = msg.attribute_identifier_list();
+        REQUIRE(retrieved_tags.size() == 2);
+        CHECK(retrieved_tags[0] == tags::patient_name);
+        CHECK(retrieved_tags[1] == tags::patient_id);
+    }
+
+    SECTION("creates request without attribute tags") {
+        auto msg = make_n_get_rq(
+            1, mpps_sop_class_uid, "1.2.3.4", {});
+
+        auto retrieved_tags = msg.attribute_identifier_list();
+        CHECK(retrieved_tags.empty());
+    }
+}
+
+TEST_CASE("make_n_get_rsp factory function", "[services][n_get]") {
+    SECTION("creates success response") {
+        auto msg = make_n_get_rsp(
+            42, mpps_sop_class_uid, "1.2.3.4.5.6.7.8", status_success);
+
+        CHECK(msg.command() == command_field::n_get_rsp);
+        CHECK(msg.status() == status_success);
+        CHECK(msg.affected_sop_class_uid() == mpps_sop_class_uid);
+        CHECK(msg.affected_sop_instance_uid() == "1.2.3.4.5.6.7.8");
+    }
+
+    SECTION("creates error response") {
+        auto msg = make_n_get_rsp(
+            42, mpps_sop_class_uid, "1.2.3.4",
+            status_error_invalid_object_instance);
+
+        CHECK(msg.command() == command_field::n_get_rsp);
+        CHECK(msg.status() == status_error_invalid_object_instance);
+    }
+}

--- a/tests/services/n_get_scu_test.cpp
+++ b/tests/services/n_get_scu_test.cpp
@@ -1,0 +1,188 @@
+/**
+ * @file n_get_scu_test.cpp
+ * @brief Unit tests for N-GET SCU service
+ *
+ * @see DICOM PS3.7 Section 10.1.2 - N-GET Service
+ * @see Issue #720 - Implement N-GET SCP/SCU service
+ */
+
+#include <pacs/services/n_get_scu.hpp>
+#include <pacs/services/mpps_scp.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+
+// ============================================================================
+// n_get_scu Construction Tests
+// ============================================================================
+
+TEST_CASE("n_get_scu construction", "[services][n_get][scu]") {
+    SECTION("default construction succeeds") {
+        n_get_scu scu;
+        CHECK(scu.gets_performed() == 0);
+    }
+
+    SECTION("construction with config succeeds") {
+        n_get_scu_config config;
+        config.timeout = std::chrono::milliseconds{60000};
+
+        n_get_scu scu(config);
+        CHECK(scu.gets_performed() == 0);
+    }
+
+    SECTION("construction with nullptr logger succeeds") {
+        n_get_scu scu(nullptr);
+        CHECK(scu.gets_performed() == 0);
+    }
+
+    SECTION("construction with config and nullptr logger succeeds") {
+        n_get_scu_config config;
+        n_get_scu scu(config, nullptr);
+        CHECK(scu.gets_performed() == 0);
+    }
+}
+
+// ============================================================================
+// n_get_scu_config Tests
+// ============================================================================
+
+TEST_CASE("n_get_scu_config defaults", "[services][n_get][scu]") {
+    n_get_scu_config config;
+
+    CHECK(config.timeout == std::chrono::milliseconds{30000});
+}
+
+TEST_CASE("n_get_scu_config customization", "[services][n_get][scu]") {
+    n_get_scu_config config;
+    config.timeout = std::chrono::milliseconds{60000};
+
+    CHECK(config.timeout == std::chrono::milliseconds{60000});
+}
+
+// ============================================================================
+// n_get_result Structure Tests
+// ============================================================================
+
+TEST_CASE("n_get_result structure", "[services][n_get][scu]") {
+    n_get_result result;
+
+    SECTION("default construction") {
+        CHECK(result.status == 0);
+        CHECK(result.error_comment.empty());
+        CHECK(result.elapsed == std::chrono::milliseconds{0});
+    }
+
+    SECTION("is_success returns true for status 0x0000") {
+        result.status = 0x0000;
+        CHECK(result.is_success());
+        CHECK_FALSE(result.is_warning());
+        CHECK_FALSE(result.is_error());
+    }
+
+    SECTION("is_warning returns true for 0xBxxx status") {
+        result.status = 0xB000;
+        CHECK_FALSE(result.is_success());
+        CHECK(result.is_warning());
+        CHECK_FALSE(result.is_error());
+
+        result.status = 0xB123;
+        CHECK(result.is_warning());
+
+        result.status = 0xBFFF;
+        CHECK(result.is_warning());
+    }
+
+    SECTION("is_error returns true for error status codes") {
+        result.status = 0xC310;
+        CHECK_FALSE(result.is_success());
+        CHECK_FALSE(result.is_warning());
+        CHECK(result.is_error());
+
+        result.status = 0xA700;  // Out of resources
+        CHECK(result.is_error());
+
+        result.status = 0x0110;  // Processing failure
+        CHECK(result.is_error());
+    }
+
+    SECTION("can store elapsed time") {
+        result.elapsed = std::chrono::milliseconds{150};
+        CHECK(result.elapsed.count() == 150);
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("n_get_scu statistics", "[services][n_get][scu]") {
+    n_get_scu scu;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scu.gets_performed() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        scu.reset_statistics();
+        CHECK(scu.gets_performed() == 0);
+    }
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple n_get_scu instances are independent", "[services][n_get][scu]") {
+    n_get_scu scu1;
+    n_get_scu scu2;
+
+    // Both should have zero statistics
+    CHECK(scu1.gets_performed() == scu2.gets_performed());
+
+    // Statistics should be independent
+    scu1.reset_statistics();
+    CHECK(scu1.gets_performed() == 0);
+    CHECK(scu2.gets_performed() == 0);
+}
+
+// ============================================================================
+// n_get_result Copy and Move Tests
+// ============================================================================
+
+TEST_CASE("n_get_result is copyable and movable", "[services][n_get][scu]") {
+    n_get_result result;
+    result.status = 0x0000;
+    result.elapsed = std::chrono::milliseconds{100};
+    result.error_comment = "test comment";
+
+    SECTION("copy construction") {
+        n_get_result copy = result;
+        CHECK(copy.status == 0x0000);
+        CHECK(copy.elapsed.count() == 100);
+        CHECK(copy.error_comment == "test comment");
+    }
+
+    SECTION("move construction") {
+        n_get_result moved = std::move(result);
+        CHECK(moved.status == 0x0000);
+        CHECK(moved.elapsed.count() == 100);
+        CHECK(moved.error_comment == "test comment");
+    }
+}
+
+// ============================================================================
+// SOP Class UID Accessibility Test
+// ============================================================================
+
+TEST_CASE("mpps_sop_class_uid is accessible from n_get_scu", "[services][n_get][scu]") {
+    // N-GET is commonly used with MPPS SOP Class for attribute retrieval
+    CHECK(mpps_sop_class_uid == "1.2.840.10008.3.1.2.3.3");
+}


### PR DESCRIPTION
Closes #720

## Summary
- Add N-GET SCP service with handler-based design, dynamic SOP class registration, attribute identifier list filtering, and statistics tracking
- Add N-GET SCU service with association-based request/response, configurable timeout, result status classification (success/warning/error), and error handling
- Add N-GET-specific error codes to `result.hpp` (handler not set, unexpected command, instance not found, context not accepted, missing UID)
- Unit tests: 16 test cases covering construction, configuration, data structures, statistics, and factory functions

## Test Plan
- [x] All 20 N-GET tests pass (16 SCP/SCU + 4 existing message-level tests)
- [x] Full project build succeeds
- [x] No existing test regressions