### PR TITLE
feat(services): implement Print Management SCP with SOP class registration (#737)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -980,6 +980,7 @@ add_library(pacs_services
     src/services/n_get_scu.cpp
     src/services/storage_commitment_scp.cpp
     src/services/storage_commitment_scu.cpp
+    src/services/print_scp.cpp
     src/services/sop_class_registry.cpp
     src/services/sop_classes/us_storage.cpp
     src/services/sop_classes/dx_storage.cpp
@@ -1798,6 +1799,7 @@ if(PACS_BUILD_TESTS)
         tests/services/storage_commitment_types_test.cpp
         tests/services/storage_commitment_scp_test.cpp
         tests/services/storage_commitment_scu_test.cpp
+        tests/services/print_scp_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/core/result.hpp
+++ b/include/pacs/core/result.hpp
@@ -187,6 +187,11 @@ namespace error_codes {
     constexpr int n_get_context_not_accepted = service_base - 85;
     constexpr int n_get_missing_uid = service_base - 86;
 
+    // Print Management service errors (-887 to -889)
+    constexpr int print_handler_not_set = service_base - 87;
+    constexpr int print_unexpected_command = service_base - 88;
+    constexpr int print_invalid_sop_class = service_base - 89;
+
     // General service errors (-890 to -899)
     constexpr int association_not_established = service_base - 90;
     constexpr int file_not_found_service = service_base - 91;

--- a/include/pacs/services/print_scp.hpp
+++ b/include/pacs/services/print_scp.hpp
@@ -1,0 +1,462 @@
+/**
+ * @file print_scp.hpp
+ * @brief DICOM Print Management SCP service (PS3.4 Annex H)
+ *
+ * This file provides the print_scp class for handling DICOM print requests
+ * including Film Session, Film Box, Image Box, and Printer management.
+ *
+ * @see DICOM PS3.4 Annex H - Print Management Service Class
+ * @see DICOM PS3.7 Section 10 - DIMSE-N Services
+ */
+
+#ifndef PACS_SERVICES_PRINT_SCP_HPP
+#define PACS_SERVICES_PRINT_SCP_HPP
+
+#include "scp_service.hpp"
+
+#include <pacs/core/dicom_dataset.hpp>
+
+#include <atomic>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace pacs::services {
+
+// =============================================================================
+// Print Management SOP Class UIDs (PS3.4 Annex H)
+// =============================================================================
+
+/// Basic Film Session SOP Class UID
+inline constexpr std::string_view basic_film_session_sop_class_uid =
+    "1.2.840.10008.5.1.1.1";
+
+/// Basic Film Box SOP Class UID
+inline constexpr std::string_view basic_film_box_sop_class_uid =
+    "1.2.840.10008.5.1.1.2";
+
+/// Basic Grayscale Image Box SOP Class UID
+inline constexpr std::string_view basic_grayscale_image_box_sop_class_uid =
+    "1.2.840.10008.5.1.1.4";
+
+/// Basic Color Image Box SOP Class UID
+inline constexpr std::string_view basic_color_image_box_sop_class_uid =
+    "1.2.840.10008.5.1.1.4.1";
+
+/// Printer SOP Class UID
+inline constexpr std::string_view printer_sop_class_uid =
+    "1.2.840.10008.5.1.1.16";
+
+/// Basic Grayscale Print Management Meta SOP Class UID
+inline constexpr std::string_view basic_grayscale_print_meta_sop_class_uid =
+    "1.2.840.10008.5.1.1.9";
+
+/// Basic Color Print Management Meta SOP Class UID
+inline constexpr std::string_view basic_color_print_meta_sop_class_uid =
+    "1.2.840.10008.5.1.1.18";
+
+// =============================================================================
+// Print Management Types
+// =============================================================================
+
+/**
+ * @brief Printer status enumeration (PS3.4 H.4.17)
+ */
+enum class printer_status {
+    normal,    ///< Printer is operating normally
+    warning,   ///< Printer has a non-critical issue
+    failure    ///< Printer has a critical error
+};
+
+/**
+ * @brief Convert printer_status to DICOM string representation
+ */
+[[nodiscard]] inline auto to_string(printer_status status) -> std::string_view {
+    switch (status) {
+        case printer_status::normal:
+            return "NORMAL";
+        case printer_status::warning:
+            return "WARNING";
+        case printer_status::failure:
+            return "FAILURE";
+        default:
+            return "NORMAL";
+    }
+}
+
+/**
+ * @brief Print job status
+ */
+enum class print_job_status {
+    pending,     ///< Job is queued
+    printing,    ///< Job is being printed
+    done,        ///< Job completed successfully
+    failure      ///< Job failed
+};
+
+/**
+ * @brief Film session data created by N-CREATE
+ */
+struct film_session {
+    /// SOP Instance UID
+    std::string sop_instance_uid;
+
+    /// Number of copies
+    uint32_t number_of_copies{1};
+
+    /// Print priority (HIGH, MED, LOW)
+    std::string print_priority{"MED"};
+
+    /// Medium type (PAPER, CLEAR FILM, BLUE FILM)
+    std::string medium_type{"BLUE FILM"};
+
+    /// Film destination (MAGAZINE, PROCESSOR)
+    std::string film_destination{"MAGAZINE"};
+
+    /// Associated film box UIDs
+    std::vector<std::string> film_box_uids;
+
+    /// Complete dataset from request
+    core::dicom_dataset data;
+};
+
+/**
+ * @brief Film box data created by N-CREATE
+ */
+struct film_box {
+    /// SOP Instance UID
+    std::string sop_instance_uid;
+
+    /// Parent film session UID
+    std::string film_session_uid;
+
+    /// Image display format (STANDARD\1,1 etc.)
+    std::string image_display_format{"STANDARD\\1,1"};
+
+    /// Film orientation (PORTRAIT, LANDSCAPE)
+    std::string film_orientation{"PORTRAIT"};
+
+    /// Film size ID (8INX10IN, 14INX17IN, etc.)
+    std::string film_size_id{"8INX10IN"};
+
+    /// Associated image box UIDs
+    std::vector<std::string> image_box_uids;
+
+    /// Complete dataset from request
+    core::dicom_dataset data;
+};
+
+/**
+ * @brief Image box data set by N-SET
+ */
+struct image_box {
+    /// SOP Instance UID
+    std::string sop_instance_uid;
+
+    /// Parent film box UID
+    std::string film_box_uid;
+
+    /// Image position (1-based)
+    uint16_t image_position{1};
+
+    /// Whether pixel data has been set
+    bool has_pixel_data{false};
+
+    /// Complete dataset from request
+    core::dicom_dataset data;
+};
+
+// =============================================================================
+// Handler Types
+// =============================================================================
+
+/**
+ * @brief Handler for film session creation
+ *
+ * @param session The film session data
+ * @return Success or error
+ */
+using print_session_handler = std::function<network::Result<std::monostate>(
+    const film_session& session)>;
+
+/**
+ * @brief Handler for print action (film box print)
+ *
+ * @param film_box_uid The film box UID to print
+ * @return Success or error
+ */
+using print_action_handler = std::function<network::Result<std::monostate>(
+    const std::string& film_box_uid)>;
+
+/**
+ * @brief Handler for printer status query
+ *
+ * @return Printer status and info dataset
+ */
+using printer_status_handler = std::function<
+    network::Result<std::pair<printer_status, core::dicom_dataset>>()>;
+
+// =============================================================================
+// Print SCP Class
+// =============================================================================
+
+/**
+ * @brief Print Management SCP service
+ *
+ * Handles DICOM print requests for Film Session, Film Box, Image Box,
+ * and Printer SOP Classes.
+ *
+ * ## Print Workflow
+ *
+ * ```
+ * SCU (Workstation)                         SCP (Print Server)
+ *  |                                        |
+ *  |  N-CREATE Film Session                 |
+ *  |--------------------------------------->|
+ *  |                                        |
+ *  |  N-CREATE Film Box                     |
+ *  |--------------------------------------->|
+ *  |                                        |
+ *  |  N-SET Image Box (pixel data)          |
+ *  |--------------------------------------->|
+ *  |                                        |
+ *  |  N-ACTION Film Box (Print)             |
+ *  |--------------------------------------->|
+ *  |                                        |
+ *  |  N-DELETE Film Session                 |
+ *  |--------------------------------------->|
+ * ```
+ */
+class print_scp final : public scp_service {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct Print SCP with optional logger
+     *
+     * @param logger Logger instance for service logging
+     */
+    explicit print_scp(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~print_scp() override = default;
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    /**
+     * @brief Set handler for film session creation
+     */
+    void set_session_handler(print_session_handler handler);
+
+    /**
+     * @brief Set handler for print action (film box print)
+     */
+    void set_print_handler(print_action_handler handler);
+
+    /**
+     * @brief Set handler for printer status query
+     */
+    void set_printer_status_handler(printer_status_handler handler);
+
+    // =========================================================================
+    // scp_service Interface Implementation
+    // =========================================================================
+
+    /**
+     * @brief Get supported SOP Class UIDs
+     *
+     * @return Vector of Print Management SOP Class UIDs
+     */
+    [[nodiscard]] std::vector<std::string> supported_sop_classes() const override;
+
+    /**
+     * @brief Handle an incoming DIMSE-N message
+     *
+     * Routes N-CREATE, N-SET, N-GET, N-ACTION, N-DELETE to appropriate handlers
+     * based on the affected SOP class.
+     */
+    [[nodiscard]] network::Result<std::monostate> handle_message(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request) override;
+
+    /**
+     * @brief Get the service name
+     *
+     * @return "Print SCP"
+     */
+    [[nodiscard]] std::string_view service_name() const noexcept override;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    [[nodiscard]] size_t sessions_created() const noexcept;
+    [[nodiscard]] size_t film_boxes_created() const noexcept;
+    [[nodiscard]] size_t images_set() const noexcept;
+    [[nodiscard]] size_t prints_executed() const noexcept;
+    [[nodiscard]] size_t printer_queries() const noexcept;
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // DIMSE-N Command Handlers
+    // =========================================================================
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_create(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_set(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_get(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_action(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_delete(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    // =========================================================================
+    // SOP-specific Create Handlers
+    // =========================================================================
+
+    [[nodiscard]] network::Result<std::monostate> create_film_session(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> create_film_box(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    // =========================================================================
+    // Response Helpers
+    // =========================================================================
+
+    [[nodiscard]] network::Result<std::monostate> send_response(
+        network::association& assoc,
+        uint8_t context_id,
+        network::dimse::command_field response_type,
+        uint16_t message_id,
+        std::string_view sop_class_uid,
+        const std::string& sop_instance_uid,
+        network::dimse::status_code status);
+
+    // =========================================================================
+    // UID Generation
+    // =========================================================================
+
+    [[nodiscard]] auto generate_uid() -> std::string;
+
+    // =========================================================================
+    // Member Variables
+    // =========================================================================
+
+    print_session_handler session_handler_;
+    print_action_handler print_handler_;
+    printer_status_handler printer_status_handler_;
+
+    /// Active film sessions indexed by SOP Instance UID
+    std::unordered_map<std::string, film_session> sessions_;
+
+    /// Active film boxes indexed by SOP Instance UID
+    std::unordered_map<std::string, film_box> film_boxes_;
+
+    /// Active image boxes indexed by SOP Instance UID
+    std::unordered_map<std::string, image_box> image_boxes_;
+
+    /// Mutex for state management
+    mutable std::mutex mutex_;
+
+    /// UID generation counter
+    std::atomic<uint32_t> uid_counter_{0};
+
+    /// Statistics
+    std::atomic<size_t> sessions_created_{0};
+    std::atomic<size_t> film_boxes_created_{0};
+    std::atomic<size_t> images_set_{0};
+    std::atomic<size_t> prints_executed_{0};
+    std::atomic<size_t> printer_queries_{0};
+};
+
+// =============================================================================
+// Print-specific DICOM Tags (PS3.4 Annex H)
+// =============================================================================
+
+namespace print_tags {
+
+/// Number of Copies (2000,0010)
+inline constexpr core::dicom_tag number_of_copies{0x2000, 0x0010};
+
+/// Print Priority (2000,0020)
+inline constexpr core::dicom_tag print_priority{0x2000, 0x0020};
+
+/// Medium Type (2000,0030)
+inline constexpr core::dicom_tag medium_type{0x2000, 0x0030};
+
+/// Film Destination (2000,0040)
+inline constexpr core::dicom_tag film_destination{0x2000, 0x0040};
+
+/// Film Session Label (2000,0050)
+inline constexpr core::dicom_tag film_session_label{0x2000, 0x0050};
+
+/// Image Display Format (2010,0010)
+inline constexpr core::dicom_tag image_display_format{0x2010, 0x0010};
+
+/// Film Orientation (2010,0040)
+inline constexpr core::dicom_tag film_orientation{0x2010, 0x0040};
+
+/// Film Size ID (2010,0050)
+inline constexpr core::dicom_tag film_size_id{0x2010, 0x0050};
+
+/// Magnification Type (2010,0060)
+inline constexpr core::dicom_tag magnification_type{0x2010, 0x0060};
+
+/// Referenced Film Session Sequence (2010,0500)
+inline constexpr core::dicom_tag referenced_film_session_sequence{0x2010, 0x0500};
+
+/// Referenced Image Box Sequence (2010,0510)
+inline constexpr core::dicom_tag referenced_image_box_sequence{0x2010, 0x0510};
+
+/// Image Position (2020,0010)
+inline constexpr core::dicom_tag image_position{0x2020, 0x0010};
+
+/// Basic Grayscale Image Sequence (2020,0110)
+inline constexpr core::dicom_tag basic_grayscale_image_sequence{0x2020, 0x0110};
+
+/// Basic Color Image Sequence (2020,0111)
+inline constexpr core::dicom_tag basic_color_image_sequence{0x2020, 0x0111};
+
+/// Printer Status (2110,0010)
+inline constexpr core::dicom_tag printer_status_tag{0x2110, 0x0010};
+
+/// Printer Status Info (2110,0020)
+inline constexpr core::dicom_tag printer_status_info{0x2110, 0x0020};
+
+/// Printer Name (2110,0030)
+inline constexpr core::dicom_tag printer_name{0x2110, 0x0030};
+
+}  // namespace print_tags
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_PRINT_SCP_HPP

--- a/include/pacs/services/sop_class_registry.hpp
+++ b/include/pacs/services/sop_class_registry.hpp
@@ -201,6 +201,7 @@ private:
     void register_rt_sop_classes();
     void register_seg_sop_classes();
     void register_sr_sop_classes();
+    void register_print_sop_classes();
     void register_other_sop_classes();
 
     std::unordered_map<std::string, sop_class_info> registry_;

--- a/src/services/print_scp.cpp
+++ b/src/services/print_scp.cpp
@@ -1,0 +1,712 @@
+/**
+ * @file print_scp.cpp
+ * @brief Implementation of the Print Management SCP service (PS3.4 Annex H)
+ */
+
+#include "pacs/services/print_scp.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/encoding/vr_type.hpp"
+#include "pacs/core/result.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+#include <chrono>
+#include <sstream>
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+print_scp::print_scp(std::shared_ptr<di::ILogger> logger)
+    : scp_service(std::move(logger)) {}
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+void print_scp::set_session_handler(print_session_handler handler) {
+    session_handler_ = std::move(handler);
+}
+
+void print_scp::set_print_handler(print_action_handler handler) {
+    print_handler_ = std::move(handler);
+}
+
+void print_scp::set_printer_status_handler(printer_status_handler handler) {
+    printer_status_handler_ = std::move(handler);
+}
+
+// =============================================================================
+// scp_service Interface
+// =============================================================================
+
+std::vector<std::string> print_scp::supported_sop_classes() const {
+    return {
+        std::string(basic_film_session_sop_class_uid),
+        std::string(basic_film_box_sop_class_uid),
+        std::string(basic_grayscale_image_box_sop_class_uid),
+        std::string(basic_color_image_box_sop_class_uid),
+        std::string(printer_sop_class_uid),
+        std::string(basic_grayscale_print_meta_sop_class_uid),
+        std::string(basic_color_print_meta_sop_class_uid),
+    };
+}
+
+network::Result<std::monostate> print_scp::handle_message(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    switch (request.command()) {
+        case command_field::n_create_rq:
+            return handle_n_create(assoc, context_id, request);
+        case command_field::n_set_rq:
+            return handle_n_set(assoc, context_id, request);
+        case command_field::n_get_rq:
+            return handle_n_get(assoc, context_id, request);
+        case command_field::n_action_rq:
+            return handle_n_action(assoc, context_id, request);
+        case command_field::n_delete_rq:
+            return handle_n_delete(assoc, context_id, request);
+        default:
+            return pacs::pacs_void_error(
+                pacs::error_codes::print_unexpected_command,
+                "Unexpected command for Print SCP: " +
+                std::string(to_string(request.command())));
+    }
+}
+
+std::string_view print_scp::service_name() const noexcept {
+    return "Print SCP";
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t print_scp::sessions_created() const noexcept {
+    return sessions_created_.load();
+}
+
+size_t print_scp::film_boxes_created() const noexcept {
+    return film_boxes_created_.load();
+}
+
+size_t print_scp::images_set() const noexcept {
+    return images_set_.load();
+}
+
+size_t print_scp::prints_executed() const noexcept {
+    return prints_executed_.load();
+}
+
+size_t print_scp::printer_queries() const noexcept {
+    return printer_queries_.load();
+}
+
+void print_scp::reset_statistics() noexcept {
+    sessions_created_ = 0;
+    film_boxes_created_ = 0;
+    images_set_ = 0;
+    prints_executed_ = 0;
+    printer_queries_ = 0;
+}
+
+// =============================================================================
+// N-CREATE Handler
+// =============================================================================
+
+network::Result<std::monostate> print_scp::handle_n_create(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    auto sop_class_uid = request.affected_sop_class_uid();
+
+    if (sop_class_uid == basic_film_session_sop_class_uid) {
+        return create_film_session(assoc, context_id, request);
+    }
+    if (sop_class_uid == basic_film_box_sop_class_uid) {
+        return create_film_box(assoc, context_id, request);
+    }
+
+    return send_response(
+        assoc, context_id, command_field::n_create_rsp,
+        request.message_id(), sop_class_uid,
+        "", status_refused_sop_class_not_supported);
+}
+
+// =============================================================================
+// N-SET Handler
+// =============================================================================
+
+network::Result<std::monostate> print_scp::handle_n_set(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    auto sop_class_uid = request.affected_sop_class_uid();
+    if (sop_class_uid.empty()) {
+        sop_class_uid = request.command_set().get_string(
+            tag_requested_sop_class_uid);
+    }
+
+    auto sop_instance_uid = request.command_set().get_string(
+        tag_requested_sop_instance_uid);
+    if (sop_instance_uid.empty()) {
+        sop_instance_uid = request.affected_sop_instance_uid();
+    }
+
+    if (sop_instance_uid.empty()) {
+        return send_response(
+            assoc, context_id, command_field::n_set_rsp,
+            request.message_id(), sop_class_uid,
+            "", status_error_missing_attribute);
+    }
+
+    // Handle Image Box N-SET (grayscale or color)
+    if (sop_class_uid == basic_grayscale_image_box_sop_class_uid ||
+        sop_class_uid == basic_color_image_box_sop_class_uid) {
+
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto it = image_boxes_.find(sop_instance_uid);
+        if (it == image_boxes_.end()) {
+            return send_response(
+                assoc, context_id, command_field::n_set_rsp,
+                request.message_id(), sop_class_uid,
+                sop_instance_uid, status_error_invalid_object_instance);
+        }
+
+        if (request.has_dataset()) {
+            it->second.data = request.dataset().value().get();
+            it->second.has_pixel_data = true;
+        }
+
+        ++images_set_;
+
+        return send_response(
+            assoc, context_id, command_field::n_set_rsp,
+            request.message_id(), sop_class_uid,
+            sop_instance_uid, status_success);
+    }
+
+    // Handle Film Session N-SET
+    if (sop_class_uid == basic_film_session_sop_class_uid) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto it = sessions_.find(sop_instance_uid);
+        if (it == sessions_.end()) {
+            return send_response(
+                assoc, context_id, command_field::n_set_rsp,
+                request.message_id(), sop_class_uid,
+                sop_instance_uid, status_error_invalid_object_instance);
+        }
+
+        if (request.has_dataset()) {
+            const auto& ds = request.dataset().value().get();
+            it->second.data = ds;
+
+            if (ds.contains(print_tags::number_of_copies)) {
+                auto copies_str = ds.get_string(print_tags::number_of_copies);
+                if (!copies_str.empty()) {
+                    it->second.number_of_copies =
+                        static_cast<uint32_t>(std::stoul(copies_str));
+                }
+            }
+            if (ds.contains(print_tags::print_priority)) {
+                it->second.print_priority = ds.get_string(print_tags::print_priority);
+            }
+            if (ds.contains(print_tags::medium_type)) {
+                it->second.medium_type = ds.get_string(print_tags::medium_type);
+            }
+        }
+
+        return send_response(
+            assoc, context_id, command_field::n_set_rsp,
+            request.message_id(), sop_class_uid,
+            sop_instance_uid, status_success);
+    }
+
+    // Handle Film Box N-SET
+    if (sop_class_uid == basic_film_box_sop_class_uid) {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        auto it = film_boxes_.find(sop_instance_uid);
+        if (it == film_boxes_.end()) {
+            return send_response(
+                assoc, context_id, command_field::n_set_rsp,
+                request.message_id(), sop_class_uid,
+                sop_instance_uid, status_error_invalid_object_instance);
+        }
+
+        if (request.has_dataset()) {
+            const auto& ds = request.dataset().value().get();
+            it->second.data = ds;
+
+            if (ds.contains(print_tags::image_display_format)) {
+                it->second.image_display_format =
+                    ds.get_string(print_tags::image_display_format);
+            }
+            if (ds.contains(print_tags::film_orientation)) {
+                it->second.film_orientation = ds.get_string(print_tags::film_orientation);
+            }
+            if (ds.contains(print_tags::film_size_id)) {
+                it->second.film_size_id = ds.get_string(print_tags::film_size_id);
+            }
+        }
+
+        return send_response(
+            assoc, context_id, command_field::n_set_rsp,
+            request.message_id(), sop_class_uid,
+            sop_instance_uid, status_success);
+    }
+
+    return send_response(
+        assoc, context_id, command_field::n_set_rsp,
+        request.message_id(), sop_class_uid,
+        sop_instance_uid, status_refused_sop_class_not_supported);
+}
+
+// =============================================================================
+// N-GET Handler (Printer Status)
+// =============================================================================
+
+network::Result<std::monostate> print_scp::handle_n_get(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    auto sop_class_uid = request.affected_sop_class_uid();
+    if (sop_class_uid.empty()) {
+        sop_class_uid = request.command_set().get_string(
+            tag_requested_sop_class_uid);
+    }
+
+    if (sop_class_uid != printer_sop_class_uid) {
+        return send_response(
+            assoc, context_id, command_field::n_get_rsp,
+            request.message_id(), sop_class_uid,
+            "", status_refused_sop_class_not_supported);
+    }
+
+    ++printer_queries_;
+
+    // Build printer status response
+    core::dicom_dataset response_ds;
+
+    using namespace encoding;
+
+    if (printer_status_handler_) {
+        auto result = printer_status_handler_();
+        if (result.is_ok()) {
+            auto& [status, info_ds] = result.value();
+            response_ds = std::move(info_ds);
+            response_ds.set_string(print_tags::printer_status_tag, vr_type::CS,
+                                   std::string(to_string(status)));
+        } else {
+            response_ds.set_string(print_tags::printer_status_tag, vr_type::CS, "NORMAL");
+            response_ds.set_string(print_tags::printer_status_info, vr_type::ST, "");
+        }
+    } else {
+        // Default: report printer as normal
+        response_ds.set_string(print_tags::printer_status_tag, vr_type::CS, "NORMAL");
+        response_ds.set_string(print_tags::printer_status_info, vr_type::ST, "");
+        response_ds.set_string(print_tags::printer_name, vr_type::LO, "PACS_PRINTER");
+    }
+
+    // Build response message
+    dimse_message response{command_field::n_get_rsp, 0};
+    response.set_message_id_responded_to(request.message_id());
+    response.set_affected_sop_class_uid(printer_sop_class_uid);
+    response.set_status(status_success);
+
+    auto sop_instance_uid = request.command_set().get_string(
+        tag_requested_sop_instance_uid);
+    if (sop_instance_uid.empty()) {
+        sop_instance_uid = request.affected_sop_instance_uid();
+    }
+    if (!sop_instance_uid.empty()) {
+        response.set_affected_sop_instance_uid(sop_instance_uid);
+    }
+
+    response.set_dataset(std::move(response_ds));
+    return assoc.send_dimse(context_id, response);
+}
+
+// =============================================================================
+// N-ACTION Handler (Print Film Box)
+// =============================================================================
+
+network::Result<std::monostate> print_scp::handle_n_action(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    auto sop_class_uid = request.affected_sop_class_uid();
+
+    // N-ACTION is used on Film Session or Film Box to initiate printing
+    if (sop_class_uid != basic_film_session_sop_class_uid &&
+        sop_class_uid != basic_film_box_sop_class_uid) {
+        return send_response(
+            assoc, context_id, command_field::n_action_rsp,
+            request.message_id(), sop_class_uid,
+            "", status_refused_sop_class_not_supported);
+    }
+
+    auto sop_instance_uid = request.affected_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        return send_response(
+            assoc, context_id, command_field::n_action_rsp,
+            request.message_id(), sop_class_uid,
+            "", status_error_missing_attribute);
+    }
+
+    // Verify the object exists
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        if (sop_class_uid == basic_film_box_sop_class_uid) {
+            if (film_boxes_.find(sop_instance_uid) == film_boxes_.end()) {
+                return send_response(
+                    assoc, context_id, command_field::n_action_rsp,
+                    request.message_id(), sop_class_uid,
+                    sop_instance_uid, status_error_invalid_object_instance);
+            }
+        } else {
+            if (sessions_.find(sop_instance_uid) == sessions_.end()) {
+                return send_response(
+                    assoc, context_id, command_field::n_action_rsp,
+                    request.message_id(), sop_class_uid,
+                    sop_instance_uid, status_error_invalid_object_instance);
+            }
+        }
+    }
+
+    // Call print handler
+    if (print_handler_) {
+        auto result = print_handler_(sop_instance_uid);
+        if (result.is_err()) {
+            return send_response(
+                assoc, context_id, command_field::n_action_rsp,
+                request.message_id(), sop_class_uid,
+                sop_instance_uid, status_error_unable_to_process);
+        }
+    }
+
+    ++prints_executed_;
+
+    // Build action response with action type ID
+    dimse_message response{command_field::n_action_rsp, 0};
+    response.set_message_id_responded_to(request.message_id());
+    response.set_affected_sop_class_uid(sop_class_uid);
+    response.set_affected_sop_instance_uid(sop_instance_uid);
+    response.set_status(status_success);
+
+    auto action_type = request.action_type_id();
+    if (action_type.has_value()) {
+        response.set_action_type_id(action_type.value());
+    }
+
+    return assoc.send_dimse(context_id, response);
+}
+
+// =============================================================================
+// N-DELETE Handler
+// =============================================================================
+
+network::Result<std::monostate> print_scp::handle_n_delete(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    auto sop_class_uid = request.affected_sop_class_uid();
+    auto sop_instance_uid = request.affected_sop_instance_uid();
+
+    if (sop_instance_uid.empty()) {
+        return send_response(
+            assoc, context_id, command_field::n_delete_rsp,
+            request.message_id(), sop_class_uid,
+            "", status_error_missing_attribute);
+    }
+
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (sop_class_uid == basic_film_session_sop_class_uid) {
+        auto it = sessions_.find(sop_instance_uid);
+        if (it == sessions_.end()) {
+            return send_response(
+                assoc, context_id, command_field::n_delete_rsp,
+                request.message_id(), sop_class_uid,
+                sop_instance_uid, status_error_invalid_object_instance);
+        }
+
+        // Delete associated film boxes and their image boxes
+        for (const auto& fb_uid : it->second.film_box_uids) {
+            auto fb_it = film_boxes_.find(fb_uid);
+            if (fb_it != film_boxes_.end()) {
+                for (const auto& ib_uid : fb_it->second.image_box_uids) {
+                    image_boxes_.erase(ib_uid);
+                }
+                film_boxes_.erase(fb_it);
+            }
+        }
+        sessions_.erase(it);
+
+    } else if (sop_class_uid == basic_film_box_sop_class_uid) {
+        auto it = film_boxes_.find(sop_instance_uid);
+        if (it == film_boxes_.end()) {
+            return send_response(
+                assoc, context_id, command_field::n_delete_rsp,
+                request.message_id(), sop_class_uid,
+                sop_instance_uid, status_error_invalid_object_instance);
+        }
+
+        // Delete associated image boxes
+        for (const auto& ib_uid : it->second.image_box_uids) {
+            image_boxes_.erase(ib_uid);
+        }
+
+        // Remove from parent session's film box list
+        for (auto& [_, session] : sessions_) {
+            auto& fb_uids = session.film_box_uids;
+            fb_uids.erase(
+                std::remove(fb_uids.begin(), fb_uids.end(), sop_instance_uid),
+                fb_uids.end());
+        }
+        film_boxes_.erase(it);
+
+    } else {
+        return send_response(
+            assoc, context_id, command_field::n_delete_rsp,
+            request.message_id(), sop_class_uid,
+            sop_instance_uid, status_refused_sop_class_not_supported);
+    }
+
+    return send_response(
+        assoc, context_id, command_field::n_delete_rsp,
+        request.message_id(), sop_class_uid,
+        sop_instance_uid, status_success);
+}
+
+// =============================================================================
+// Film Session Creation
+// =============================================================================
+
+network::Result<std::monostate> print_scp::create_film_session(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    auto sop_instance_uid = request.affected_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        sop_instance_uid = generate_uid();
+    }
+
+    film_session session;
+    session.sop_instance_uid = sop_instance_uid;
+
+    if (request.has_dataset()) {
+        const auto& ds = request.dataset().value().get();
+        session.data = ds;
+
+        if (ds.contains(print_tags::number_of_copies)) {
+            auto copies_str = ds.get_string(print_tags::number_of_copies);
+            if (!copies_str.empty()) {
+                session.number_of_copies =
+                    static_cast<uint32_t>(std::stoul(copies_str));
+            }
+        }
+        if (ds.contains(print_tags::print_priority)) {
+            session.print_priority = ds.get_string(print_tags::print_priority);
+        }
+        if (ds.contains(print_tags::medium_type)) {
+            session.medium_type = ds.get_string(print_tags::medium_type);
+        }
+        if (ds.contains(print_tags::film_destination)) {
+            session.film_destination = ds.get_string(print_tags::film_destination);
+        }
+    }
+
+    // Call session handler
+    if (session_handler_) {
+        auto result = session_handler_(session);
+        if (result.is_err()) {
+            return send_response(
+                assoc, context_id, command_field::n_create_rsp,
+                request.message_id(), basic_film_session_sop_class_uid,
+                sop_instance_uid, status_error_unable_to_process);
+        }
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        sessions_.emplace(sop_instance_uid, std::move(session));
+    }
+
+    ++sessions_created_;
+
+    return send_response(
+        assoc, context_id, command_field::n_create_rsp,
+        request.message_id(), basic_film_session_sop_class_uid,
+        sop_instance_uid, status_success);
+}
+
+// =============================================================================
+// Film Box Creation
+// =============================================================================
+
+network::Result<std::monostate> print_scp::create_film_box(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    auto sop_instance_uid = request.affected_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        sop_instance_uid = generate_uid();
+    }
+
+    film_box box;
+    box.sop_instance_uid = sop_instance_uid;
+
+    if (request.has_dataset()) {
+        const auto& ds = request.dataset().value().get();
+        box.data = ds;
+
+        if (ds.contains(print_tags::image_display_format)) {
+            box.image_display_format = ds.get_string(print_tags::image_display_format);
+        }
+        if (ds.contains(print_tags::film_orientation)) {
+            box.film_orientation = ds.get_string(print_tags::film_orientation);
+        }
+        if (ds.contains(print_tags::film_size_id)) {
+            box.film_size_id = ds.get_string(print_tags::film_size_id);
+        }
+    }
+
+    // Parse image display format to determine image box count
+    // Format: "STANDARD\C,R" where C=columns, R=rows
+    uint16_t num_image_boxes = 1;
+    auto format = box.image_display_format;
+    auto backslash_pos = format.find('\\');
+    if (backslash_pos != std::string::npos) {
+        auto dims = format.substr(backslash_pos + 1);
+        auto comma_pos = dims.find(',');
+        if (comma_pos != std::string::npos) {
+            auto cols = static_cast<uint16_t>(
+                std::stoul(dims.substr(0, comma_pos)));
+            auto rows = static_cast<uint16_t>(
+                std::stoul(dims.substr(comma_pos + 1)));
+            num_image_boxes = static_cast<uint16_t>(cols * rows);
+        }
+    }
+
+    // Create image boxes for this film box
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Link to parent film session if found
+    for (auto& [_, session] : sessions_) {
+        session.film_box_uids.push_back(sop_instance_uid);
+        box.film_session_uid = session.sop_instance_uid;
+        break;  // Link to first (most recent) session
+    }
+
+    for (uint16_t i = 1; i <= num_image_boxes; ++i) {
+        image_box ib;
+        ib.sop_instance_uid = generate_uid();
+        ib.film_box_uid = sop_instance_uid;
+        ib.image_position = i;
+        box.image_box_uids.push_back(ib.sop_instance_uid);
+        image_boxes_.emplace(ib.sop_instance_uid, std::move(ib));
+    }
+
+    film_boxes_.emplace(sop_instance_uid, std::move(box));
+    ++film_boxes_created_;
+
+    // Build response with Referenced Image Box Sequence
+    dimse_message response{command_field::n_create_rsp, 0};
+    response.set_message_id_responded_to(request.message_id());
+    response.set_affected_sop_class_uid(basic_film_box_sop_class_uid);
+    response.set_affected_sop_instance_uid(sop_instance_uid);
+    response.set_status(status_success);
+
+    // Add referenced image box UIDs in response dataset
+    using namespace encoding;
+    core::dicom_dataset response_ds;
+    auto& fb = film_boxes_.at(sop_instance_uid);
+    auto& seq = response_ds.get_or_create_sequence(
+        print_tags::referenced_image_box_sequence);
+    for (size_t i = 0; i < fb.image_box_uids.size(); ++i) {
+        core::dicom_dataset ref_item;
+        ref_item.set_string(core::tags::referenced_sop_class_uid, vr_type::UI,
+                           std::string(basic_grayscale_image_box_sop_class_uid));
+        ref_item.set_string(core::tags::referenced_sop_instance_uid, vr_type::UI,
+                           fb.image_box_uids[i]);
+        seq.push_back(std::move(ref_item));
+    }
+    response.set_dataset(std::move(response_ds));
+
+    return assoc.send_dimse(context_id, response);
+}
+
+// =============================================================================
+// Response Helper
+// =============================================================================
+
+network::Result<std::monostate> print_scp::send_response(
+    network::association& assoc,
+    uint8_t context_id,
+    network::dimse::command_field response_type,
+    uint16_t message_id,
+    std::string_view sop_class_uid,
+    const std::string& sop_instance_uid,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    dimse_message response{response_type, 0};
+    response.set_message_id_responded_to(message_id);
+    response.set_affected_sop_class_uid(sop_class_uid);
+    response.set_status(status);
+
+    if (!sop_instance_uid.empty()) {
+        response.set_affected_sop_instance_uid(sop_instance_uid);
+    }
+
+    return assoc.send_dimse(context_id, response);
+}
+
+// =============================================================================
+// UID Generation
+// =============================================================================
+
+auto print_scp::generate_uid() -> std::string {
+    auto counter = uid_counter_.fetch_add(1);
+    auto now = std::chrono::steady_clock::now().time_since_epoch();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
+
+    std::ostringstream oss;
+    oss << "2.25." << ms << "." << counter;
+    return oss.str();
+}
+
+}  // namespace pacs::services

--- a/src/services/sop_class_registry.cpp
+++ b/src/services/sop_class_registry.cpp
@@ -162,6 +162,7 @@ void sop_class_registry::register_standard_sop_classes() {
     register_rt_sop_classes();
     register_seg_sop_classes();
     register_sr_sop_classes();
+    register_print_sop_classes();
     register_other_sop_classes();
 }
 
@@ -764,6 +765,99 @@ void sop_class_registry::register_sr_sop_classes() {
             "X-Ray Radiation Dose SR Storage",
             sop_class_category::storage,
             modality_type::sr,
+            false,
+            false
+        }
+    );
+}
+
+void sop_class_registry::register_print_sop_classes() {
+    // Basic Film Session SOP Class (PS3.4 Annex H)
+    registry_.emplace(
+        "1.2.840.10008.5.1.1.1",
+        sop_class_info{
+            "1.2.840.10008.5.1.1.1",
+            "Basic Film Session",
+            sop_class_category::print,
+            modality_type::other,
+            false,
+            false
+        }
+    );
+
+    // Basic Film Box SOP Class
+    registry_.emplace(
+        "1.2.840.10008.5.1.1.2",
+        sop_class_info{
+            "1.2.840.10008.5.1.1.2",
+            "Basic Film Box",
+            sop_class_category::print,
+            modality_type::other,
+            false,
+            false
+        }
+    );
+
+    // Basic Grayscale Image Box SOP Class
+    registry_.emplace(
+        "1.2.840.10008.5.1.1.4",
+        sop_class_info{
+            "1.2.840.10008.5.1.1.4",
+            "Basic Grayscale Image Box",
+            sop_class_category::print,
+            modality_type::other,
+            false,
+            false
+        }
+    );
+
+    // Basic Color Image Box SOP Class
+    registry_.emplace(
+        "1.2.840.10008.5.1.1.4.1",
+        sop_class_info{
+            "1.2.840.10008.5.1.1.4.1",
+            "Basic Color Image Box",
+            sop_class_category::print,
+            modality_type::other,
+            false,
+            false
+        }
+    );
+
+    // Printer SOP Class
+    registry_.emplace(
+        "1.2.840.10008.5.1.1.16",
+        sop_class_info{
+            "1.2.840.10008.5.1.1.16",
+            "Printer",
+            sop_class_category::print,
+            modality_type::other,
+            false,
+            false
+        }
+    );
+
+    // Basic Grayscale Print Management Meta SOP Class
+    registry_.emplace(
+        "1.2.840.10008.5.1.1.9",
+        sop_class_info{
+            "1.2.840.10008.5.1.1.9",
+            "Basic Grayscale Print Management Meta",
+            sop_class_category::print,
+            modality_type::other,
+            false,
+            false
+        }
+    );
+
+    // Basic Color Print Management Meta SOP Class
+    registry_.emplace(
+        "1.2.840.10008.5.1.1.18",
+        sop_class_info{
+            "1.2.840.10008.5.1.1.18",
+            "Basic Color Print Management Meta",
+            sop_class_category::print,
+            modality_type::other,
             false,
             false
         }

--- a/tests/services/print_scp_test.cpp
+++ b/tests/services/print_scp_test.cpp
@@ -1,0 +1,366 @@
+/**
+ * @file print_scp_test.cpp
+ * @brief Unit tests for Print Management SCP service (PS3.4 Annex H)
+ */
+
+#include <pacs/services/print_scp.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#include <pacs/services/sop_class_registry.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+
+// ============================================================================
+// print_scp Construction Tests
+// ============================================================================
+
+TEST_CASE("print_scp construction", "[services][print]") {
+    print_scp scp;
+
+    SECTION("service name is correct") {
+        CHECK(scp.service_name() == "Print SCP");
+    }
+
+    SECTION("supports multiple SOP classes") {
+        auto classes = scp.supported_sop_classes();
+        CHECK(classes.size() == 7);
+    }
+}
+
+// ============================================================================
+// SOP Class Support Tests
+// ============================================================================
+
+TEST_CASE("print_scp SOP class support", "[services][print]") {
+    print_scp scp;
+
+    SECTION("supports Basic Film Session") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.1.1"));
+        CHECK(scp.supports_sop_class(basic_film_session_sop_class_uid));
+    }
+
+    SECTION("supports Basic Film Box") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.1.2"));
+        CHECK(scp.supports_sop_class(basic_film_box_sop_class_uid));
+    }
+
+    SECTION("supports Basic Grayscale Image Box") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.1.4"));
+        CHECK(scp.supports_sop_class(basic_grayscale_image_box_sop_class_uid));
+    }
+
+    SECTION("supports Basic Color Image Box") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.1.4.1"));
+        CHECK(scp.supports_sop_class(basic_color_image_box_sop_class_uid));
+    }
+
+    SECTION("supports Printer") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.1.16"));
+        CHECK(scp.supports_sop_class(printer_sop_class_uid));
+    }
+
+    SECTION("supports Print Management Meta SOP classes") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.1.9"));
+        CHECK(scp.supports_sop_class(basic_grayscale_print_meta_sop_class_uid));
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.1.18"));
+        CHECK(scp.supports_sop_class(basic_color_print_meta_sop_class_uid));
+    }
+
+    SECTION("does not support unrelated SOP classes") {
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.1.1"));
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.1.1.2"));
+        CHECK_FALSE(scp.supports_sop_class(""));
+    }
+}
+
+// ============================================================================
+// SOP Class UID Constants
+// ============================================================================
+
+TEST_CASE("print SOP class UID constants", "[services][print]") {
+    CHECK(basic_film_session_sop_class_uid == "1.2.840.10008.5.1.1.1");
+    CHECK(basic_film_box_sop_class_uid == "1.2.840.10008.5.1.1.2");
+    CHECK(basic_grayscale_image_box_sop_class_uid == "1.2.840.10008.5.1.1.4");
+    CHECK(basic_color_image_box_sop_class_uid == "1.2.840.10008.5.1.1.4.1");
+    CHECK(printer_sop_class_uid == "1.2.840.10008.5.1.1.16");
+    CHECK(basic_grayscale_print_meta_sop_class_uid == "1.2.840.10008.5.1.1.9");
+    CHECK(basic_color_print_meta_sop_class_uid == "1.2.840.10008.5.1.1.18");
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("print_scp statistics", "[services][print]") {
+    print_scp scp;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scp.sessions_created() == 0);
+        CHECK(scp.film_boxes_created() == 0);
+        CHECK(scp.images_set() == 0);
+        CHECK(scp.prints_executed() == 0);
+        CHECK(scp.printer_queries() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        scp.reset_statistics();
+        CHECK(scp.sessions_created() == 0);
+        CHECK(scp.film_boxes_created() == 0);
+        CHECK(scp.images_set() == 0);
+        CHECK(scp.prints_executed() == 0);
+        CHECK(scp.printer_queries() == 0);
+    }
+}
+
+// ============================================================================
+// Handler Configuration Tests
+// ============================================================================
+
+TEST_CASE("print_scp handler configuration", "[services][print]") {
+    print_scp scp;
+
+    SECTION("can set session handler") {
+        bool handler_called = false;
+        scp.set_session_handler([&handler_called](const film_session& /*session*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set print handler") {
+        bool handler_called = false;
+        scp.set_print_handler([&handler_called](const std::string& /*uid*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set printer status handler") {
+        bool handler_called = false;
+        scp.set_printer_status_handler([&handler_called]() {
+            handler_called = true;
+            return Result<std::pair<printer_status, dicom_dataset>>{
+                std::pair{printer_status::normal, dicom_dataset{}}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+}
+
+// ============================================================================
+// printer_status Enumeration Tests
+// ============================================================================
+
+TEST_CASE("printer_status to_string conversion", "[services][print]") {
+    CHECK(to_string(printer_status::normal) == "NORMAL");
+    CHECK(to_string(printer_status::warning) == "WARNING");
+    CHECK(to_string(printer_status::failure) == "FAILURE");
+}
+
+// ============================================================================
+// Data Structure Tests
+// ============================================================================
+
+TEST_CASE("film_session structure", "[services][print]") {
+    film_session session;
+
+    SECTION("default construction") {
+        CHECK(session.sop_instance_uid.empty());
+        CHECK(session.number_of_copies == 1);
+        CHECK(session.print_priority == "MED");
+        CHECK(session.medium_type == "BLUE FILM");
+        CHECK(session.film_destination == "MAGAZINE");
+        CHECK(session.film_box_uids.empty());
+    }
+
+    SECTION("can be initialized") {
+        session.sop_instance_uid = "1.2.3.4.5.6";
+        session.number_of_copies = 3;
+        session.print_priority = "HIGH";
+        session.medium_type = "PAPER";
+        session.film_destination = "PROCESSOR";
+
+        CHECK(session.sop_instance_uid == "1.2.3.4.5.6");
+        CHECK(session.number_of_copies == 3);
+        CHECK(session.print_priority == "HIGH");
+        CHECK(session.medium_type == "PAPER");
+        CHECK(session.film_destination == "PROCESSOR");
+    }
+}
+
+TEST_CASE("film_box structure", "[services][print]") {
+    film_box box;
+
+    SECTION("default construction") {
+        CHECK(box.sop_instance_uid.empty());
+        CHECK(box.film_session_uid.empty());
+        CHECK(box.image_display_format == "STANDARD\\1,1");
+        CHECK(box.film_orientation == "PORTRAIT");
+        CHECK(box.film_size_id == "8INX10IN");
+        CHECK(box.image_box_uids.empty());
+    }
+}
+
+TEST_CASE("image_box structure", "[services][print]") {
+    image_box ib;
+
+    SECTION("default construction") {
+        CHECK(ib.sop_instance_uid.empty());
+        CHECK(ib.film_box_uid.empty());
+        CHECK(ib.image_position == 1);
+        CHECK_FALSE(ib.has_pixel_data);
+    }
+}
+
+// ============================================================================
+// Print Tags Tests
+// ============================================================================
+
+TEST_CASE("print_tags namespace contains print-specific DICOM tags", "[services][print]") {
+    using namespace print_tags;
+
+    SECTION("film session tags") {
+        CHECK(number_of_copies == dicom_tag{0x2000, 0x0010});
+        CHECK(print_priority == dicom_tag{0x2000, 0x0020});
+        CHECK(medium_type == dicom_tag{0x2000, 0x0030});
+        CHECK(film_destination == dicom_tag{0x2000, 0x0040});
+        CHECK(film_session_label == dicom_tag{0x2000, 0x0050});
+    }
+
+    SECTION("film box tags") {
+        CHECK(image_display_format == dicom_tag{0x2010, 0x0010});
+        CHECK(film_orientation == dicom_tag{0x2010, 0x0040});
+        CHECK(film_size_id == dicom_tag{0x2010, 0x0050});
+        CHECK(magnification_type == dicom_tag{0x2010, 0x0060});
+        CHECK(referenced_film_session_sequence == dicom_tag{0x2010, 0x0500});
+        CHECK(referenced_image_box_sequence == dicom_tag{0x2010, 0x0510});
+    }
+
+    SECTION("image box tags") {
+        CHECK(image_position == dicom_tag{0x2020, 0x0010});
+        CHECK(basic_grayscale_image_sequence == dicom_tag{0x2020, 0x0110});
+        CHECK(basic_color_image_sequence == dicom_tag{0x2020, 0x0111});
+    }
+
+    SECTION("printer tags") {
+        CHECK(printer_status_tag == dicom_tag{0x2110, 0x0010});
+        CHECK(printer_status_info == dicom_tag{0x2110, 0x0020});
+        CHECK(printer_name == dicom_tag{0x2110, 0x0030});
+    }
+}
+
+// ============================================================================
+// scp_service Base Class Tests
+// ============================================================================
+
+TEST_CASE("print_scp is a scp_service", "[services][print]") {
+    std::unique_ptr<scp_service> base_ptr = std::make_unique<print_scp>();
+
+    CHECK(base_ptr->service_name() == "Print SCP");
+    CHECK(base_ptr->supported_sop_classes().size() == 7);
+    CHECK(base_ptr->supports_sop_class("1.2.840.10008.5.1.1.1"));
+    CHECK(base_ptr->supports_sop_class("1.2.840.10008.5.1.1.2"));
+    CHECK(base_ptr->supports_sop_class("1.2.840.10008.5.1.1.4"));
+    CHECK(base_ptr->supports_sop_class("1.2.840.10008.5.1.1.16"));
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple print_scp instances are independent", "[services][print]") {
+    print_scp scp1;
+    print_scp scp2;
+
+    CHECK(scp1.service_name() == scp2.service_name());
+    CHECK(scp1.supported_sop_classes() == scp2.supported_sop_classes());
+    CHECK(scp1.sessions_created() == scp2.sessions_created());
+}
+
+// ============================================================================
+// DIMSE-N Command Field Tests
+// ============================================================================
+
+TEST_CASE("Print-related DIMSE-N command fields", "[services][print]") {
+    SECTION("N-CREATE command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_create_rq) == 0x0140);
+        CHECK(static_cast<uint16_t>(command_field::n_create_rsp) == 0x8140);
+    }
+
+    SECTION("N-SET command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_set_rq) == 0x0120);
+        CHECK(static_cast<uint16_t>(command_field::n_set_rsp) == 0x8120);
+    }
+
+    SECTION("N-GET command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_get_rq) == 0x0110);
+        CHECK(static_cast<uint16_t>(command_field::n_get_rsp) == 0x8110);
+    }
+
+    SECTION("N-ACTION command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_action_rq) == 0x0130);
+        CHECK(static_cast<uint16_t>(command_field::n_action_rsp) == 0x8130);
+    }
+
+    SECTION("N-DELETE command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_delete_rq) == 0x0150);
+        CHECK(static_cast<uint16_t>(command_field::n_delete_rsp) == 0x8150);
+    }
+
+    SECTION("all are DIMSE-N commands") {
+        CHECK(is_dimse_n(command_field::n_create_rq));
+        CHECK(is_dimse_n(command_field::n_set_rq));
+        CHECK(is_dimse_n(command_field::n_get_rq));
+        CHECK(is_dimse_n(command_field::n_action_rq));
+        CHECK(is_dimse_n(command_field::n_delete_rq));
+    }
+}
+
+// ============================================================================
+// SOP Class Registry Integration Tests
+// ============================================================================
+
+TEST_CASE("print SOP classes are registered in registry", "[services][print]") {
+    auto& registry = sop_class_registry::instance();
+
+    SECTION("all print SOP classes are registered") {
+        CHECK(registry.is_supported("1.2.840.10008.5.1.1.1"));
+        CHECK(registry.is_supported("1.2.840.10008.5.1.1.2"));
+        CHECK(registry.is_supported("1.2.840.10008.5.1.1.4"));
+        CHECK(registry.is_supported("1.2.840.10008.5.1.1.4.1"));
+        CHECK(registry.is_supported("1.2.840.10008.5.1.1.16"));
+        CHECK(registry.is_supported("1.2.840.10008.5.1.1.9"));
+        CHECK(registry.is_supported("1.2.840.10008.5.1.1.18"));
+    }
+
+    SECTION("print SOP classes have correct category") {
+        auto print_classes = registry.get_by_category(sop_class_category::print);
+        CHECK(print_classes.size() == 7);
+    }
+
+    SECTION("print SOP class names are correct") {
+        CHECK(get_sop_class_name("1.2.840.10008.5.1.1.1") == "Basic Film Session");
+        CHECK(get_sop_class_name("1.2.840.10008.5.1.1.2") == "Basic Film Box");
+        CHECK(get_sop_class_name("1.2.840.10008.5.1.1.4") == "Basic Grayscale Image Box");
+        CHECK(get_sop_class_name("1.2.840.10008.5.1.1.4.1") == "Basic Color Image Box");
+        CHECK(get_sop_class_name("1.2.840.10008.5.1.1.16") == "Printer");
+    }
+}
+
+// ============================================================================
+// print_job_status Enumeration Tests
+// ============================================================================
+
+TEST_CASE("print_job_status values", "[services][print]") {
+    CHECK(static_cast<int>(print_job_status::pending) == 0);
+    CHECK(static_cast<int>(print_job_status::printing) == 1);
+    CHECK(static_cast<int>(print_job_status::done) == 2);
+    CHECK(static_cast<int>(print_job_status::failure) == 3);
+}


### PR DESCRIPTION
## Summary
- Implement `print_scp` service class inheriting from `scp_service`, handling all DIMSE-N commands (N-CREATE, N-SET, N-GET, N-ACTION, N-DELETE) for Print Management
- Register 7 Print Management SOP classes in `sop_class_registry`: Basic Film Session, Basic Film Box, Basic Grayscale/Color Image Box, Printer, and Meta SOP classes
- Add print-specific error codes to `result.hpp`
- Support complete print workflow: film session/box lifecycle management, image box pixel data placement, printer status query (N-GET), and print action execution (N-ACTION)
- Internal state management for film sessions, film boxes, and image boxes with automatic cleanup on N-DELETE

## Test plan
- [x] All 15 print_scp tests pass (121 assertions)
- [x] Build succeeds with `-Wall -Wextra -Wpedantic -Werror`
- [x] SOP class registry correctly registers all 7 print SOP classes
- [x] Existing service tests remain unaffected

Part of #726
Closes #737