### PR TITLE
feat(services): implement Print Management SCU client (#738)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -981,6 +981,7 @@ add_library(pacs_services
     src/services/storage_commitment_scp.cpp
     src/services/storage_commitment_scu.cpp
     src/services/print_scp.cpp
+    src/services/print_scu.cpp
     src/services/sop_class_registry.cpp
     src/services/sop_classes/us_storage.cpp
     src/services/sop_classes/dx_storage.cpp
@@ -1800,6 +1801,7 @@ if(PACS_BUILD_TESTS)
         tests/services/storage_commitment_scp_test.cpp
         tests/services/storage_commitment_scu_test.cpp
         tests/services/print_scp_test.cpp
+        tests/services/print_scu_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/services/print_scu.hpp
+++ b/include/pacs/services/print_scu.hpp
@@ -1,0 +1,421 @@
+/**
+ * @file print_scu.hpp
+ * @brief DICOM Print Management SCU service (PS3.4 Annex H)
+ *
+ * This file provides the print_scu class for sending DICOM print requests
+ * to remote Print SCP systems, including Film Session, Film Box, Image Box,
+ * and Printer management operations.
+ *
+ * @see DICOM PS3.4 Annex H - Print Management Service Class
+ * @see DICOM PS3.7 Section 10 - DIMSE-N Services
+ */
+
+#ifndef PACS_SERVICES_PRINT_SCU_HPP
+#define PACS_SERVICES_PRINT_SCU_HPP
+
+#include "print_scp.hpp"
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/di/ilogger.hpp"
+#include "pacs/network/association.hpp"
+#include "pacs/network/dimse/dimse_message.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pacs::services {
+
+// =============================================================================
+// Print SCU Data Structures
+// =============================================================================
+
+/**
+ * @brief Result of a Print DIMSE-N operation
+ *
+ * Contains outcome information from N-CREATE, N-SET, N-GET, N-ACTION,
+ * or N-DELETE operations.
+ */
+struct print_result {
+    /// SOP Instance UID (session, film box, image box, or printer)
+    std::string sop_instance_uid;
+
+    /// DIMSE status code (0x0000 = success)
+    uint16_t status{0};
+
+    /// Error comment from the SCP (if any)
+    std::string error_comment;
+
+    /// Time taken for the operation
+    std::chrono::milliseconds elapsed{0};
+
+    /// Response dataset (e.g., printer status, referenced image box UIDs)
+    core::dicom_dataset response_data;
+
+    /// Check if the operation was successful
+    [[nodiscard]] bool is_success() const noexcept {
+        return status == 0x0000;
+    }
+
+    /// Check if this was a warning status
+    [[nodiscard]] bool is_warning() const noexcept {
+        return (status & 0xF000) == 0xB000;
+    }
+
+    /// Check if this was an error status
+    [[nodiscard]] bool is_error() const noexcept {
+        return !is_success() && !is_warning();
+    }
+};
+
+/**
+ * @brief Data for creating a Film Session via N-CREATE
+ */
+struct print_session_data {
+    /// SOP Instance UID (generated if empty)
+    std::string sop_instance_uid;
+
+    /// Number of copies to print
+    uint32_t number_of_copies{1};
+
+    /// Print priority (HIGH, MED, LOW)
+    std::string print_priority{"MED"};
+
+    /// Medium type (PAPER, CLEAR FILM, BLUE FILM)
+    std::string medium_type{"BLUE FILM"};
+
+    /// Film destination (MAGAZINE, PROCESSOR)
+    std::string film_destination{"MAGAZINE"};
+
+    /// Film session label
+    std::string film_session_label;
+};
+
+/**
+ * @brief Data for creating a Film Box via N-CREATE
+ */
+struct print_film_box_data {
+    /// Image display format (e.g., "STANDARD\\1,1")
+    std::string image_display_format{"STANDARD\\1,1"};
+
+    /// Film orientation (PORTRAIT, LANDSCAPE)
+    std::string film_orientation{"PORTRAIT"};
+
+    /// Film size ID (8INX10IN, 14INX17IN, etc.)
+    std::string film_size_id{"8INX10IN"};
+
+    /// Magnification type (REPLICATE, BILINEAR, CUBIC, NONE)
+    std::string magnification_type;
+
+    /// Parent film session SOP Instance UID
+    std::string film_session_uid;
+};
+
+/**
+ * @brief Data for setting an Image Box via N-SET
+ */
+struct print_image_data {
+    /// Pixel data to set on the image box
+    core::dicom_dataset pixel_data;
+
+    /// Image position within the film box (1-based)
+    uint16_t image_position{0};
+};
+
+/**
+ * @brief Configuration for Print SCU service
+ */
+struct print_scu_config {
+    /// Timeout for receiving DIMSE response
+    std::chrono::milliseconds timeout{30000};
+
+    /// Auto-generate SOP Instance UIDs if not provided
+    bool auto_generate_uid{true};
+};
+
+// =============================================================================
+// Print SCU Class
+// =============================================================================
+
+/**
+ * @brief Print Management SCU service
+ *
+ * The Print SCU (Service Class User) sends DIMSE-N requests to remote
+ * Print SCP systems to manage print sessions, film boxes, image boxes,
+ * and printer status.
+ *
+ * ## Print Workflow
+ *
+ * ```
+ * Workstation (Print SCU)                      Printer (Print SCP)
+ *  |                                           |
+ *  |  N-CREATE Film Session                    |
+ *  |------------------------------------------>|
+ *  |  N-CREATE-RSP (session UID)               |
+ *  |<------------------------------------------|
+ *  |                                           |
+ *  |  N-CREATE Film Box                        |
+ *  |------------------------------------------>|
+ *  |  N-CREATE-RSP (box UID + image box UIDs)  |
+ *  |<------------------------------------------|
+ *  |                                           |
+ *  |  N-SET Image Box (pixel data)             |
+ *  |------------------------------------------>|
+ *  |  N-SET-RSP (success)                      |
+ *  |<------------------------------------------|
+ *  |                                           |
+ *  |  N-ACTION Film Box (Print)                |
+ *  |------------------------------------------>|
+ *  |  N-ACTION-RSP (success)                   |
+ *  |<------------------------------------------|
+ *  |                                           |
+ *  |  N-DELETE Film Session                    |
+ *  |------------------------------------------>|
+ *  |  N-DELETE-RSP (success)                   |
+ *  |<------------------------------------------|
+ * ```
+ *
+ * @example Basic Usage
+ * @code
+ * // Establish association with Print SCP
+ * association_config config;
+ * config.calling_ae_title = "WORKSTATION";
+ * config.called_ae_title = "PRINTER_SCP";
+ * config.proposed_contexts.push_back({
+ *     1,
+ *     std::string(basic_grayscale_print_meta_sop_class_uid),
+ *     {"1.2.840.10008.1.2.1", "1.2.840.10008.1.2"}
+ * });
+ *
+ * auto assoc_result = association::connect("192.168.1.200", 10400, config);
+ * auto& assoc = assoc_result.value();
+ *
+ * print_scu scu;
+ *
+ * // Create film session
+ * print_session_data session_data;
+ * session_data.number_of_copies = 1;
+ * session_data.print_priority = "HIGH";
+ *
+ * auto session_result = scu.create_film_session(assoc, session_data);
+ * auto session_uid = session_result.value().sop_instance_uid;
+ *
+ * // Create film box
+ * print_film_box_data box_data;
+ * box_data.image_display_format = "STANDARD\\1,1";
+ * box_data.film_session_uid = session_uid;
+ *
+ * auto box_result = scu.create_film_box(assoc, box_data);
+ *
+ * // Set image box (pixel data)
+ * print_image_data image_data;
+ * image_data.pixel_data = my_image_dataset;
+ * scu.set_image_box(assoc, image_box_uid, image_data);
+ *
+ * // Print and cleanup
+ * auto film_box_uid = box_result.value().sop_instance_uid;
+ * scu.print_film_box(assoc, film_box_uid);
+ * scu.delete_film_session(assoc, session_uid);
+ *
+ * assoc.release();
+ * @endcode
+ */
+class print_scu {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct Print SCU with default configuration
+     *
+     * @param logger Logger instance for service logging (nullptr uses null_logger)
+     */
+    explicit print_scu(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    /**
+     * @brief Construct Print SCU with custom configuration
+     *
+     * @param config Configuration options
+     * @param logger Logger instance for service logging (nullptr uses null_logger)
+     */
+    explicit print_scu(const print_scu_config& config,
+                       std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~print_scu() = default;
+
+    // Non-copyable, non-movable (due to atomic members)
+    print_scu(const print_scu&) = delete;
+    print_scu& operator=(const print_scu&) = delete;
+    print_scu(print_scu&&) = delete;
+    print_scu& operator=(print_scu&&) = delete;
+
+    // =========================================================================
+    // Film Session Operations
+    // =========================================================================
+
+    /**
+     * @brief Create a new Film Session (N-CREATE)
+     *
+     * @param assoc The established association to use
+     * @param data Film session creation data
+     * @return Result containing print_result on success
+     */
+    [[nodiscard]] network::Result<print_result> create_film_session(
+        network::association& assoc,
+        const print_session_data& data);
+
+    /**
+     * @brief Delete a Film Session (N-DELETE)
+     *
+     * Also deletes all associated Film Boxes and Image Boxes on the SCP side.
+     *
+     * @param assoc The established association to use
+     * @param session_uid Film Session SOP Instance UID
+     * @return Result containing print_result on success
+     */
+    [[nodiscard]] network::Result<print_result> delete_film_session(
+        network::association& assoc,
+        std::string_view session_uid);
+
+    // =========================================================================
+    // Film Box Operations
+    // =========================================================================
+
+    /**
+     * @brief Create a new Film Box (N-CREATE)
+     *
+     * The SCP will auto-create Image Boxes based on the image display format.
+     * Referenced Image Box UIDs are returned in the response dataset.
+     *
+     * @param assoc The established association to use
+     * @param data Film box creation data
+     * @return Result containing print_result (response_data has image box UIDs)
+     */
+    [[nodiscard]] network::Result<print_result> create_film_box(
+        network::association& assoc,
+        const print_film_box_data& data);
+
+    /**
+     * @brief Print a Film Box (N-ACTION)
+     *
+     * Sends N-ACTION to the SCP to initiate printing of the film box.
+     *
+     * @param assoc The established association to use
+     * @param film_box_uid Film Box SOP Instance UID
+     * @return Result containing print_result on success
+     */
+    [[nodiscard]] network::Result<print_result> print_film_box(
+        network::association& assoc,
+        std::string_view film_box_uid);
+
+    /**
+     * @brief Delete a Film Box (N-DELETE)
+     *
+     * @param assoc The established association to use
+     * @param film_box_uid Film Box SOP Instance UID
+     * @return Result containing print_result on success
+     */
+    [[nodiscard]] network::Result<print_result> delete_film_box(
+        network::association& assoc,
+        std::string_view film_box_uid);
+
+    // =========================================================================
+    // Image Box Operations
+    // =========================================================================
+
+    /**
+     * @brief Set Image Box pixel data (N-SET)
+     *
+     * Sets the pixel data for an Image Box in the film box.
+     * Use Basic Grayscale Image Box SOP Class by default.
+     *
+     * @param assoc The established association to use
+     * @param image_box_uid Image Box SOP Instance UID
+     * @param data Image data to set
+     * @param use_color Use Basic Color Image Box instead of Grayscale
+     * @return Result containing print_result on success
+     */
+    [[nodiscard]] network::Result<print_result> set_image_box(
+        network::association& assoc,
+        std::string_view image_box_uid,
+        const print_image_data& data,
+        bool use_color = false);
+
+    // =========================================================================
+    // Printer Status
+    // =========================================================================
+
+    /**
+     * @brief Query printer status (N-GET)
+     *
+     * Sends N-GET to the Printer SOP Class to retrieve printer status.
+     * The response_data in print_result contains the printer status dataset.
+     *
+     * @param assoc The established association to use
+     * @return Result containing print_result with printer status in response_data
+     */
+    [[nodiscard]] network::Result<print_result> query_printer_status(
+        network::association& assoc);
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    [[nodiscard]] size_t sessions_created() const noexcept;
+    [[nodiscard]] size_t film_boxes_created() const noexcept;
+    [[nodiscard]] size_t images_set() const noexcept;
+    [[nodiscard]] size_t prints_executed() const noexcept;
+    [[nodiscard]] size_t printer_queries() const noexcept;
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    /**
+     * @brief Find an accepted presentation context for a print SOP class
+     *
+     * Tries the specific SOP class first, then falls back to Meta SOP classes.
+     */
+    [[nodiscard]] std::optional<uint8_t> find_print_context(
+        network::association& assoc,
+        std::string_view sop_class_uid) const;
+
+    /**
+     * @brief Generate a unique SOP Instance UID
+     */
+    [[nodiscard]] std::string generate_uid() const;
+
+    /**
+     * @brief Get the next message ID for DIMSE operations
+     */
+    [[nodiscard]] uint16_t next_message_id() noexcept;
+
+    // =========================================================================
+    // Private Members
+    // =========================================================================
+
+    /// Logger instance
+    std::shared_ptr<di::ILogger> logger_;
+
+    /// Configuration
+    print_scu_config config_;
+
+    /// Message ID counter
+    std::atomic<uint16_t> message_id_counter_{1};
+
+    /// Statistics
+    std::atomic<size_t> sessions_created_{0};
+    std::atomic<size_t> film_boxes_created_{0};
+    std::atomic<size_t> images_set_{0};
+    std::atomic<size_t> prints_executed_{0};
+    std::atomic<size_t> printer_queries_{0};
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_PRINT_SCU_HPP

--- a/src/services/print_scu.cpp
+++ b/src/services/print_scu.cpp
@@ -1,0 +1,839 @@
+/**
+ * @file print_scu.cpp
+ * @brief Implementation of the Print Management SCU service (PS3.4 Annex H)
+ */
+
+#include "pacs/services/print_scu.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/core/result.hpp"
+#include "pacs/encoding/vr_type.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+#include <chrono>
+#include <random>
+#include <sstream>
+
+namespace pacs::services {
+
+// =============================================================================
+// Local Helper Functions
+// =============================================================================
+
+namespace {
+
+/// UID root for auto-generated Print UIDs
+constexpr const char* uid_root = "1.2.826.0.1.3680043.2.1545.1";
+
+/// Requested SOP Instance UID tag (used in N-SET/N-GET command set)
+constexpr core::dicom_tag tag_requested_sop_instance_uid{0x0000, 0x1001};
+
+/**
+ * @brief Create N-CREATE request message for a Print SOP Class
+ */
+network::dimse::dimse_message make_n_create_rq(
+    uint16_t message_id,
+    std::string_view sop_class_uid,
+    std::string_view sop_instance_uid,
+    core::dicom_dataset dataset) {
+
+    using namespace network::dimse;
+
+    dimse_message msg{command_field::n_create_rq, message_id};
+    msg.set_affected_sop_class_uid(sop_class_uid);
+    if (!sop_instance_uid.empty()) {
+        msg.set_affected_sop_instance_uid(sop_instance_uid);
+    }
+    msg.set_dataset(std::move(dataset));
+
+    return msg;
+}
+
+/**
+ * @brief Create N-SET request message
+ */
+network::dimse::dimse_message make_n_set_rq(
+    uint16_t message_id,
+    std::string_view sop_class_uid,
+    std::string_view sop_instance_uid,
+    core::dicom_dataset modifications) {
+
+    using namespace network::dimse;
+    using namespace encoding;
+
+    dimse_message msg{command_field::n_set_rq, message_id};
+    msg.set_affected_sop_class_uid(sop_class_uid);
+    msg.command_set().set_string(
+        tag_requested_sop_instance_uid,
+        vr_type::UI,
+        std::string(sop_instance_uid));
+    msg.set_dataset(std::move(modifications));
+
+    return msg;
+}
+
+/**
+ * @brief Create N-GET request message
+ */
+network::dimse::dimse_message make_n_get_rq(
+    uint16_t message_id,
+    std::string_view sop_class_uid,
+    std::string_view sop_instance_uid) {
+
+    using namespace network::dimse;
+    using namespace encoding;
+
+    dimse_message msg{command_field::n_get_rq, message_id};
+    msg.set_affected_sop_class_uid(sop_class_uid);
+    msg.command_set().set_string(
+        tag_requested_sop_instance_uid,
+        vr_type::UI,
+        std::string(sop_instance_uid));
+
+    return msg;
+}
+
+/**
+ * @brief Create N-ACTION request message
+ */
+network::dimse::dimse_message make_n_action_rq(
+    uint16_t message_id,
+    std::string_view sop_class_uid,
+    std::string_view sop_instance_uid,
+    uint16_t action_type_id) {
+
+    using namespace network::dimse;
+
+    dimse_message msg{command_field::n_action_rq, message_id};
+    msg.set_affected_sop_class_uid(sop_class_uid);
+    msg.set_affected_sop_instance_uid(sop_instance_uid);
+    msg.set_action_type_id(action_type_id);
+
+    return msg;
+}
+
+/**
+ * @brief Create N-DELETE request message
+ */
+network::dimse::dimse_message make_n_delete_rq(
+    uint16_t message_id,
+    std::string_view sop_class_uid,
+    std::string_view sop_instance_uid) {
+
+    using namespace network::dimse;
+
+    dimse_message msg{command_field::n_delete_rq, message_id};
+    msg.set_affected_sop_class_uid(sop_class_uid);
+    msg.set_affected_sop_instance_uid(sop_instance_uid);
+
+    return msg;
+}
+
+}  // namespace
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+print_scu::print_scu(std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()) {}
+
+print_scu::print_scu(const print_scu_config& config,
+                     std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()),
+      config_(config) {}
+
+// =============================================================================
+// Film Session Operations
+// =============================================================================
+
+network::Result<print_result> print_scu::create_film_session(
+    network::association& assoc,
+    const print_session_data& data) {
+
+    using namespace network::dimse;
+    using namespace encoding;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    auto context_id = find_print_context(assoc, basic_film_session_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_invalid_sop_class,
+            "No accepted presentation context for Film Session SOP Class");
+    }
+
+    std::string session_uid = data.sop_instance_uid;
+    if (session_uid.empty() && config_.auto_generate_uid) {
+        session_uid = generate_uid();
+    }
+
+    // Build creation dataset
+    core::dicom_dataset ds;
+    ds.set_string(print_tags::number_of_copies, vr_type::IS,
+                  std::to_string(data.number_of_copies));
+    if (!data.print_priority.empty()) {
+        ds.set_string(print_tags::print_priority, vr_type::CS, data.print_priority);
+    }
+    if (!data.medium_type.empty()) {
+        ds.set_string(print_tags::medium_type, vr_type::CS, data.medium_type);
+    }
+    if (!data.film_destination.empty()) {
+        ds.set_string(print_tags::film_destination, vr_type::CS, data.film_destination);
+    }
+    if (!data.film_session_label.empty()) {
+        ds.set_string(print_tags::film_session_label, vr_type::LO, data.film_session_label);
+    }
+
+    auto request = make_n_create_rq(
+        next_message_id(),
+        basic_film_session_sop_class_uid,
+        session_uid,
+        std::move(ds));
+
+    logger_->debug("Sending N-CREATE Film Session: " + session_uid);
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-CREATE Film Session: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-CREATE Film Session response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_create_rsp) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_unexpected_command,
+            "Expected N-CREATE-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+
+    print_result result;
+    result.sop_instance_uid = response.affected_sop_instance_uid().empty()
+        ? session_uid : std::string(response.affected_sop_instance_uid());
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    sessions_created_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-CREATE Film Session successful: " + result.sop_instance_uid);
+    } else {
+        logger_->warn("N-CREATE Film Session status 0x" +
+                      std::to_string(result.status) + ": " + result.sop_instance_uid);
+    }
+
+    return result;
+}
+
+network::Result<print_result> print_scu::delete_film_session(
+    network::association& assoc,
+    std::string_view session_uid) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    auto context_id = find_print_context(assoc, basic_film_session_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_invalid_sop_class,
+            "No accepted presentation context for Film Session SOP Class");
+    }
+
+    auto request = make_n_delete_rq(
+        next_message_id(),
+        basic_film_session_sop_class_uid,
+        session_uid);
+
+    logger_->debug("Sending N-DELETE Film Session: " + std::string(session_uid));
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-DELETE Film Session: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-DELETE Film Session response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_delete_rsp) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_unexpected_command,
+            "Expected N-DELETE-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+
+    print_result result;
+    result.sop_instance_uid = std::string(session_uid);
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    if (result.is_success()) {
+        logger_->info("N-DELETE Film Session successful: " + std::string(session_uid));
+    } else {
+        logger_->warn("N-DELETE Film Session status 0x" +
+                      std::to_string(result.status) + ": " + std::string(session_uid));
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Film Box Operations
+// =============================================================================
+
+network::Result<print_result> print_scu::create_film_box(
+    network::association& assoc,
+    const print_film_box_data& data) {
+
+    using namespace network::dimse;
+    using namespace encoding;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    auto context_id = find_print_context(assoc, basic_film_box_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_invalid_sop_class,
+            "No accepted presentation context for Film Box SOP Class");
+    }
+
+    // Build creation dataset
+    core::dicom_dataset ds;
+    if (!data.image_display_format.empty()) {
+        ds.set_string(print_tags::image_display_format, vr_type::ST,
+                      data.image_display_format);
+    }
+    if (!data.film_orientation.empty()) {
+        ds.set_string(print_tags::film_orientation, vr_type::CS, data.film_orientation);
+    }
+    if (!data.film_size_id.empty()) {
+        ds.set_string(print_tags::film_size_id, vr_type::CS, data.film_size_id);
+    }
+    if (!data.magnification_type.empty()) {
+        ds.set_string(print_tags::magnification_type, vr_type::CS,
+                      data.magnification_type);
+    }
+
+    // Add referenced film session sequence
+    if (!data.film_session_uid.empty()) {
+        auto& seq = ds.get_or_create_sequence(
+            print_tags::referenced_film_session_sequence);
+        core::dicom_dataset ref_item;
+        ref_item.set_string(core::tags::referenced_sop_class_uid, vr_type::UI,
+                           std::string(basic_film_session_sop_class_uid));
+        ref_item.set_string(core::tags::referenced_sop_instance_uid, vr_type::UI,
+                           data.film_session_uid);
+        seq.push_back(std::move(ref_item));
+    }
+
+    auto request = make_n_create_rq(
+        next_message_id(),
+        basic_film_box_sop_class_uid,
+        "",  // SCP generates the UID
+        std::move(ds));
+
+    logger_->debug("Sending N-CREATE Film Box");
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-CREATE Film Box: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-CREATE Film Box response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_create_rsp) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_unexpected_command,
+            "Expected N-CREATE-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+
+    print_result result;
+    result.sop_instance_uid = std::string(response.affected_sop_instance_uid());
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    // Capture response dataset (contains Referenced Image Box Sequence)
+    if (response.has_dataset()) {
+        result.response_data = response.dataset().value().get();
+    }
+
+    film_boxes_created_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-CREATE Film Box successful: " + result.sop_instance_uid);
+    } else {
+        logger_->warn("N-CREATE Film Box status 0x" +
+                      std::to_string(result.status));
+    }
+
+    return result;
+}
+
+network::Result<print_result> print_scu::print_film_box(
+    network::association& assoc,
+    std::string_view film_box_uid) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    auto context_id = find_print_context(assoc, basic_film_box_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_invalid_sop_class,
+            "No accepted presentation context for Film Box SOP Class");
+    }
+
+    // Action Type ID 1 = Print
+    auto request = make_n_action_rq(
+        next_message_id(),
+        basic_film_box_sop_class_uid,
+        film_box_uid,
+        1);
+
+    logger_->debug("Sending N-ACTION Print Film Box: " + std::string(film_box_uid));
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-ACTION Print: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-ACTION Print response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_action_rsp) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_unexpected_command,
+            "Expected N-ACTION-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+
+    print_result result;
+    result.sop_instance_uid = std::string(film_box_uid);
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    prints_executed_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-ACTION Print successful: " + std::string(film_box_uid));
+    } else {
+        logger_->warn("N-ACTION Print status 0x" +
+                      std::to_string(result.status) + ": " + std::string(film_box_uid));
+    }
+
+    return result;
+}
+
+network::Result<print_result> print_scu::delete_film_box(
+    network::association& assoc,
+    std::string_view film_box_uid) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    auto context_id = find_print_context(assoc, basic_film_box_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_invalid_sop_class,
+            "No accepted presentation context for Film Box SOP Class");
+    }
+
+    auto request = make_n_delete_rq(
+        next_message_id(),
+        basic_film_box_sop_class_uid,
+        film_box_uid);
+
+    logger_->debug("Sending N-DELETE Film Box: " + std::string(film_box_uid));
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-DELETE Film Box: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-DELETE Film Box response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_delete_rsp) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_unexpected_command,
+            "Expected N-DELETE-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+
+    print_result result;
+    result.sop_instance_uid = std::string(film_box_uid);
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    if (result.is_success()) {
+        logger_->info("N-DELETE Film Box successful: " + std::string(film_box_uid));
+    } else {
+        logger_->warn("N-DELETE Film Box status 0x" +
+                      std::to_string(result.status) + ": " + std::string(film_box_uid));
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Image Box Operations
+// =============================================================================
+
+network::Result<print_result> print_scu::set_image_box(
+    network::association& assoc,
+    std::string_view image_box_uid,
+    const print_image_data& data,
+    bool use_color) {
+
+    using namespace network::dimse;
+    using namespace encoding;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    auto sop_class_uid = use_color
+        ? basic_color_image_box_sop_class_uid
+        : basic_grayscale_image_box_sop_class_uid;
+
+    auto context_id = find_print_context(assoc, sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_invalid_sop_class,
+            "No accepted presentation context for Image Box SOP Class");
+    }
+
+    // Build modification dataset with pixel data in the appropriate sequence
+    core::dicom_dataset ds = data.pixel_data;
+
+    if (data.image_position > 0) {
+        ds.set_string(print_tags::image_position, vr_type::US,
+                      std::to_string(data.image_position));
+    }
+
+    auto request = make_n_set_rq(
+        next_message_id(),
+        sop_class_uid,
+        image_box_uid,
+        std::move(ds));
+
+    logger_->debug("Sending N-SET Image Box: " + std::string(image_box_uid));
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-SET Image Box: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-SET Image Box response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_set_rsp) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_unexpected_command,
+            "Expected N-SET-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+
+    print_result result;
+    result.sop_instance_uid = std::string(image_box_uid);
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    images_set_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-SET Image Box successful: " + std::string(image_box_uid));
+    } else {
+        logger_->warn("N-SET Image Box status 0x" +
+                      std::to_string(result.status) + ": " + std::string(image_box_uid));
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Printer Status
+// =============================================================================
+
+network::Result<print_result> print_scu::query_printer_status(
+    network::association& assoc) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    auto context_id = find_print_context(assoc, printer_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_invalid_sop_class,
+            "No accepted presentation context for Printer SOP Class");
+    }
+
+    // Well-Known Printer SOP Instance UID (PS3.4 H.4.17)
+    constexpr std::string_view printer_instance_uid =
+        "1.2.840.10008.5.1.1.17";
+
+    auto request = make_n_get_rq(
+        next_message_id(),
+        printer_sop_class_uid,
+        printer_instance_uid);
+
+    logger_->debug("Sending N-GET Printer Status");
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-GET Printer Status: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-GET Printer Status response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_get_rsp) {
+        return pacs::pacs_error<print_result>(
+            pacs::error_codes::print_unexpected_command,
+            "Expected N-GET-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+
+    print_result result;
+    result.sop_instance_uid = std::string(printer_instance_uid);
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    if (response.has_dataset()) {
+        result.response_data = response.dataset().value().get();
+    }
+
+    printer_queries_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-GET Printer Status successful");
+    } else {
+        logger_->warn("N-GET Printer Status returned 0x" +
+                      std::to_string(result.status));
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t print_scu::sessions_created() const noexcept {
+    return sessions_created_.load(std::memory_order_relaxed);
+}
+
+size_t print_scu::film_boxes_created() const noexcept {
+    return film_boxes_created_.load(std::memory_order_relaxed);
+}
+
+size_t print_scu::images_set() const noexcept {
+    return images_set_.load(std::memory_order_relaxed);
+}
+
+size_t print_scu::prints_executed() const noexcept {
+    return prints_executed_.load(std::memory_order_relaxed);
+}
+
+size_t print_scu::printer_queries() const noexcept {
+    return printer_queries_.load(std::memory_order_relaxed);
+}
+
+void print_scu::reset_statistics() noexcept {
+    sessions_created_.store(0, std::memory_order_relaxed);
+    film_boxes_created_.store(0, std::memory_order_relaxed);
+    images_set_.store(0, std::memory_order_relaxed);
+    prints_executed_.store(0, std::memory_order_relaxed);
+    printer_queries_.store(0, std::memory_order_relaxed);
+}
+
+// =============================================================================
+// Private Implementation
+// =============================================================================
+
+std::optional<uint8_t> print_scu::find_print_context(
+    network::association& assoc,
+    std::string_view sop_class_uid) const {
+
+    // Try the specific SOP class first
+    auto context = assoc.accepted_context_id(sop_class_uid);
+    if (context) {
+        return context;
+    }
+
+    // Fall back to Meta SOP Classes which bundle multiple print SOP classes
+    context = assoc.accepted_context_id(basic_grayscale_print_meta_sop_class_uid);
+    if (context) {
+        return context;
+    }
+
+    context = assoc.accepted_context_id(basic_color_print_meta_sop_class_uid);
+    return context;
+}
+
+std::string print_scu::generate_uid() const {
+    static std::mt19937_64 gen{std::random_device{}()};
+    static std::uniform_int_distribution<uint64_t> dist;
+
+    auto now = std::chrono::system_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now.time_since_epoch()).count();
+
+    return std::string(uid_root) + "." + std::to_string(timestamp) +
+           "." + std::to_string(dist(gen) % 100000);
+}
+
+uint16_t print_scu::next_message_id() noexcept {
+    uint16_t id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    if (id == 0) {
+        id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    }
+    return id;
+}
+
+}  // namespace pacs::services

--- a/tests/services/print_scu_test.cpp
+++ b/tests/services/print_scu_test.cpp
@@ -1,0 +1,449 @@
+/**
+ * @file print_scu_test.cpp
+ * @brief Unit tests for Print Management SCU service (PS3.4 Annex H)
+ */
+
+#include <pacs/services/print_scu.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#include <pacs/services/sop_class_registry.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+
+// ============================================================================
+// print_scu Construction Tests
+// ============================================================================
+
+TEST_CASE("print_scu construction", "[services][print][scu]") {
+    SECTION("default construction succeeds") {
+        print_scu scu;
+        CHECK(scu.sessions_created() == 0);
+        CHECK(scu.film_boxes_created() == 0);
+        CHECK(scu.images_set() == 0);
+        CHECK(scu.prints_executed() == 0);
+        CHECK(scu.printer_queries() == 0);
+    }
+
+    SECTION("construction with config succeeds") {
+        print_scu_config config;
+        config.timeout = std::chrono::milliseconds{60000};
+        config.auto_generate_uid = false;
+
+        print_scu scu(config);
+        CHECK(scu.sessions_created() == 0);
+        CHECK(scu.film_boxes_created() == 0);
+    }
+
+    SECTION("construction with nullptr logger succeeds") {
+        print_scu scu(nullptr);
+        CHECK(scu.sessions_created() == 0);
+    }
+
+    SECTION("construction with config and nullptr logger succeeds") {
+        print_scu_config config;
+        print_scu scu(config, nullptr);
+        CHECK(scu.sessions_created() == 0);
+    }
+}
+
+// ============================================================================
+// print_scu_config Tests
+// ============================================================================
+
+TEST_CASE("print_scu_config defaults", "[services][print][scu]") {
+    print_scu_config config;
+
+    CHECK(config.timeout == std::chrono::milliseconds{30000});
+    CHECK(config.auto_generate_uid == true);
+}
+
+TEST_CASE("print_scu_config customization", "[services][print][scu]") {
+    print_scu_config config;
+    config.timeout = std::chrono::milliseconds{60000};
+    config.auto_generate_uid = false;
+
+    CHECK(config.timeout == std::chrono::milliseconds{60000});
+    CHECK(config.auto_generate_uid == false);
+}
+
+// ============================================================================
+// print_result Structure Tests
+// ============================================================================
+
+TEST_CASE("print_result structure", "[services][print][scu]") {
+    print_result result;
+
+    SECTION("default construction") {
+        CHECK(result.sop_instance_uid.empty());
+        CHECK(result.status == 0);
+        CHECK(result.error_comment.empty());
+        CHECK(result.elapsed == std::chrono::milliseconds{0});
+    }
+
+    SECTION("is_success returns true for status 0x0000") {
+        result.status = 0x0000;
+        CHECK(result.is_success());
+        CHECK_FALSE(result.is_warning());
+        CHECK_FALSE(result.is_error());
+    }
+
+    SECTION("is_warning returns true for 0xBxxx status") {
+        result.status = 0xB000;
+        CHECK_FALSE(result.is_success());
+        CHECK(result.is_warning());
+        CHECK_FALSE(result.is_error());
+
+        result.status = 0xB123;
+        CHECK(result.is_warning());
+
+        result.status = 0xBFFF;
+        CHECK(result.is_warning());
+    }
+
+    SECTION("is_error returns true for error status codes") {
+        result.status = 0xC310;
+        CHECK_FALSE(result.is_success());
+        CHECK_FALSE(result.is_warning());
+        CHECK(result.is_error());
+
+        result.status = 0xA700;
+        CHECK(result.is_error());
+
+        result.status = 0x0110;
+        CHECK(result.is_error());
+    }
+
+    SECTION("can store elapsed time") {
+        result.elapsed = std::chrono::milliseconds{250};
+        CHECK(result.elapsed.count() == 250);
+    }
+
+    SECTION("can store response data") {
+        result.response_data.set_string(
+            print_tags::printer_status_tag,
+            pacs::encoding::vr_type::CS,
+            "NORMAL");
+        CHECK(result.response_data.contains(print_tags::printer_status_tag));
+    }
+}
+
+// ============================================================================
+// print_session_data Structure Tests
+// ============================================================================
+
+TEST_CASE("print_session_data structure", "[services][print][scu]") {
+    print_session_data data;
+
+    SECTION("default construction") {
+        CHECK(data.sop_instance_uid.empty());
+        CHECK(data.number_of_copies == 1);
+        CHECK(data.print_priority == "MED");
+        CHECK(data.medium_type == "BLUE FILM");
+        CHECK(data.film_destination == "MAGAZINE");
+        CHECK(data.film_session_label.empty());
+    }
+
+    SECTION("can be initialized with values") {
+        data.sop_instance_uid = "1.2.3.4.5.6";
+        data.number_of_copies = 3;
+        data.print_priority = "HIGH";
+        data.medium_type = "PAPER";
+        data.film_destination = "PROCESSOR";
+        data.film_session_label = "CHEST_XRAY";
+
+        CHECK(data.sop_instance_uid == "1.2.3.4.5.6");
+        CHECK(data.number_of_copies == 3);
+        CHECK(data.print_priority == "HIGH");
+        CHECK(data.medium_type == "PAPER");
+        CHECK(data.film_destination == "PROCESSOR");
+        CHECK(data.film_session_label == "CHEST_XRAY");
+    }
+}
+
+// ============================================================================
+// print_film_box_data Structure Tests
+// ============================================================================
+
+TEST_CASE("print_film_box_data structure", "[services][print][scu]") {
+    print_film_box_data data;
+
+    SECTION("default construction") {
+        CHECK(data.image_display_format == "STANDARD\\1,1");
+        CHECK(data.film_orientation == "PORTRAIT");
+        CHECK(data.film_size_id == "8INX10IN");
+        CHECK(data.magnification_type.empty());
+        CHECK(data.film_session_uid.empty());
+    }
+
+    SECTION("can be initialized with values") {
+        data.image_display_format = "STANDARD\\2,2";
+        data.film_orientation = "LANDSCAPE";
+        data.film_size_id = "14INX17IN";
+        data.magnification_type = "BILINEAR";
+        data.film_session_uid = "1.2.3.4.5.6";
+
+        CHECK(data.image_display_format == "STANDARD\\2,2");
+        CHECK(data.film_orientation == "LANDSCAPE");
+        CHECK(data.film_size_id == "14INX17IN");
+        CHECK(data.magnification_type == "BILINEAR");
+        CHECK(data.film_session_uid == "1.2.3.4.5.6");
+    }
+}
+
+// ============================================================================
+// print_image_data Structure Tests
+// ============================================================================
+
+TEST_CASE("print_image_data structure", "[services][print][scu]") {
+    print_image_data data;
+
+    SECTION("default construction") {
+        CHECK(data.image_position == 0);
+    }
+
+    SECTION("can be initialized with values") {
+        data.image_position = 3;
+        CHECK(data.image_position == 3);
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("print_scu statistics", "[services][print][scu]") {
+    print_scu scu;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scu.sessions_created() == 0);
+        CHECK(scu.film_boxes_created() == 0);
+        CHECK(scu.images_set() == 0);
+        CHECK(scu.prints_executed() == 0);
+        CHECK(scu.printer_queries() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        scu.reset_statistics();
+        CHECK(scu.sessions_created() == 0);
+        CHECK(scu.film_boxes_created() == 0);
+        CHECK(scu.images_set() == 0);
+        CHECK(scu.prints_executed() == 0);
+        CHECK(scu.printer_queries() == 0);
+    }
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple print_scu instances are independent", "[services][print][scu]") {
+    print_scu scu1;
+    print_scu scu2;
+
+    CHECK(scu1.sessions_created() == scu2.sessions_created());
+    CHECK(scu1.film_boxes_created() == scu2.film_boxes_created());
+    CHECK(scu1.images_set() == scu2.images_set());
+    CHECK(scu1.prints_executed() == scu2.prints_executed());
+    CHECK(scu1.printer_queries() == scu2.printer_queries());
+
+    scu1.reset_statistics();
+    CHECK(scu1.sessions_created() == 0);
+    CHECK(scu2.sessions_created() == 0);
+}
+
+// ============================================================================
+// Print SOP Class UID Constants Tests (from print_scp.hpp, used by SCU)
+// ============================================================================
+
+TEST_CASE("print SOP class UID constants accessible from print_scu", "[services][print][scu]") {
+    CHECK(basic_film_session_sop_class_uid == "1.2.840.10008.5.1.1.1");
+    CHECK(basic_film_box_sop_class_uid == "1.2.840.10008.5.1.1.2");
+    CHECK(basic_grayscale_image_box_sop_class_uid == "1.2.840.10008.5.1.1.4");
+    CHECK(basic_color_image_box_sop_class_uid == "1.2.840.10008.5.1.1.4.1");
+    CHECK(printer_sop_class_uid == "1.2.840.10008.5.1.1.16");
+    CHECK(basic_grayscale_print_meta_sop_class_uid == "1.2.840.10008.5.1.1.9");
+    CHECK(basic_color_print_meta_sop_class_uid == "1.2.840.10008.5.1.1.18");
+}
+
+// ============================================================================
+// printer_status Enumeration Tests (from print_scp.hpp, used by SCU)
+// ============================================================================
+
+TEST_CASE("printer_status to_string conversion (SCU)", "[services][print][scu]") {
+    CHECK(to_string(printer_status::normal) == "NORMAL");
+    CHECK(to_string(printer_status::warning) == "WARNING");
+    CHECK(to_string(printer_status::failure) == "FAILURE");
+}
+
+// ============================================================================
+// print_job_status Enumeration Tests (from print_scp.hpp, used by SCU)
+// ============================================================================
+
+TEST_CASE("print_job_status values (SCU)", "[services][print][scu]") {
+    CHECK(static_cast<int>(print_job_status::pending) == 0);
+    CHECK(static_cast<int>(print_job_status::printing) == 1);
+    CHECK(static_cast<int>(print_job_status::done) == 2);
+    CHECK(static_cast<int>(print_job_status::failure) == 3);
+}
+
+// ============================================================================
+// Print Tags Tests (from print_scp.hpp, used by SCU)
+// ============================================================================
+
+TEST_CASE("print_tags accessible from print_scu", "[services][print][scu]") {
+    using namespace print_tags;
+
+    SECTION("film session tags") {
+        CHECK(number_of_copies == dicom_tag{0x2000, 0x0010});
+        CHECK(print_priority == dicom_tag{0x2000, 0x0020});
+        CHECK(medium_type == dicom_tag{0x2000, 0x0030});
+        CHECK(film_destination == dicom_tag{0x2000, 0x0040});
+        CHECK(film_session_label == dicom_tag{0x2000, 0x0050});
+    }
+
+    SECTION("film box tags") {
+        CHECK(image_display_format == dicom_tag{0x2010, 0x0010});
+        CHECK(film_orientation == dicom_tag{0x2010, 0x0040});
+        CHECK(film_size_id == dicom_tag{0x2010, 0x0050});
+        CHECK(magnification_type == dicom_tag{0x2010, 0x0060});
+        CHECK(referenced_film_session_sequence == dicom_tag{0x2010, 0x0500});
+        CHECK(referenced_image_box_sequence == dicom_tag{0x2010, 0x0510});
+    }
+
+    SECTION("image box tags") {
+        CHECK(image_position == dicom_tag{0x2020, 0x0010});
+        CHECK(basic_grayscale_image_sequence == dicom_tag{0x2020, 0x0110});
+        CHECK(basic_color_image_sequence == dicom_tag{0x2020, 0x0111});
+    }
+
+    SECTION("printer tags") {
+        CHECK(printer_status_tag == dicom_tag{0x2110, 0x0010});
+        CHECK(printer_status_info == dicom_tag{0x2110, 0x0020});
+        CHECK(printer_name == dicom_tag{0x2110, 0x0030});
+    }
+}
+
+// ============================================================================
+// DIMSE-N Command Field Tests (Print-related)
+// ============================================================================
+
+TEST_CASE("Print-related DIMSE-N command fields (SCU)", "[services][print][scu]") {
+    SECTION("N-CREATE command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_create_rq) == 0x0140);
+        CHECK(static_cast<uint16_t>(command_field::n_create_rsp) == 0x8140);
+    }
+
+    SECTION("N-SET command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_set_rq) == 0x0120);
+        CHECK(static_cast<uint16_t>(command_field::n_set_rsp) == 0x8120);
+    }
+
+    SECTION("N-GET command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_get_rq) == 0x0110);
+        CHECK(static_cast<uint16_t>(command_field::n_get_rsp) == 0x8110);
+    }
+
+    SECTION("N-ACTION command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_action_rq) == 0x0130);
+        CHECK(static_cast<uint16_t>(command_field::n_action_rsp) == 0x8130);
+    }
+
+    SECTION("N-DELETE command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_delete_rq) == 0x0150);
+        CHECK(static_cast<uint16_t>(command_field::n_delete_rsp) == 0x8150);
+    }
+}
+
+// ============================================================================
+// Data Structure Copy and Move Tests
+// ============================================================================
+
+TEST_CASE("print_session_data is copyable and movable", "[services][print][scu]") {
+    print_session_data data;
+    data.sop_instance_uid = "1.2.3.4.5.6";
+    data.number_of_copies = 2;
+    data.print_priority = "HIGH";
+
+    SECTION("copy construction") {
+        print_session_data copy = data;
+        CHECK(copy.sop_instance_uid == "1.2.3.4.5.6");
+        CHECK(copy.number_of_copies == 2);
+        CHECK(copy.print_priority == "HIGH");
+    }
+
+    SECTION("move construction") {
+        print_session_data moved = std::move(data);
+        CHECK(moved.sop_instance_uid == "1.2.3.4.5.6");
+        CHECK(moved.number_of_copies == 2);
+        CHECK(moved.print_priority == "HIGH");
+    }
+}
+
+TEST_CASE("print_film_box_data is copyable and movable", "[services][print][scu]") {
+    print_film_box_data data;
+    data.image_display_format = "STANDARD\\2,2";
+    data.film_orientation = "LANDSCAPE";
+    data.film_session_uid = "1.2.3.4.5.6";
+
+    SECTION("copy construction") {
+        print_film_box_data copy = data;
+        CHECK(copy.image_display_format == "STANDARD\\2,2");
+        CHECK(copy.film_orientation == "LANDSCAPE");
+        CHECK(copy.film_session_uid == "1.2.3.4.5.6");
+    }
+
+    SECTION("move construction") {
+        print_film_box_data moved = std::move(data);
+        CHECK(moved.image_display_format == "STANDARD\\2,2");
+        CHECK(moved.film_orientation == "LANDSCAPE");
+        CHECK(moved.film_session_uid == "1.2.3.4.5.6");
+    }
+}
+
+TEST_CASE("print_result is copyable and movable", "[services][print][scu]") {
+    print_result result;
+    result.sop_instance_uid = "1.2.3.4.5.6.7.8";
+    result.status = 0x0000;
+    result.elapsed = std::chrono::milliseconds{100};
+
+    SECTION("copy construction") {
+        print_result copy = result;
+        CHECK(copy.sop_instance_uid == "1.2.3.4.5.6.7.8");
+        CHECK(copy.status == 0x0000);
+        CHECK(copy.elapsed.count() == 100);
+        CHECK(copy.is_success());
+    }
+
+    SECTION("move construction") {
+        print_result moved = std::move(result);
+        CHECK(moved.sop_instance_uid == "1.2.3.4.5.6.7.8");
+        CHECK(moved.status == 0x0000);
+        CHECK(moved.elapsed.count() == 100);
+        CHECK(moved.is_success());
+    }
+}
+
+// ============================================================================
+// SOP Class Registry Integration Tests
+// ============================================================================
+
+TEST_CASE("print SOP classes are registered (SCU view)", "[services][print][scu]") {
+    auto& registry = sop_class_registry::instance();
+
+    CHECK(registry.is_supported(basic_film_session_sop_class_uid));
+    CHECK(registry.is_supported(basic_film_box_sop_class_uid));
+    CHECK(registry.is_supported(basic_grayscale_image_box_sop_class_uid));
+    CHECK(registry.is_supported(basic_color_image_box_sop_class_uid));
+    CHECK(registry.is_supported(printer_sop_class_uid));
+    CHECK(registry.is_supported(basic_grayscale_print_meta_sop_class_uid));
+    CHECK(registry.is_supported(basic_color_print_meta_sop_class_uid));
+
+    auto print_classes = registry.get_by_category(sop_class_category::print);
+    CHECK(print_classes.size() == 7);
+}


### PR DESCRIPTION
Closes #738

## Summary
- Implement `print_scu` class for sending DICOM print requests to remote Print SCP systems
- Full DIMSE-N print workflow: N-CREATE (Film Session, Film Box), N-SET (Image Box), N-GET (Printer Status), N-ACTION (Print), N-DELETE (Film Session, Film Box)
- Meta SOP Class fallback for presentation context negotiation
- Well-Known Printer SOP Instance UID (1.2.840.10008.5.1.1.17) support
- Comprehensive unit tests: 18 test cases, 142 assertions

## Files Changed
- `include/pacs/services/print_scu.hpp` - Print SCU header with data structures and class interface
- `src/services/print_scu.cpp` - Full implementation of Print SCU operations
- `tests/services/print_scu_test.cpp` - Unit tests for construction, data structures, statistics, SOP class UIDs, tags, and DIMSE command fields
- `CMakeLists.txt` - Build integration

## Test Plan
- [x] All 18 print_scu test cases pass (142 assertions)
- [x] All 33 combined print tests pass (263 assertions, SCP + SCU)
- [x] Build succeeds with `-Wall -Wextra -Wpedantic -Werror`