### PR TITLE
fix(tests): make integration test temp dirs unique per-process

### DIFF
--- a/tests/integration/config_reload_integration_test.cpp
+++ b/tests/integration/config_reload_integration_test.cpp
@@ -39,7 +39,7 @@
 #include <vector>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #endif
@@ -55,7 +55,7 @@ namespace {
 
 auto current_process_id() -> unsigned long long {
 #if defined(_WIN32)
-    return static_cast<unsigned long long>(::GetCurrentProcessId());
+    return static_cast<unsigned long long>(::_getpid());
 #else
     return static_cast<unsigned long long>(::getpid());
 #endif

--- a/tests/integration/dicom_workflow_integration_test.cpp
+++ b/tests/integration/dicom_workflow_integration_test.cpp
@@ -42,7 +42,7 @@
 #include <vector>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #endif
@@ -58,7 +58,7 @@ namespace {
 
 auto current_process_id() -> unsigned long long {
 #if defined(_WIN32)
-    return static_cast<unsigned long long>(::GetCurrentProcessId());
+    return static_cast<unsigned long long>(::_getpid());
 #else
     return static_cast<unsigned long long>(::getpid());
 #endif

--- a/tests/integration/error_propagation_integration_test.cpp
+++ b/tests/integration/error_propagation_integration_test.cpp
@@ -43,7 +43,7 @@
 #include <vector>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #endif
@@ -59,7 +59,7 @@ namespace {
 
 auto current_process_id() -> unsigned long long {
 #if defined(_WIN32)
-    return static_cast<unsigned long long>(::GetCurrentProcessId());
+    return static_cast<unsigned long long>(::_getpid());
 #else
     return static_cast<unsigned long long>(::getpid());
 #endif

--- a/tests/integration/itk_adapter_test.cpp
+++ b/tests/integration/itk_adapter_test.cpp
@@ -25,7 +25,7 @@
 #include <thread>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #endif
@@ -38,7 +38,7 @@ namespace {
 
 auto current_process_id() -> unsigned long long {
 #if defined(_WIN32)
-    return static_cast<unsigned long long>(::GetCurrentProcessId());
+    return static_cast<unsigned long long>(::_getpid());
 #else
     return static_cast<unsigned long long>(::getpid());
 #endif

--- a/tests/integration/load_integration_test.cpp
+++ b/tests/integration/load_integration_test.cpp
@@ -44,7 +44,7 @@
 #include <vector>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #endif
@@ -60,7 +60,7 @@ namespace {
 
 auto current_process_id() -> unsigned long long {
 #if defined(_WIN32)
-    return static_cast<unsigned long long>(::GetCurrentProcessId());
+    return static_cast<unsigned long long>(::_getpid());
 #else
     return static_cast<unsigned long long>(::getpid());
 #endif

--- a/tests/integration/logger_adapter_test.cpp
+++ b/tests/integration/logger_adapter_test.cpp
@@ -15,7 +15,7 @@
 #include <thread>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #endif
@@ -30,7 +30,7 @@ namespace {
 
 auto current_process_id() -> unsigned long long {
 #if defined(_WIN32)
-    return static_cast<unsigned long long>(::GetCurrentProcessId());
+    return static_cast<unsigned long long>(::_getpid());
 #else
     return static_cast<unsigned long long>(::getpid());
 #endif

--- a/tests/integration/shutdown_integration_test.cpp
+++ b/tests/integration/shutdown_integration_test.cpp
@@ -41,7 +41,7 @@
 #include <vector>
 
 #if defined(_WIN32)
-#include <processthreadsapi.h>
+#include <process.h>
 #else
 #include <unistd.h>
 #endif
@@ -57,7 +57,7 @@ namespace {
 
 auto current_process_id() -> unsigned long long {
 #if defined(_WIN32)
-    return static_cast<unsigned long long>(::GetCurrentProcessId());
+    return static_cast<unsigned long long>(::_getpid());
 #else
     return static_cast<unsigned long long>(::getpid());
 #endif


### PR DESCRIPTION
## Summary
- Replace hard-coded temporary test directories with unique, per-process timestamped paths
- Prevents directory collisions when CTest runs integration tests in parallel
- Uses `std::error_code` overloads for `remove_all` to suppress exceptions during cleanup

## Root Cause
CTest discovers each Catch2 SECTION as a separate test and runs them in parallel. Multiple `pacs_integration_tests` processes simultaneously used the same fixed temporary directories (e.g., `/tmp/pacs_logger_test`), causing:
- `logger_adapter security event logging` - assertion failure (corrupted audit log)
- `System shutdown order` - subprocess abort (directory removed mid-test)
- `Thread pool reconfiguration` - subprocess abort (same race condition)

## Changes
Each integration test now generates unique temp directories using `PID + timestamp + attempt` naming:
```
/tmp/pacs_logger_test_12345_98765432_0/
```

Files modified (7):
- `tests/integration/logger_adapter_test.cpp`
- `tests/integration/shutdown_integration_test.cpp`
- `tests/integration/config_reload_integration_test.cpp`
- `tests/integration/dicom_workflow_integration_test.cpp`
- `tests/integration/error_propagation_integration_test.cpp`
- `tests/integration/load_integration_test.cpp`
- `tests/integration/itk_adapter_test.cpp`

## Test Plan
- [x] All 3 previously failing tests pass
- [x] All 87 integration tests pass (0 failures)
- [x] Tests run successfully in parallel (`ctest -j4`)