### PR TITLE
feat(core): add automatic Private Creator element management

### DIFF
--- a/include/pacs/core/dicom_dataset.hpp
+++ b/include/pacs/core/dicom_dataset.hpp
@@ -259,6 +259,56 @@ public:
                                           uint16_t group) const
         -> std::vector<const dicom_element*>;
 
+    /**
+     * @brief Insert a private data element with automatic creator management
+     *
+     * Automatically ensures the corresponding Private Creator element exists.
+     * If the creator already owns a block in the given group, reuses that block.
+     * Otherwise, allocates the next available slot.
+     *
+     * Per DICOM PS3.5 §7.8.1, Private Creator elements are placed at
+     * (gggg,00xx) and data elements at (gggg,xxyy).
+     *
+     * @param creator_id Private Creator identification (e.g. "SIEMENS CSA HEADER")
+     * @param group Odd group number (e.g. 0x0009)
+     * @param element_offset Offset within the block (0x00-0xFF)
+     * @param vr Value Representation for the data element
+     * @param value The element value
+     * @return The actual tag assigned, or nullopt if allocation failed
+     */
+    auto set_private_element(std::string_view creator_id, uint16_t group,
+                             uint8_t element_offset, encoding::vr_type vr,
+                             std::string_view value) -> std::optional<dicom_tag>;
+
+    /**
+     * @brief Remove all private data elements and their creator for a given creator
+     *
+     * Removes both the Private Creator element and all associated data elements
+     * in the specified group.
+     *
+     * @param creator_id The Private Creator identification string
+     * @param group The private group number (must be odd)
+     * @return Number of elements removed (including the creator)
+     */
+    auto remove_private_block(std::string_view creator_id, uint16_t group)
+        -> size_t;
+
+    /**
+     * @brief Remove orphaned Private Creator elements that have no data elements
+     * @return Number of orphaned creators removed
+     */
+    auto cleanup_orphaned_creators() -> size_t;
+
+    /**
+     * @brief Validate private tag relationships in this dataset
+     *
+     * Checks that every private data element has a corresponding Private Creator
+     * element and returns tags that are missing their creator.
+     *
+     * @return Vector of private data element tags missing their Private Creator
+     */
+    [[nodiscard]] auto validate_private_tags() const -> std::vector<dicom_tag>;
+
     // ========================================================================
     // Modification
     // ========================================================================

--- a/src/core/dicom_dataset.cpp
+++ b/src/core/dicom_dataset.cpp
@@ -167,6 +167,139 @@ auto dicom_dataset::get_private_block(std::string_view creator_id,
     return result;
 }
 
+auto dicom_dataset::set_private_element(std::string_view creator_id,
+                                        uint16_t group,
+                                        uint8_t element_offset,
+                                        encoding::vr_type vr,
+                                        std::string_view value)
+    -> std::optional<dicom_tag> {
+    // Group must be odd and > 0x0008 for private tags
+    if ((group & 1) == 0 || group <= 0x0008) {
+        return std::nullopt;
+    }
+
+    // Find existing block for this creator, or allocate a new slot
+    uint16_t block_number = 0;
+    bool found = false;
+
+    for (uint16_t slot = 0x0010; slot <= 0x00FF; ++slot) {
+        const dicom_tag creator_tag{group, slot};
+        const auto* creator_elem = get(creator_tag);
+        if (creator_elem == nullptr) {
+            // Empty slot — allocate if we haven't found a match yet
+            if (!found) {
+                block_number = slot;
+                found = true;
+            }
+            continue;
+        }
+        auto str_result = creator_elem->as_string();
+        if (str_result.is_ok() && str_result.value() == creator_id) {
+            // Creator already owns this slot
+            block_number = slot;
+            found = true;
+            break;
+        }
+    }
+
+    if (!found) {
+        return std::nullopt;  // No available slots
+    }
+
+    // Ensure the Private Creator element exists
+    const dicom_tag creator_tag{group, block_number};
+    if (get(creator_tag) == nullptr) {
+        set_string(creator_tag, encoding::vr_type::LO, creator_id);
+    }
+
+    // Place the data element at (group, block_number << 8 | element_offset)
+    const auto data_element_num = static_cast<uint16_t>(
+        (block_number << 8) | element_offset);
+    const dicom_tag data_tag{group, data_element_num};
+    set_string(data_tag, vr, value);
+
+    return data_tag;
+}
+
+auto dicom_dataset::remove_private_block(std::string_view creator_id,
+                                          uint16_t group) -> size_t {
+    size_t removed = 0;
+
+    for (uint16_t slot = 0x0010; slot <= 0x00FF; ++slot) {
+        const dicom_tag creator_tag{group, slot};
+        const auto* creator_elem = get(creator_tag);
+        if (creator_elem == nullptr) {
+            continue;
+        }
+        auto str_result = creator_elem->as_string();
+        if (str_result.is_err() || str_result.value() != creator_id) {
+            continue;
+        }
+
+        // Found the creator — remove all data elements in its block
+        const auto range = creator_tag.private_data_range();
+        if (range) {
+            const auto [first, last] = *range;
+            auto it = elements_.lower_bound(first);
+            while (it != elements_.end() && it->first <= last) {
+                it = elements_.erase(it);
+                ++removed;
+            }
+        }
+
+        // Remove the creator element itself
+        elements_.erase(creator_tag);
+        ++removed;
+        break;
+    }
+
+    return removed;
+}
+
+auto dicom_dataset::cleanup_orphaned_creators() -> size_t {
+    size_t removed = 0;
+    std::vector<dicom_tag> orphans;
+
+    for (const auto& [tag, elem] : elements_) {
+        if (!tag.is_private_creator()) {
+            continue;
+        }
+        // Check if any data elements exist in this creator's block
+        const auto range = tag.private_data_range();
+        if (!range) {
+            continue;
+        }
+        const auto [first, last] = *range;
+        auto it = elements_.lower_bound(first);
+        if (it == elements_.end() || it->first > last) {
+            orphans.push_back(tag);
+        }
+    }
+
+    for (const auto& tag : orphans) {
+        elements_.erase(tag);
+        ++removed;
+    }
+
+    return removed;
+}
+
+auto dicom_dataset::validate_private_tags() const -> std::vector<dicom_tag> {
+    std::vector<dicom_tag> missing_creators;
+
+    for (const auto& [tag, elem] : elements_) {
+        if (!tag.is_private_data()) {
+            continue;
+        }
+        const auto creator_tag = tag.private_creator_tag();
+        if (!creator_tag || !contains(*creator_tag)) {
+            missing_creators.push_back(tag);
+        }
+    }
+
+    return missing_creators;
+}
+
 // ============================================================================
 // Modification
 // ============================================================================

--- a/tests/core/dicom_dataset_test.cpp
+++ b/tests/core/dicom_dataset_test.cpp
@@ -864,6 +864,241 @@ TEST_CASE("dicom_dataset get_private_creator", "[core][dicom_dataset][private]")
     }
 }
 
+TEST_CASE("dicom_dataset set_private_element", "[core][dicom_dataset][private]") {
+    SECTION("creates both creator and data element") {
+        dicom_dataset ds;
+        auto tag = ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO,
+                                          "some value");
+
+        REQUIRE(tag.has_value());
+        CHECK(tag->group() == 0x0009);
+        // Creator should be at (0009,0010), data at (0009,1001)
+        CHECK(ds.contains({0x0009, 0x0010}));
+        CHECK(ds.get_string({0x0009, 0x0010}) == "MY_APP");
+        CHECK(ds.get_string(*tag) == "some value");
+    }
+
+    SECTION("reuses same block for same creator") {
+        dicom_dataset ds;
+        auto tag1 = ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO,
+                                           "value1");
+        auto tag2 = ds.set_private_element("MY_APP", 0x0009, 0x02, vr_type::LO,
+                                           "value2");
+
+        REQUIRE(tag1.has_value());
+        REQUIRE(tag2.has_value());
+        // Both should use block 0x10
+        CHECK(*tag1 == dicom_tag{0x0009, 0x1001});
+        CHECK(*tag2 == dicom_tag{0x0009, 0x1002});
+        // Only one creator element
+        CHECK(ds.get_string({0x0009, 0x0010}) == "MY_APP");
+    }
+
+    SECTION("different creators get different blocks") {
+        dicom_dataset ds;
+        auto tag1 = ds.set_private_element("APP_A", 0x0009, 0x01, vr_type::LO,
+                                           "a_value");
+        auto tag2 = ds.set_private_element("APP_B", 0x0009, 0x01, vr_type::LO,
+                                           "b_value");
+
+        REQUIRE(tag1.has_value());
+        REQUIRE(tag2.has_value());
+        // APP_A at block 0x10, APP_B at block 0x11
+        CHECK(*tag1 == dicom_tag{0x0009, 0x1001});
+        CHECK(*tag2 == dicom_tag{0x0009, 0x1101});
+        CHECK(ds.get_string({0x0009, 0x0010}) == "APP_A");
+        CHECK(ds.get_string({0x0009, 0x0011}) == "APP_B");
+    }
+
+    SECTION("rejects even group number") {
+        dicom_dataset ds;
+        auto tag = ds.set_private_element("MY_APP", 0x0010, 0x01, vr_type::LO,
+                                          "value");
+        CHECK_FALSE(tag.has_value());
+    }
+
+    SECTION("rejects group <= 0x0008") {
+        dicom_dataset ds;
+        auto tag = ds.set_private_element("MY_APP", 0x0007, 0x01, vr_type::LO,
+                                          "value");
+        CHECK_FALSE(tag.has_value());
+    }
+
+    SECTION("overwrites existing data element value") {
+        dicom_dataset ds;
+        ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO, "old");
+        auto tag = ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO,
+                                          "new");
+
+        REQUIRE(tag.has_value());
+        CHECK(ds.get_string(*tag) == "new");
+    }
+}
+
+TEST_CASE("dicom_dataset remove_private_block", "[core][dicom_dataset][private]") {
+    SECTION("removes creator and all data elements") {
+        dicom_dataset ds;
+        ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO, "v1");
+        ds.set_private_element("MY_APP", 0x0009, 0x02, vr_type::LO, "v2");
+
+        auto removed = ds.remove_private_block("MY_APP", 0x0009);
+
+        CHECK(removed == 3);  // creator + 2 data elements
+        CHECK_FALSE(ds.contains({0x0009, 0x0010}));
+        CHECK_FALSE(ds.contains({0x0009, 0x1001}));
+        CHECK_FALSE(ds.contains({0x0009, 0x1002}));
+    }
+
+    SECTION("does not affect other creators") {
+        dicom_dataset ds;
+        ds.set_private_element("APP_A", 0x0009, 0x01, vr_type::LO, "a_val");
+        ds.set_private_element("APP_B", 0x0009, 0x01, vr_type::LO, "b_val");
+
+        ds.remove_private_block("APP_A", 0x0009);
+
+        CHECK_FALSE(ds.contains({0x0009, 0x0010}));
+        CHECK(ds.contains({0x0009, 0x0011}));
+        CHECK(ds.get_string({0x0009, 0x1101}) == "b_val");
+    }
+
+    SECTION("returns zero for unknown creator") {
+        dicom_dataset ds;
+        ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO, "val");
+
+        auto removed = ds.remove_private_block("UNKNOWN", 0x0009);
+        CHECK(removed == 0);
+    }
+
+    SECTION("returns zero for wrong group") {
+        dicom_dataset ds;
+        ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO, "val");
+
+        auto removed = ds.remove_private_block("MY_APP", 0x0011);
+        CHECK(removed == 0);
+    }
+}
+
+TEST_CASE("dicom_dataset cleanup_orphaned_creators",
+          "[core][dicom_dataset][private]") {
+    SECTION("removes creators with no data elements") {
+        dicom_dataset ds;
+        // Manually add a creator without any data elements
+        ds.set_string({0x0009, 0x0010}, vr_type::LO, "ORPHAN_CREATOR");
+
+        auto removed = ds.cleanup_orphaned_creators();
+
+        CHECK(removed == 1);
+        CHECK_FALSE(ds.contains({0x0009, 0x0010}));
+    }
+
+    SECTION("preserves creators that have data elements") {
+        dicom_dataset ds;
+        ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO, "value");
+
+        auto removed = ds.cleanup_orphaned_creators();
+
+        CHECK(removed == 0);
+        CHECK(ds.contains({0x0009, 0x0010}));
+    }
+
+    SECTION("handles mixed orphaned and valid creators") {
+        dicom_dataset ds;
+        ds.set_private_element("VALID_APP", 0x0009, 0x01, vr_type::LO, "val");
+        // Add orphan manually
+        ds.set_string({0x0009, 0x0011}, vr_type::LO, "ORPHAN_APP");
+
+        auto removed = ds.cleanup_orphaned_creators();
+
+        CHECK(removed == 1);
+        CHECK(ds.contains({0x0009, 0x0010}));  // VALID_APP stays
+        CHECK_FALSE(ds.contains({0x0009, 0x0011}));  // ORPHAN_APP removed
+    }
+
+    SECTION("returns zero when no orphans exist") {
+        dicom_dataset ds;
+        auto removed = ds.cleanup_orphaned_creators();
+        CHECK(removed == 0);
+    }
+}
+
+TEST_CASE("dicom_dataset validate_private_tags",
+          "[core][dicom_dataset][private]") {
+    SECTION("returns empty for valid dataset") {
+        dicom_dataset ds;
+        ds.set_private_element("MY_APP", 0x0009, 0x01, vr_type::LO, "val");
+
+        auto missing = ds.validate_private_tags();
+        CHECK(missing.empty());
+    }
+
+    SECTION("detects data elements without creator") {
+        dicom_dataset ds;
+        // Manually add data element without creator
+        ds.insert(dicom_element::from_string({0x0009, 0x1001}, vr_type::UN,
+                                             "orphan_data"));
+
+        auto missing = ds.validate_private_tags();
+
+        REQUIRE(missing.size() == 1);
+        CHECK(missing[0] == dicom_tag{0x0009, 0x1001});
+    }
+
+    SECTION("returns empty for dataset with no private elements") {
+        dicom_dataset ds;
+        ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+
+        auto missing = ds.validate_private_tags();
+        CHECK(missing.empty());
+    }
+
+    SECTION("detects multiple missing creators") {
+        dicom_dataset ds;
+        ds.insert(dicom_element::from_string({0x0009, 0x1001}, vr_type::UN,
+                                             "data1"));
+        ds.insert(dicom_element::from_string({0x0009, 0x1100}, vr_type::UN,
+                                             "data2"));
+
+        auto missing = ds.validate_private_tags();
+        CHECK(missing.size() == 2);
+    }
+}
+
+TEST_CASE("dicom_dataset private element round-trip",
+          "[core][dicom_dataset][private]") {
+    SECTION("write private elements and verify creator relationships") {
+        dicom_dataset ds;
+        ds.set_private_element("VENDOR_A", 0x0009, 0x01, vr_type::LO,
+                               "value_a1");
+        ds.set_private_element("VENDOR_A", 0x0009, 0x02, vr_type::LO,
+                               "value_a2");
+        ds.set_private_element("VENDOR_B", 0x0009, 0x01, vr_type::LO,
+                               "value_b1");
+
+        // Verify creator relationships
+        auto creator_a = ds.get_private_creator({0x0009, 0x1001});
+        REQUIRE(creator_a.has_value());
+        CHECK(*creator_a == "VENDOR_A");
+
+        auto creator_a2 = ds.get_private_creator({0x0009, 0x1002});
+        REQUIRE(creator_a2.has_value());
+        CHECK(*creator_a2 == "VENDOR_A");
+
+        auto creator_b = ds.get_private_creator({0x0009, 0x1101});
+        REQUIRE(creator_b.has_value());
+        CHECK(*creator_b == "VENDOR_B");
+
+        // get_private_block returns correct elements
+        auto block_a = ds.get_private_block("VENDOR_A", 0x0009);
+        CHECK(block_a.size() == 2);
+
+        auto block_b = ds.get_private_block("VENDOR_B", 0x0009);
+        CHECK(block_b.size() == 1);
+
+        // Validation passes
+        CHECK(ds.validate_private_tags().empty());
+    }
+}
+
 TEST_CASE("dicom_dataset get_private_block", "[core][dicom_dataset][private]") {
     dicom_dataset ds;
     // Two creators in group 0x0009


### PR DESCRIPTION
Closes #773

## Summary
- Add `set_private_element()` for inserting private data elements with automatic Private Creator management and block allocation per DICOM PS3.5 §7.8.1
- Add `remove_private_block()` to remove a creator and all its associated data elements
- Add `cleanup_orphaned_creators()` to remove Private Creator elements that have no data elements
- Add `validate_private_tags()` to detect private data elements missing their Private Creator

## Test Plan
- [x] `set_private_element` creates both creator and data element
- [x] Same creator reuses the same block number
- [x] Different creators get different block numbers
- [x] Invalid group numbers (even, <= 0x0008) are rejected
- [x] `remove_private_block` removes creator + all data elements
- [x] `remove_private_block` does not affect other creators
- [x] `cleanup_orphaned_creators` removes creators without data elements
- [x] `cleanup_orphaned_creators` preserves valid creators
- [x] `validate_private_tags` detects missing creators
- [x] Round-trip test verifying creator relationships via `get_private_creator` and `get_private_block`
- [x] All 400 assertions pass across 20 dicom_dataset test cases
- [x] Build passes with no warnings