### PR TITLE
feat(security): add private tag bulk removal option to anonymizer

### DIFF
--- a/include/pacs/security/anonymizer.hpp
+++ b/include/pacs/security/anonymizer.hpp
@@ -63,6 +63,21 @@
 namespace pacs::security {
 
 /**
+ * @brief Action to take on private tags during anonymization
+ *
+ * DICOM PS3.15 Annex E recommends removing private data elements
+ * during de-identification, as they may contain Protected Health
+ * Information (PHI) in vendor-specific formats.
+ *
+ * @see DICOM PS3.15 Annex E - Basic Profile
+ */
+enum class private_tag_action : std::uint8_t {
+    keep,        ///< Preserve all private tags (default for backward compatibility)
+    remove_all,  ///< Remove all private data elements and their creators
+    remove_data  ///< Remove private data elements but keep creators (for auditing)
+};
+
+/**
  * @brief DICOM de-identification/anonymization engine
  *
  * This class provides comprehensive DICOM de-identification capabilities
@@ -186,6 +201,28 @@ public:
      * @param profile The new profile to use
      */
     void set_profile(anonymization_profile profile);
+
+    // ========================================================================
+    // Private Tag Handling
+    // ========================================================================
+
+    /**
+     * @brief Set the action to take on private tags during anonymization
+     *
+     * DICOM PS3.15 Annex E recommends removing private data elements
+     * during de-identification, as they may contain PHI in vendor-specific
+     * formats that cannot be reliably inspected.
+     *
+     * @param action The private tag action
+     */
+    void set_private_tag_action(private_tag_action action);
+
+    /**
+     * @brief Get the current private tag action
+     * @return The configured private tag action
+     */
+    [[nodiscard]] auto get_private_tag_action() const noexcept
+        -> private_tag_action;
 
     // ========================================================================
     // Custom Tag Actions
@@ -372,6 +409,9 @@ private:
 
     /// Hash salt
     std::optional<std::string> hash_salt_;
+
+    /// Action for private tags
+    private_tag_action private_tag_action_{private_tag_action::keep};
 
     /// Whether to include detailed action records in report
     bool detailed_reporting_{false};

--- a/include/pacs/security/tag_action.hpp
+++ b/include/pacs/security/tag_action.hpp
@@ -280,6 +280,9 @@ struct anonymization_report {
     /// Number of values hashed
     std::size_t values_hashed{0};
 
+    /// Number of private tags removed
+    std::size_t private_tags_removed{0};
+
     /// Detailed action records (optional, for audit)
     std::vector<tag_action_record> action_records;
 
@@ -310,7 +313,8 @@ struct anonymization_report {
      */
     [[nodiscard]] auto total_modifications() const noexcept -> std::size_t {
         return tags_removed + tags_emptied + tags_replaced +
-               uids_replaced + dates_shifted + values_hashed;
+               uids_replaced + dates_shifted + values_hashed +
+               private_tags_removed;
     }
 };
 

--- a/src/security/anonymizer.cpp
+++ b/src/security/anonymizer.cpp
@@ -59,6 +59,7 @@ anonymizer::anonymizer(const anonymizer& other)
     , date_offset_{other.date_offset_}
     , encryption_key_{other.encryption_key_}
     , hash_salt_{other.hash_salt_}
+    , private_tag_action_{other.private_tag_action_}
     , detailed_reporting_{other.detailed_reporting_} {}
 
 anonymizer::anonymizer(anonymizer&& other) noexcept
@@ -67,6 +68,7 @@ anonymizer::anonymizer(anonymizer&& other) noexcept
     , date_offset_{other.date_offset_}
     , encryption_key_{std::move(other.encryption_key_)}
     , hash_salt_{std::move(other.hash_salt_)}
+    , private_tag_action_{other.private_tag_action_}
     , detailed_reporting_{other.detailed_reporting_} {}
 
 auto anonymizer::operator=(const anonymizer& other) -> anonymizer& {
@@ -76,6 +78,7 @@ auto anonymizer::operator=(const anonymizer& other) -> anonymizer& {
         date_offset_ = other.date_offset_;
         encryption_key_ = other.encryption_key_;
         hash_salt_ = other.hash_salt_;
+        private_tag_action_ = other.private_tag_action_;
         detailed_reporting_ = other.detailed_reporting_;
     }
     return *this;
@@ -88,6 +91,7 @@ auto anonymizer::operator=(anonymizer&& other) noexcept -> anonymizer& {
         date_offset_ = other.date_offset_;
         encryption_key_ = std::move(other.encryption_key_);
         hash_salt_ = std::move(other.hash_salt_);
+        private_tag_action_ = other.private_tag_action_;
         detailed_reporting_ = other.detailed_reporting_;
     }
     return *this;
@@ -176,6 +180,30 @@ auto anonymizer::anonymize_with_mapping(
         }
     }
 
+    // Remove private tags if configured
+    if (private_tag_action_ != private_tag_action::keep) {
+        std::vector<dicom_tag> tags_to_remove;
+
+        for (auto it = dataset.begin(); it != dataset.end(); ++it) {
+            auto tag = it->first;
+            if (private_tag_action_ == private_tag_action::remove_all) {
+                if (tag.is_private()) {
+                    tags_to_remove.push_back(tag);
+                }
+            } else if (private_tag_action_ == private_tag_action::remove_data) {
+                if (tag.is_private_data()) {
+                    tags_to_remove.push_back(tag);
+                }
+            }
+        }
+
+        for (const auto& tag : tags_to_remove) {
+            if (dataset.remove(tag)) {
+                report.private_tags_removed++;
+            }
+        }
+    }
+
     return report;
 }
 
@@ -186,6 +214,15 @@ auto anonymizer::get_profile() const noexcept -> anonymization_profile {
 void anonymizer::set_profile(anonymization_profile profile) {
     profile_ = profile;
     initialize_profile_actions();
+}
+
+void anonymizer::set_private_tag_action(private_tag_action action) {
+    private_tag_action_ = action;
+}
+
+auto anonymizer::get_private_tag_action() const noexcept
+    -> private_tag_action {
+    return private_tag_action_;
 }
 
 void anonymizer::add_tag_action(dicom_tag tag, tag_action_config config) {

--- a/tests/security/anonymizer_test.cpp
+++ b/tests/security/anonymizer_test.cpp
@@ -518,7 +518,169 @@ TEST_CASE("Anonymization Report", "[security][anonymization]") {
         report.uids_replaced = 4;
         report.dates_shifted = 1;
         report.values_hashed = 2;
+        report.private_tags_removed = 3;
 
-        REQUIRE(report.total_modifications() == 17);
+        REQUIRE(report.total_modifications() == 20);
     }
+}
+
+// ============================================================================
+// Private Tag Removal Tests
+// ============================================================================
+
+namespace {
+
+dicom_dataset create_dataset_with_private_tags() {
+    dicom_dataset ds;
+
+    // Standard tags
+    ds.set_string(tags::patient_name, vr_type::PN, "DOE^JOHN");
+    ds.set_string(tags::patient_id, vr_type::LO, "12345");
+    ds.set_string(tags::study_instance_uid, vr_type::UI, "1.2.3.4.5");
+    ds.set_string(tags::series_instance_uid, vr_type::UI, "1.2.3.4.6");
+    ds.set_string(tags::sop_instance_uid, vr_type::UI, "1.2.3.4.7");
+
+    // Private Creator 1 (group 0x0009, block 0x10)
+    ds.set_string({0x0009, 0x0010}, vr_type::LO, "SIEMENS CSA HEADER");
+    // Private data elements for block 0x10
+    ds.set_string({0x0009, 0x1001}, vr_type::OB, "csa_data_1");
+    ds.set_string({0x0009, 0x1002}, vr_type::OB, "csa_data_2");
+
+    // Private Creator 2 (group 0x0009, block 0x11)
+    ds.set_string({0x0009, 0x0011}, vr_type::LO, "GE PRIVATE DATA");
+    // Private data elements for block 0x11
+    ds.set_string({0x0009, 0x1101}, vr_type::LO, "ge_data_1");
+    ds.set_string({0x0009, 0x1102}, vr_type::LO, "ge_data_2");
+    ds.set_string({0x0009, 0x1103}, vr_type::LO, "ge_data_3");
+
+    return ds;
+}
+
+} // namespace
+
+TEST_CASE("Anonymizer: Private Tag Action - keep", "[security][anonymization][private]") {
+    anonymizer anon(anonymization_profile::basic);
+    anon.set_private_tag_action(private_tag_action::keep);
+
+    auto dataset = create_dataset_with_private_tags();
+
+    auto result = anon.anonymize(dataset);
+    REQUIRE(result.is_ok());
+
+    auto report = result.value();
+    CHECK(report.private_tags_removed == 0);
+
+    // All private tags should still exist
+    CHECK(dataset.contains({0x0009, 0x0010}));
+    CHECK(dataset.contains({0x0009, 0x0011}));
+    CHECK(dataset.contains({0x0009, 0x1001}));
+    CHECK(dataset.contains({0x0009, 0x1102}));
+}
+
+TEST_CASE("Anonymizer: Private Tag Action - remove_all", "[security][anonymization][private]") {
+    anonymizer anon(anonymization_profile::basic);
+    anon.set_private_tag_action(private_tag_action::remove_all);
+
+    auto dataset = create_dataset_with_private_tags();
+
+    auto result = anon.anonymize(dataset);
+    REQUIRE(result.is_ok());
+
+    auto report = result.value();
+
+    SECTION("All private elements are removed") {
+        // 2 creators + 5 data elements = 7 total
+        CHECK(report.private_tags_removed == 7);
+    }
+
+    SECTION("No private tags remain") {
+        CHECK_FALSE(dataset.contains({0x0009, 0x0010}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x0011}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1001}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1002}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1101}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1102}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1103}));
+    }
+
+    SECTION("Standard tags are unaffected") {
+        CHECK(dataset.contains(tags::patient_name));
+        CHECK(dataset.contains(tags::study_instance_uid));
+    }
+}
+
+TEST_CASE("Anonymizer: Private Tag Action - remove_data", "[security][anonymization][private]") {
+    anonymizer anon(anonymization_profile::basic);
+    anon.set_private_tag_action(private_tag_action::remove_data);
+
+    auto dataset = create_dataset_with_private_tags();
+
+    auto result = anon.anonymize(dataset);
+    REQUIRE(result.is_ok());
+
+    auto report = result.value();
+
+    SECTION("Only data elements are removed, creators preserved") {
+        // 5 data elements removed
+        CHECK(report.private_tags_removed == 5);
+    }
+
+    SECTION("Creators still exist") {
+        CHECK(dataset.contains({0x0009, 0x0010}));
+        CHECK(dataset.contains({0x0009, 0x0011}));
+        CHECK(dataset.get_string({0x0009, 0x0010}) == "SIEMENS CSA HEADER");
+        CHECK(dataset.get_string({0x0009, 0x0011}) == "GE PRIVATE DATA");
+    }
+
+    SECTION("Data elements are removed") {
+        CHECK_FALSE(dataset.contains({0x0009, 0x1001}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1002}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1101}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1102}));
+        CHECK_FALSE(dataset.contains({0x0009, 0x1103}));
+    }
+}
+
+TEST_CASE("Anonymizer: Private tag action getter/setter", "[security][anonymization][private]") {
+    anonymizer anon(anonymization_profile::basic);
+
+    SECTION("Default is keep") {
+        CHECK(anon.get_private_tag_action() == private_tag_action::keep);
+    }
+
+    SECTION("Can set to remove_all") {
+        anon.set_private_tag_action(private_tag_action::remove_all);
+        CHECK(anon.get_private_tag_action() == private_tag_action::remove_all);
+    }
+
+    SECTION("Can set to remove_data") {
+        anon.set_private_tag_action(private_tag_action::remove_data);
+        CHECK(anon.get_private_tag_action() == private_tag_action::remove_data);
+    }
+}
+
+TEST_CASE("Anonymizer: Private tag removal with no private tags", "[security][anonymization][private]") {
+    anonymizer anon(anonymization_profile::basic);
+    anon.set_private_tag_action(private_tag_action::remove_all);
+
+    auto dataset = create_test_dataset();  // No private tags
+
+    auto result = anon.anonymize(dataset);
+    REQUIRE(result.is_ok());
+
+    CHECK(result.value().private_tags_removed == 0);
+}
+
+TEST_CASE("Anonymizer: Private tag removal report in total_modifications", "[security][anonymization][private]") {
+    anonymizer anon(anonymization_profile::basic);
+    anon.set_private_tag_action(private_tag_action::remove_all);
+
+    auto dataset = create_dataset_with_private_tags();
+
+    auto result = anon.anonymize(dataset);
+    REQUIRE(result.is_ok());
+
+    auto report = result.value();
+    CHECK(report.private_tags_removed > 0);
+    CHECK(report.total_modifications() >= report.private_tags_removed);
 }


### PR DESCRIPTION
Closes #775

## Summary
- Add `private_tag_action` enum with three modes: `keep`, `remove_all`, `remove_data`
- Add `set_private_tag_action()` / `get_private_tag_action()` API to `anonymizer`
- Implement private tag removal in `anonymize_with_mapping()` pipeline
- Add `private_tags_removed` counter to `anonymization_report`
- Add 6 test cases covering all modes and edge cases

## Details

Per DICOM PS3.15 Annex E, private data elements should be removed during
de-identification as they may contain PHI in vendor-specific formats that
cannot be reliably inspected.

### `private_tag_action` Modes

| Mode | Behavior |
|------|----------|
| `keep` | Preserve all private tags (backward compatible default) |
| `remove_all` | Remove all private elements including Private Creators |
| `remove_data` | Remove data elements but keep Private Creators for auditing |

### Usage

```cpp
anonymizer anon(anonymization_profile::basic);
anon.set_private_tag_action(private_tag_action::remove_all);
auto result = anon.anonymize(dataset);
// result.value().private_tags_removed == 7 (2 creators + 5 data)
```

## Test Plan
- `remove_all` removes all 7 private elements (2 creators + 5 data)
- `remove_data` removes 5 data elements, preserves 2 creators
- `keep` leaves all private tags intact
- Getter/setter API works correctly
- No private tags in dataset produces 0 removals
- `private_tags_removed` included in `total_modifications()`