### PR TITLE
feat(encoding): add HTJ2K Transfer Syntax registration and codec infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -743,6 +743,7 @@ add_library(pacs_encoding
     src/encoding/dataset_charset.cpp
     src/encoding/compression/jpeg_baseline_codec.cpp
     src/encoding/compression/jpeg_lossless_codec.cpp
+    src/encoding/compression/htj2k_codec.cpp
     src/encoding/compression/jpeg2000_codec.cpp
     src/encoding/compression/jpeg_ls_codec.cpp
     src/encoding/compression/rle_codec.cpp
@@ -1697,6 +1698,7 @@ if(PACS_BUILD_TESTS)
         tests/encoding/explicit_vr_big_endian_codec_test.cpp
         tests/encoding/compression/jpeg_baseline_codec_test.cpp
         tests/encoding/compression/jpeg_lossless_codec_test.cpp
+        tests/encoding/compression/htj2k_codec_test.cpp
         tests/encoding/compression/jpeg2000_codec_test.cpp
         tests/encoding/compression/jpeg_ls_codec_test.cpp
         tests/encoding/compression/rle_codec_test.cpp

--- a/include/pacs/encoding/compression/htj2k_codec.hpp
+++ b/include/pacs/encoding/compression/htj2k_codec.hpp
@@ -1,0 +1,201 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file htj2k_codec.hpp
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_ENCODING_COMPRESSION_HTJ2K_CODEC_HPP
+#define PACS_ENCODING_COMPRESSION_HTJ2K_CODEC_HPP
+
+#include "pacs/encoding/compression/compression_codec.hpp"
+
+namespace pacs::encoding::compression {
+
+/**
+ * @brief High-Throughput JPEG 2000 (HTJ2K) codec implementation.
+ *
+ * Implements DICOM Transfer Syntaxes defined in Supplement 235:
+ * - 1.2.840.10008.1.2.4.201 (HTJ2K Lossless Only)
+ * - 1.2.840.10008.1.2.4.202 (HTJ2K with RPCL Options - Lossless Only)
+ * - 1.2.840.10008.1.2.4.203 (HTJ2K - Lossy)
+ *
+ * HTJ2K provides 10-50x faster decoding than legacy JPEG 2000 while
+ * maintaining comparable compression ratios. Uses the Part 15 (HTJ2K)
+ * block coder which enables highly parallelizable decoding.
+ *
+ * Supported Features:
+ * - 8-bit, 12-bit, 16-bit grayscale images
+ * - 8-bit color images (RGB, YCbCr)
+ * - Lossless mode (reversible 5/3 wavelet transform with HT block coder)
+ * - Lossy mode (irreversible 9/7 wavelet transform with HT block coder)
+ * - RPCL progression order for streaming/progressive decoding
+ *
+ * Thread Safety:
+ * - This class is NOT thread-safe
+ * - Create separate instances per thread for concurrent operations
+ *
+ * @note Actual encode/decode operations require OpenJPH library integration
+ *       (see issue #785). Without OpenJPH, encode/decode return an error.
+ *
+ * @see DICOM Supplement 235 - HTJ2K Transfer Syntaxes
+ * @see ISO/IEC 15444-15 (JPEG 2000 Part 15 - High-Throughput block coder)
+ */
+class htj2k_codec final : public compression_codec {
+public:
+    /// DICOM Transfer Syntax UID for HTJ2K Lossless Only
+    static constexpr std::string_view kTransferSyntaxUIDLossless =
+        "1.2.840.10008.1.2.4.201";
+
+    /// DICOM Transfer Syntax UID for HTJ2K with RPCL Options (Lossless Only)
+    static constexpr std::string_view kTransferSyntaxUIDRPCL =
+        "1.2.840.10008.1.2.4.202";
+
+    /// DICOM Transfer Syntax UID for HTJ2K (Lossy)
+    static constexpr std::string_view kTransferSyntaxUIDLossy =
+        "1.2.840.10008.1.2.4.203";
+
+    /// Default compression ratio for lossy mode (20:1)
+    static constexpr float kDefaultCompressionRatio = 20.0f;
+
+    /// Default number of resolution levels
+    static constexpr int kDefaultResolutionLevels = 6;
+
+    /**
+     * @brief Constructs an HTJ2K codec instance.
+     *
+     * @param lossless If true, use lossless mode (Transfer Syntax .201 or .202).
+     *                 If false, use lossy mode (Transfer Syntax .203).
+     * @param use_rpcl If true, use RPCL progression order (Transfer Syntax .202).
+     *                 Only meaningful in lossless mode. Enables progressive
+     *                 resolution decoding for streaming use cases.
+     * @param compression_ratio Target compression ratio for lossy mode (ignored in lossless).
+     *                          Higher values = smaller files but lower quality.
+     * @param resolution_levels Number of DWT resolution levels (1-32, default: 6).
+     */
+    explicit htj2k_codec(bool lossless = true,
+                          bool use_rpcl = false,
+                          float compression_ratio = kDefaultCompressionRatio,
+                          int resolution_levels = kDefaultResolutionLevels);
+
+    ~htj2k_codec() override;
+
+    // Non-copyable but movable
+    htj2k_codec(const htj2k_codec&) = delete;
+    htj2k_codec& operator=(const htj2k_codec&) = delete;
+    htj2k_codec(htj2k_codec&&) noexcept;
+    htj2k_codec& operator=(htj2k_codec&&) noexcept;
+
+    /// @name Codec Information
+    /// @{
+
+    [[nodiscard]] std::string_view transfer_syntax_uid() const noexcept override;
+    [[nodiscard]] std::string_view name() const noexcept override;
+    [[nodiscard]] bool is_lossy() const noexcept override;
+    [[nodiscard]] bool can_encode(const image_params& params) const noexcept override;
+    [[nodiscard]] bool can_decode(const image_params& params) const noexcept override;
+
+    /// @}
+
+    /// @name Configuration
+    /// @{
+
+    /**
+     * @brief Checks if this codec is configured for lossless mode.
+     * @return true if lossless, false if lossy
+     */
+    [[nodiscard]] bool is_lossless_mode() const noexcept;
+
+    /**
+     * @brief Checks if RPCL progression order is enabled.
+     * @return true if RPCL mode is active
+     */
+    [[nodiscard]] bool is_rpcl_mode() const noexcept;
+
+    /**
+     * @brief Gets the current compression ratio setting.
+     * @return Compression ratio (only meaningful for lossy mode)
+     */
+    [[nodiscard]] float compression_ratio() const noexcept;
+
+    /**
+     * @brief Gets the number of DWT resolution levels.
+     * @return Resolution levels (1-32)
+     */
+    [[nodiscard]] int resolution_levels() const noexcept;
+
+    /// @}
+
+    /// @name Compression Operations
+    /// @{
+
+    /**
+     * @brief Compresses pixel data to HTJ2K format.
+     *
+     * @param pixel_data Uncompressed pixel data (8/12/16-bit, grayscale or color)
+     * @param params Image parameters
+     * @param options Compression options
+     * @return Compressed HTJ2K codestream or error
+     *
+     * @note Currently returns an error indicating OpenJPH is not integrated.
+     *       Full implementation will be added in issue #785.
+     */
+    [[nodiscard]] codec_result encode(
+        std::span<const uint8_t> pixel_data,
+        const image_params& params,
+        const compression_options& options = {}) const override;
+
+    /**
+     * @brief Decompresses HTJ2K data.
+     *
+     * @param compressed_data HTJ2K compressed data
+     * @param params Image parameters (width/height for validation)
+     * @return Decompressed pixel data or error
+     *
+     * @note Currently returns an error indicating OpenJPH is not integrated.
+     *       Full implementation will be added in issue #785.
+     */
+    [[nodiscard]] codec_result decode(
+        std::span<const uint8_t> compressed_data,
+        const image_params& params) const override;
+
+    /// @}
+
+private:
+    bool lossless_;
+    bool use_rpcl_;
+    float compression_ratio_;
+    int resolution_levels_;
+};
+
+}  // namespace pacs::encoding::compression
+
+#endif  // PACS_ENCODING_COMPRESSION_HTJ2K_CODEC_HPP

--- a/include/pacs/encoding/transfer_syntax.hpp
+++ b/include/pacs/encoding/transfer_syntax.hpp
@@ -158,6 +158,15 @@ public:
     /// RLE Lossless (1.2.840.10008.1.2.5)
     static const transfer_syntax rle_lossless;
 
+    /// HTJ2K Lossless Only (1.2.840.10008.1.2.4.201)
+    static const transfer_syntax htj2k_lossless;
+
+    /// HTJ2K RPCL (1.2.840.10008.1.2.4.202) - Lossless or Lossy
+    static const transfer_syntax htj2k_rpcl;
+
+    /// HTJ2K (1.2.840.10008.1.2.4.203) - Lossy
+    static const transfer_syntax htj2k_lossy;
+
     /// @}
 
     /// @name Comparison Operators

--- a/src/encoding/compression/codec_factory.cpp
+++ b/src/encoding/compression/codec_factory.cpp
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "pacs/encoding/compression/codec_factory.hpp"
+#include "pacs/encoding/compression/htj2k_codec.hpp"
 #include "pacs/encoding/compression/jpeg_baseline_codec.hpp"
 #include "pacs/encoding/compression/jpeg_lossless_codec.hpp"
 #include "pacs/encoding/compression/jpeg2000_codec.hpp"
@@ -46,7 +47,7 @@ namespace {
  * As more codecs are implemented (RLE, etc.),
  * they should be added to this list.
  */
-static constexpr std::array<std::string_view, 7> kSupportedTransferSyntaxes = {{
+static constexpr std::array<std::string_view, 10> kSupportedTransferSyntaxes = {{
     rle_codec::kTransferSyntaxUID,                   // 1.2.840.10008.1.2.5
     jpeg_baseline_codec::kTransferSyntaxUID,         // 1.2.840.10008.1.2.4.50
     jpeg_lossless_codec::kTransferSyntaxUID,         // 1.2.840.10008.1.2.4.70
@@ -54,6 +55,9 @@ static constexpr std::array<std::string_view, 7> kSupportedTransferSyntaxes = {{
     jpeg_ls_codec::kTransferSyntaxUIDNearLossless,   // 1.2.840.10008.1.2.4.81
     jpeg2000_codec::kTransferSyntaxUIDLossless,      // 1.2.840.10008.1.2.4.90
     jpeg2000_codec::kTransferSyntaxUIDLossy,         // 1.2.840.10008.1.2.4.91
+    htj2k_codec::kTransferSyntaxUIDLossless,         // 1.2.840.10008.1.2.4.201
+    htj2k_codec::kTransferSyntaxUIDRPCL,             // 1.2.840.10008.1.2.4.202
+    htj2k_codec::kTransferSyntaxUIDLossy,            // 1.2.840.10008.1.2.4.203
 }};
 
 }  // namespace
@@ -94,6 +98,21 @@ std::unique_ptr<compression_codec> codec_factory::create(
     // JPEG 2000 (1.2.840.10008.1.2.4.91) - can be lossy or lossless
     if (transfer_syntax_uid == jpeg2000_codec::kTransferSyntaxUIDLossy) {
         return std::make_unique<jpeg2000_codec>(false);  // lossless = false (default lossy)
+    }
+
+    // HTJ2K Lossless Only (1.2.840.10008.1.2.4.201)
+    if (transfer_syntax_uid == htj2k_codec::kTransferSyntaxUIDLossless) {
+        return std::make_unique<htj2k_codec>(true, false);
+    }
+
+    // HTJ2K with RPCL Options (1.2.840.10008.1.2.4.202)
+    if (transfer_syntax_uid == htj2k_codec::kTransferSyntaxUIDRPCL) {
+        return std::make_unique<htj2k_codec>(true, true);
+    }
+
+    // HTJ2K (1.2.840.10008.1.2.4.203) - lossy
+    if (transfer_syntax_uid == htj2k_codec::kTransferSyntaxUIDLossy) {
+        return std::make_unique<htj2k_codec>(false);
     }
 
     return nullptr;

--- a/src/encoding/compression/htj2k_codec.cpp
+++ b/src/encoding/compression/htj2k_codec.cpp
@@ -1,0 +1,119 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pacs/encoding/compression/htj2k_codec.hpp"
+
+namespace pacs::encoding::compression {
+
+htj2k_codec::htj2k_codec(bool lossless,
+                           bool use_rpcl,
+                           float compression_ratio,
+                           int resolution_levels)
+    : lossless_(lossless),
+      use_rpcl_(use_rpcl),
+      compression_ratio_(compression_ratio),
+      resolution_levels_(resolution_levels) {}
+
+htj2k_codec::~htj2k_codec() = default;
+
+htj2k_codec::htj2k_codec(htj2k_codec&&) noexcept = default;
+htj2k_codec& htj2k_codec::operator=(htj2k_codec&&) noexcept = default;
+
+std::string_view htj2k_codec::transfer_syntax_uid() const noexcept {
+    if (lossless_) {
+        return use_rpcl_ ? kTransferSyntaxUIDRPCL : kTransferSyntaxUIDLossless;
+    }
+    return kTransferSyntaxUIDLossy;
+}
+
+std::string_view htj2k_codec::name() const noexcept {
+    if (lossless_) {
+        return use_rpcl_ ? "HTJ2K with RPCL (Lossless)" : "HTJ2K (Lossless)";
+    }
+    return "HTJ2K (Lossy)";
+}
+
+bool htj2k_codec::is_lossy() const noexcept {
+    return !lossless_;
+}
+
+bool htj2k_codec::can_encode(const image_params& params) const noexcept {
+    if (params.width == 0 || params.height == 0) {
+        return false;
+    }
+
+    if (params.samples_per_pixel != 1 && params.samples_per_pixel != 3) {
+        return false;
+    }
+
+    if (params.bits_stored < 1 || params.bits_stored > 16) {
+        return false;
+    }
+
+    return true;
+}
+
+bool htj2k_codec::can_decode(const image_params& params) const noexcept {
+    return can_encode(params);
+}
+
+bool htj2k_codec::is_lossless_mode() const noexcept {
+    return lossless_;
+}
+
+bool htj2k_codec::is_rpcl_mode() const noexcept {
+    return use_rpcl_;
+}
+
+float htj2k_codec::compression_ratio() const noexcept {
+    return compression_ratio_;
+}
+
+int htj2k_codec::resolution_levels() const noexcept {
+    return resolution_levels_;
+}
+
+codec_result htj2k_codec::encode(
+    [[maybe_unused]] std::span<const uint8_t> pixel_data,
+    [[maybe_unused]] const image_params& params,
+    [[maybe_unused]] const compression_options& options) const {
+    return pacs::pacs_error<compression_result>(
+        pacs::error_codes::compression_error,
+        "HTJ2K encode not yet implemented: OpenJPH library integration required (see #785)");
+}
+
+codec_result htj2k_codec::decode(
+    [[maybe_unused]] std::span<const uint8_t> compressed_data,
+    [[maybe_unused]] const image_params& params) const {
+    return pacs::pacs_error<compression_result>(
+        pacs::error_codes::decompression_error,
+        "HTJ2K decode not yet implemented: OpenJPH library integration required (see #785)");
+}
+
+}  // namespace pacs::encoding::compression

--- a/src/encoding/transfer_syntax.cpp
+++ b/src/encoding/transfer_syntax.cpp
@@ -57,7 +57,7 @@ struct ts_entry {
  * This table contains the standard Transfer Syntaxes defined in DICOM PS3.5.
  * Compression support will be added in later phases.
  */
-static constexpr std::array<ts_entry, 9> TS_REGISTRY = {{
+static constexpr std::array<ts_entry, 12> TS_REGISTRY = {{
     // Uncompressed Transfer Syntaxes (supported in Phase 1)
     {"1.2.840.10008.1.2",
      "Implicit VR Little Endian",
@@ -116,6 +116,25 @@ static constexpr std::array<ts_entry, 9> TS_REGISTRY = {{
      byte_order::little_endian,
      vr_encoding::explicit_vr,
      true, false, true},
+
+    // High-Throughput JPEG 2000 Transfer Syntaxes (DICOM Supplement 235)
+    {"1.2.840.10008.1.2.4.201",
+     "High-Throughput JPEG 2000 Image Compression (Lossless Only)",
+     byte_order::little_endian,
+     vr_encoding::explicit_vr,
+     true, false, false},
+
+    {"1.2.840.10008.1.2.4.202",
+     "High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)",
+     byte_order::little_endian,
+     vr_encoding::explicit_vr,
+     true, false, false},
+
+    {"1.2.840.10008.1.2.4.203",
+     "High-Throughput JPEG 2000 Image Compression",
+     byte_order::little_endian,
+     vr_encoding::explicit_vr,
+     true, false, false},
 }};
 
 /**
@@ -196,6 +215,27 @@ const transfer_syntax transfer_syntax::rle_lossless{
     byte_order::little_endian,
     vr_encoding::explicit_vr,
     true, false, true};
+
+const transfer_syntax transfer_syntax::htj2k_lossless{
+    "1.2.840.10008.1.2.4.201",
+    "High-Throughput JPEG 2000 Image Compression (Lossless Only)",
+    byte_order::little_endian,
+    vr_encoding::explicit_vr,
+    true, false, false};
+
+const transfer_syntax transfer_syntax::htj2k_rpcl{
+    "1.2.840.10008.1.2.4.202",
+    "High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)",
+    byte_order::little_endian,
+    vr_encoding::explicit_vr,
+    true, false, false};
+
+const transfer_syntax transfer_syntax::htj2k_lossy{
+    "1.2.840.10008.1.2.4.203",
+    "High-Throughput JPEG 2000 Image Compression",
+    byte_order::little_endian,
+    vr_encoding::explicit_vr,
+    true, false, false};
 
 // Public constructor - looks up UID in registry
 transfer_syntax::transfer_syntax(std::string_view uid)

--- a/tests/encoding/compression/htj2k_codec_test.cpp
+++ b/tests/encoding/compression/htj2k_codec_test.cpp
@@ -1,0 +1,244 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "pacs/encoding/compression/htj2k_codec.hpp"
+#include "pacs/encoding/compression/codec_factory.hpp"
+#include "pacs/encoding/compression/image_params.hpp"
+
+using namespace pacs::encoding::compression;
+
+TEST_CASE("htj2k_codec construction", "[encoding][compression][htj2k]") {
+    SECTION("Default construction creates lossless codec") {
+        htj2k_codec codec;
+
+        CHECK(codec.transfer_syntax_uid() == htj2k_codec::kTransferSyntaxUIDLossless);
+        CHECK(codec.name() == "HTJ2K (Lossless)");
+        CHECK_FALSE(codec.is_lossy());
+        CHECK(codec.is_lossless_mode());
+        CHECK_FALSE(codec.is_rpcl_mode());
+    }
+
+    SECTION("Lossless with RPCL creates RPCL codec") {
+        htj2k_codec codec(true, true);
+
+        CHECK(codec.transfer_syntax_uid() == htj2k_codec::kTransferSyntaxUIDRPCL);
+        CHECK(codec.name() == "HTJ2K with RPCL (Lossless)");
+        CHECK_FALSE(codec.is_lossy());
+        CHECK(codec.is_lossless_mode());
+        CHECK(codec.is_rpcl_mode());
+    }
+
+    SECTION("Lossy construction creates lossy codec") {
+        htj2k_codec codec(false);
+
+        CHECK(codec.transfer_syntax_uid() == htj2k_codec::kTransferSyntaxUIDLossy);
+        CHECK(codec.name() == "HTJ2K (Lossy)");
+        CHECK(codec.is_lossy());
+        CHECK_FALSE(codec.is_lossless_mode());
+    }
+
+    SECTION("Custom compression ratio and resolution levels") {
+        htj2k_codec codec(false, false, 30.0f, 8);
+
+        CHECK(codec.compression_ratio() == 30.0f);
+        CHECK(codec.resolution_levels() == 8);
+    }
+
+    SECTION("Default compression ratio and resolution levels") {
+        htj2k_codec codec;
+
+        CHECK(codec.compression_ratio() == htj2k_codec::kDefaultCompressionRatio);
+        CHECK(codec.resolution_levels() == htj2k_codec::kDefaultResolutionLevels);
+    }
+}
+
+TEST_CASE("htj2k_codec transfer syntax UIDs", "[encoding][compression][htj2k]") {
+    SECTION("UIDs match DICOM Supplement 235 definitions") {
+        CHECK(htj2k_codec::kTransferSyntaxUIDLossless == "1.2.840.10008.1.2.4.201");
+        CHECK(htj2k_codec::kTransferSyntaxUIDRPCL == "1.2.840.10008.1.2.4.202");
+        CHECK(htj2k_codec::kTransferSyntaxUIDLossy == "1.2.840.10008.1.2.4.203");
+    }
+
+    SECTION("All three UIDs are distinct") {
+        CHECK(htj2k_codec::kTransferSyntaxUIDLossless != htj2k_codec::kTransferSyntaxUIDRPCL);
+        CHECK(htj2k_codec::kTransferSyntaxUIDRPCL != htj2k_codec::kTransferSyntaxUIDLossy);
+        CHECK(htj2k_codec::kTransferSyntaxUIDLossless != htj2k_codec::kTransferSyntaxUIDLossy);
+    }
+}
+
+TEST_CASE("htj2k_codec can_encode/can_decode", "[encoding][compression][htj2k]") {
+    htj2k_codec codec;
+
+    SECTION("Valid 8-bit grayscale parameters") {
+        image_params params;
+        params.width = 512;
+        params.height = 512;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.high_bit = 7;
+        params.samples_per_pixel = 1;
+
+        CHECK(codec.can_encode(params));
+        CHECK(codec.can_decode(params));
+    }
+
+    SECTION("Valid 16-bit grayscale parameters") {
+        image_params params;
+        params.width = 256;
+        params.height = 256;
+        params.bits_allocated = 16;
+        params.bits_stored = 16;
+        params.high_bit = 15;
+        params.samples_per_pixel = 1;
+
+        CHECK(codec.can_encode(params));
+        CHECK(codec.can_decode(params));
+    }
+
+    SECTION("Valid 8-bit RGB parameters") {
+        image_params params;
+        params.width = 128;
+        params.height = 128;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.high_bit = 7;
+        params.samples_per_pixel = 3;
+
+        CHECK(codec.can_encode(params));
+        CHECK(codec.can_decode(params));
+    }
+
+    SECTION("Zero dimensions rejected") {
+        image_params params;
+        params.width = 0;
+        params.height = 512;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.samples_per_pixel = 1;
+
+        CHECK_FALSE(codec.can_encode(params));
+
+        params.width = 512;
+        params.height = 0;
+        CHECK_FALSE(codec.can_encode(params));
+    }
+
+    SECTION("Unsupported samples_per_pixel rejected") {
+        image_params params;
+        params.width = 64;
+        params.height = 64;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.samples_per_pixel = 4;
+
+        CHECK_FALSE(codec.can_encode(params));
+    }
+
+    SECTION("Unsupported bit depth rejected") {
+        image_params params;
+        params.width = 64;
+        params.height = 64;
+        params.bits_allocated = 32;
+        params.bits_stored = 32;
+        params.samples_per_pixel = 1;
+
+        CHECK_FALSE(codec.can_encode(params));
+    }
+}
+
+TEST_CASE("htj2k_codec encode/decode returns not-implemented error",
+          "[encoding][compression][htj2k]") {
+    htj2k_codec codec;
+    std::vector<uint8_t> data(64 * 64);
+    image_params params;
+    params.width = 64;
+    params.height = 64;
+    params.bits_allocated = 8;
+    params.bits_stored = 8;
+    params.high_bit = 7;
+    params.samples_per_pixel = 1;
+
+    SECTION("Encode returns error with OpenJPH message") {
+        auto result = codec.encode(data, params);
+        REQUIRE_FALSE(result.is_ok());
+        CHECK_THAT(result.error().message,
+                   Catch::Matchers::ContainsSubstring("OpenJPH"));
+    }
+
+    SECTION("Decode returns error with OpenJPH message") {
+        auto result = codec.decode(data, params);
+        REQUIRE_FALSE(result.is_ok());
+        CHECK_THAT(result.error().message,
+                   Catch::Matchers::ContainsSubstring("OpenJPH"));
+    }
+}
+
+TEST_CASE("htj2k_codec move semantics", "[encoding][compression][htj2k]") {
+    SECTION("Move construction preserves state") {
+        htj2k_codec original(false, false, 30.0f, 8);
+        htj2k_codec moved(std::move(original));
+
+        CHECK(moved.is_lossy());
+        CHECK(moved.compression_ratio() == 30.0f);
+        CHECK(moved.resolution_levels() == 8);
+        CHECK(moved.transfer_syntax_uid() == htj2k_codec::kTransferSyntaxUIDLossy);
+    }
+
+    SECTION("Move assignment preserves state") {
+        htj2k_codec original(true, true);
+        htj2k_codec target;
+        target = std::move(original);
+
+        CHECK_FALSE(target.is_lossy());
+        CHECK(target.is_rpcl_mode());
+        CHECK(target.transfer_syntax_uid() == htj2k_codec::kTransferSyntaxUIDRPCL);
+    }
+}
+
+TEST_CASE("codec_factory HTJ2K support", "[encoding][compression][htj2k]") {
+    SECTION("Factory recognizes HTJ2K Lossless UID") {
+        CHECK(codec_factory::is_supported("1.2.840.10008.1.2.4.201"));
+
+        auto codec = codec_factory::create("1.2.840.10008.1.2.4.201");
+        REQUIRE(codec != nullptr);
+        CHECK(codec->transfer_syntax_uid() == "1.2.840.10008.1.2.4.201");
+        CHECK_FALSE(codec->is_lossy());
+    }
+
+    SECTION("Factory recognizes HTJ2K RPCL UID") {
+        CHECK(codec_factory::is_supported("1.2.840.10008.1.2.4.202"));
+
+        auto codec = codec_factory::create("1.2.840.10008.1.2.4.202");
+        REQUIRE(codec != nullptr);
+        CHECK(codec->transfer_syntax_uid() == "1.2.840.10008.1.2.4.202");
+        CHECK_FALSE(codec->is_lossy());
+    }
+
+    SECTION("Factory recognizes HTJ2K Lossy UID") {
+        CHECK(codec_factory::is_supported("1.2.840.10008.1.2.4.203"));
+
+        auto codec = codec_factory::create("1.2.840.10008.1.2.4.203");
+        REQUIRE(codec != nullptr);
+        CHECK(codec->transfer_syntax_uid() == "1.2.840.10008.1.2.4.203");
+        CHECK(codec->is_lossy());
+    }
+
+    SECTION("HTJ2K UIDs appear in supported transfer syntaxes list") {
+        auto supported = codec_factory::supported_transfer_syntaxes();
+
+        bool found_lossless = false;
+        bool found_rpcl = false;
+        bool found_lossy = false;
+
+        for (const auto& uid : supported) {
+            if (uid == "1.2.840.10008.1.2.4.201") found_lossless = true;
+            if (uid == "1.2.840.10008.1.2.4.202") found_rpcl = true;
+            if (uid == "1.2.840.10008.1.2.4.203") found_lossy = true;
+        }
+
+        CHECK(found_lossless);
+        CHECK(found_rpcl);
+        CHECK(found_lossy);
+    }
+}

--- a/tests/encoding/transfer_syntax_test.cpp
+++ b/tests/encoding/transfer_syntax_test.cpp
@@ -91,6 +91,43 @@ TEST_CASE("transfer_syntax properties", "[encoding][transfer_syntax]") {
         CHECK(ts.is_encapsulated());
         CHECK_FALSE(ts.is_supported());
     }
+
+    SECTION("HTJ2K Lossless") {
+        const auto& ts = transfer_syntax::htj2k_lossless;
+
+        CHECK(ts.uid() == "1.2.840.10008.1.2.4.201");
+        CHECK(ts.name() == "High-Throughput JPEG 2000 Image Compression (Lossless Only)");
+        CHECK(ts.endianness() == byte_order::little_endian);
+        CHECK(ts.vr_type() == vr_encoding::explicit_vr);
+        CHECK(ts.is_encapsulated());
+        CHECK_FALSE(ts.is_deflated());
+        CHECK(ts.is_valid());
+        CHECK_FALSE(ts.is_supported());
+    }
+
+    SECTION("HTJ2K RPCL") {
+        const auto& ts = transfer_syntax::htj2k_rpcl;
+
+        CHECK(ts.uid() == "1.2.840.10008.1.2.4.202");
+        CHECK(ts.endianness() == byte_order::little_endian);
+        CHECK(ts.vr_type() == vr_encoding::explicit_vr);
+        CHECK(ts.is_encapsulated());
+        CHECK_FALSE(ts.is_deflated());
+        CHECK(ts.is_valid());
+        CHECK_FALSE(ts.is_supported());
+    }
+
+    SECTION("HTJ2K Lossy") {
+        const auto& ts = transfer_syntax::htj2k_lossy;
+
+        CHECK(ts.uid() == "1.2.840.10008.1.2.4.203");
+        CHECK(ts.endianness() == byte_order::little_endian);
+        CHECK(ts.vr_type() == vr_encoding::explicit_vr);
+        CHECK(ts.is_encapsulated());
+        CHECK_FALSE(ts.is_deflated());
+        CHECK(ts.is_valid());
+        CHECK_FALSE(ts.is_supported());
+    }
 }
 
 TEST_CASE("transfer_syntax construction from UID", "[encoding][transfer_syntax]") {
@@ -116,6 +153,33 @@ TEST_CASE("transfer_syntax construction from UID", "[encoding][transfer_syntax]"
 
         CHECK_FALSE(ts.is_valid());
         CHECK(ts.name() == "Unknown");
+    }
+}
+
+TEST_CASE("transfer_syntax construction from HTJ2K UID", "[encoding][transfer_syntax]") {
+    SECTION("HTJ2K Lossless UID creates valid transfer_syntax") {
+        transfer_syntax ts{"1.2.840.10008.1.2.4.201"};
+
+        CHECK(ts.is_valid());
+        CHECK(ts.uid() == "1.2.840.10008.1.2.4.201");
+        CHECK(ts.is_encapsulated());
+        CHECK_FALSE(ts.is_supported());
+    }
+
+    SECTION("HTJ2K RPCL UID creates valid transfer_syntax") {
+        transfer_syntax ts{"1.2.840.10008.1.2.4.202"};
+
+        CHECK(ts.is_valid());
+        CHECK(ts.uid() == "1.2.840.10008.1.2.4.202");
+        CHECK(ts.is_encapsulated());
+    }
+
+    SECTION("HTJ2K Lossy UID creates valid transfer_syntax") {
+        transfer_syntax ts{"1.2.840.10008.1.2.4.203"};
+
+        CHECK(ts.is_valid());
+        CHECK(ts.uid() == "1.2.840.10008.1.2.4.203");
+        CHECK(ts.is_encapsulated());
     }
 }
 
@@ -157,7 +221,7 @@ TEST_CASE("transfer_syntax support enumeration", "[encoding][transfer_syntax]") 
     SECTION("all_transfer_syntaxes returns all registered") {
         auto all = all_transfer_syntaxes();
 
-        CHECK(all.size() >= 8);
+        CHECK(all.size() >= 12);
 
         for (const auto& ts : all) {
             CHECK(ts.is_valid());


### PR DESCRIPTION
Closes #784

## Summary

- Register 3 HTJ2K Transfer Syntax UIDs (Supplement 235) in `transfer_syntax` registry
- Add `htj2k_codec` class inheriting from `compression_codec` with stub encode/decode
- Extend `codec_factory` to create `htj2k_codec` instances for all 3 HTJ2K UIDs
- Add comprehensive tests for Transfer Syntax properties, codec construction, factory integration

## Transfer Syntaxes Added

| Transfer Syntax | UID | Type |
|----------------|-----|------|
| HTJ2K (Lossless Only) | 1.2.840.10008.1.2.4.201 | Lossless |
| HTJ2K (RPCL) | 1.2.840.10008.1.2.4.202 | Lossless or Lossy |
| HTJ2K (Lossy) | 1.2.840.10008.1.2.4.203 | Lossy |

## Files Changed

- `include/pacs/encoding/transfer_syntax.hpp` — 3 static HTJ2K instances
- `src/encoding/transfer_syntax.cpp` — Registry entries + static definitions
- `include/pacs/encoding/compression/htj2k_codec.hpp` — New codec class
- `src/encoding/compression/htj2k_codec.cpp` — Codec implementation (stub encode/decode)
- `src/encoding/compression/codec_factory.cpp` — HTJ2K factory entries
- `CMakeLists.txt` — Source and test file registration
- `tests/encoding/transfer_syntax_test.cpp` — HTJ2K TS property tests
- `tests/encoding/compression/htj2k_codec_test.cpp` — Codec and factory tests

## Test Plan

- [x] All 3 HTJ2K UIDs resolve to valid `transfer_syntax` with correct properties
- [x] `codec_factory::is_supported()` returns true for all 3 HTJ2K UIDs
- [x] `codec_factory::create()` returns non-null `htj2k_codec` for each UID
- [x] Codec reports correct Transfer Syntax UID based on mode (lossless/RPCL/lossy)
- [x] Encode/decode return descriptive "not yet implemented" error
- [x] Move semantics preserve codec state
- [x] Full encoding test suite passes (177 test cases, 15,379 assertions)
- [x] Full project build succeeds with no errors

## Next Steps

- #785 — Integrate OpenJPH library for actual encode/decode
- #786 — Add HTJ2K association negotiation and DICOMweb support