### PR TITLE
feat(services): implement UPS Push SCP with DIMSE-N handlers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1051,6 +1051,7 @@ add_library(pacs_services
     src/services/storage_commitment_scu.cpp
     src/services/print_scp.cpp
     src/services/print_scu.cpp
+    src/services/ups/ups_push_scp.cpp
     src/services/sop_class_registry.cpp
     src/services/sop_classes/us_storage.cpp
     src/services/sop_classes/dx_storage.cpp
@@ -1859,6 +1860,7 @@ if(PACS_BUILD_TESTS)
         tests/services/storage_commitment_scu_test.cpp
         tests/services/print_scp_test.cpp
         tests/services/print_scu_test.cpp
+        tests/services/ups_push_scp_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/core/result.hpp
+++ b/include/pacs/core/result.hpp
@@ -229,6 +229,15 @@ namespace error_codes {
     constexpr int not_a_regular_file = service_base - 92;
     constexpr int file_parsing_not_implemented = service_base - 93;
     constexpr int file_parse_failed = service_base - 94;
+
+    // UPS service errors (-895 to -905)
+    constexpr int ups_handler_not_set = service_base - 95;
+    constexpr int ups_unexpected_command = service_base - 96;
+    constexpr int ups_invalid_state_transition = service_base - 97;
+    constexpr int ups_missing_uid = service_base - 98;
+    constexpr int ups_workitem_not_found = service_base - 99;
+    constexpr int ups_invalid_action_type = service_base - 100;
+    constexpr int ups_missing_transaction_uid = service_base - 101;
 } // namespace error_codes
 
 // Re-export common utility functions

--- a/include/pacs/services/ups/ups_push_scp.hpp
+++ b/include/pacs/services/ups/ups_push_scp.hpp
@@ -1,0 +1,329 @@
+/**
+ * @file ups_push_scp.hpp
+ * @brief DICOM UPS (Unified Procedure Step) Push SCP service
+ *
+ * This file provides the ups_push_scp class for handling N-CREATE, N-SET,
+ * N-GET, and N-ACTION requests for UPS workitem management.
+ *
+ * @see DICOM PS3.4 Annex CC - Unified Procedure Step Service
+ * @see DICOM PS3.7 Section 10 - DIMSE-N Services
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_UPS_PUSH_SCP_HPP
+#define PACS_SERVICES_UPS_PUSH_SCP_HPP
+
+#include "../scp_service.hpp"
+
+#include <atomic>
+#include <functional>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "pacs/storage/ups_workitem.hpp"
+
+namespace pacs::services {
+
+// =============================================================================
+// SOP Class UID
+// =============================================================================
+
+/// UPS Push SOP Class UID (PS3.4 Table CC.2-1)
+inline constexpr std::string_view ups_push_sop_class_uid =
+    "1.2.840.10008.5.1.4.34.6.1";
+
+// =============================================================================
+// N-ACTION Type Constants
+// =============================================================================
+
+/// N-ACTION Type 1: Change UPS State (PS3.4 CC.2.4)
+inline constexpr uint16_t ups_action_change_state = 1;
+
+/// N-ACTION Type 3: Request Cancellation (PS3.4 CC.2.5)
+inline constexpr uint16_t ups_action_request_cancel = 3;
+
+// =============================================================================
+// Handler Types
+// =============================================================================
+
+/**
+ * @brief N-CREATE handler function type
+ *
+ * Called when an N-CREATE request is received to create a new UPS workitem.
+ * The workitem will always have state=SCHEDULED.
+ *
+ * @param workitem The UPS workitem data from the N-CREATE request
+ * @return Success if the workitem was created, error description otherwise
+ */
+using ups_create_handler = std::function<network::Result<std::monostate>(
+    const storage::ups_workitem& workitem)>;
+
+/**
+ * @brief N-SET handler function type
+ *
+ * Called when an N-SET request is received to update an existing UPS workitem.
+ *
+ * @param workitem_uid The SOP Instance UID of the workitem to update
+ * @param modifications The dataset containing the modifications
+ * @return Success if the workitem was updated, error description otherwise
+ */
+using ups_set_handler = std::function<network::Result<std::monostate>(
+    const std::string& workitem_uid,
+    const core::dicom_dataset& modifications)>;
+
+/**
+ * @brief N-GET handler function type
+ *
+ * Called when an N-GET request is received to retrieve a UPS workitem.
+ *
+ * @param workitem_uid The SOP Instance UID of the workitem to retrieve
+ * @return The workitem if found, error otherwise
+ */
+using ups_get_handler = std::function<network::Result<storage::ups_workitem>(
+    const std::string& workitem_uid)>;
+
+/**
+ * @brief N-ACTION Type 1 handler: Change UPS State
+ *
+ * Called when an N-ACTION request with Action Type ID 1 is received.
+ *
+ * @param workitem_uid The SOP Instance UID of the workitem
+ * @param new_state The requested new state
+ * @param transaction_uid The transaction UID for claiming
+ * @return Success if the state was changed, error otherwise
+ */
+using ups_change_state_handler = std::function<network::Result<std::monostate>(
+    const std::string& workitem_uid,
+    const std::string& new_state,
+    const std::string& transaction_uid)>;
+
+/**
+ * @brief N-ACTION Type 3 handler: Request Cancellation
+ *
+ * Called when an N-ACTION request with Action Type ID 3 is received.
+ *
+ * @param workitem_uid The SOP Instance UID of the workitem
+ * @param reason The cancellation reason (may be empty)
+ * @return Success if the cancellation request was accepted, error otherwise
+ */
+using ups_request_cancel_handler = std::function<network::Result<std::monostate>(
+    const std::string& workitem_uid,
+    const std::string& reason)>;
+
+// =============================================================================
+// UPS Push SCP Class
+// =============================================================================
+
+/**
+ * @brief UPS Push SCP service for handling workitem management requests
+ *
+ * The UPS Push SCP (Service Class Provider) responds to N-CREATE, N-SET,
+ * N-GET, and N-ACTION requests from SCU peers. It manages UPS workitems
+ * following the DICOM Unified Procedure Step Push model (PS3.4 Annex CC).
+ *
+ * ## UPS Push Message Flow
+ *
+ * ```
+ * SCU (Performer)                          UPS Push SCP
+ *  │                                       │
+ *  │  N-CREATE-RQ (Create workitem)        │
+ *  │  state = "SCHEDULED"                  │
+ *  │──────────────────────────────────────►│
+ *  │  N-CREATE-RSP                         │
+ *  │◄──────────────────────────────────────│
+ *  │                                       │
+ *  │  N-ACTION-RQ (Claim: Type 1)          │
+ *  │  new_state = "IN PROGRESS"            │
+ *  │──────────────────────────────────────►│
+ *  │  N-ACTION-RSP                         │
+ *  │◄──────────────────────────────────────│
+ *  │                                       │
+ *  │  N-SET-RQ (Update progress)           │
+ *  │──────────────────────────────────────►│
+ *  │  N-SET-RSP                            │
+ *  │◄──────────────────────────────────────│
+ *  │                                       │
+ *  │  N-ACTION-RQ (Complete: Type 1)       │
+ *  │  new_state = "COMPLETED"              │
+ *  │──────────────────────────────────────►│
+ *  │  N-ACTION-RSP                         │
+ *  │◄──────────────────────────────────────│
+ * ```
+ *
+ * @example Usage
+ * @code
+ * ups_push_scp scp;
+ *
+ * scp.set_create_handler([&db](const ups_workitem& wi) {
+ *     return db.create_ups_workitem(wi);
+ * });
+ *
+ * scp.set_change_state_handler([&db](const auto& uid, const auto& state,
+ *                                     const auto& txn_uid) {
+ *     return db.change_ups_state(uid, state, txn_uid);
+ * });
+ *
+ * auto result = scp.handle_message(association, context_id, request);
+ * @endcode
+ */
+class ups_push_scp final : public scp_service {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct UPS Push SCP with optional logger
+     *
+     * @param logger Logger instance for service logging (nullptr uses null_logger)
+     */
+    explicit ups_push_scp(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~ups_push_scp() override = default;
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    void set_create_handler(ups_create_handler handler);
+    void set_set_handler(ups_set_handler handler);
+    void set_get_handler(ups_get_handler handler);
+    void set_change_state_handler(ups_change_state_handler handler);
+    void set_request_cancel_handler(ups_request_cancel_handler handler);
+
+    // =========================================================================
+    // scp_service Interface Implementation
+    // =========================================================================
+
+    [[nodiscard]] std::vector<std::string> supported_sop_classes() const override;
+
+    [[nodiscard]] network::Result<std::monostate> handle_message(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request) override;
+
+    [[nodiscard]] std::string_view service_name() const noexcept override;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    [[nodiscard]] size_t creates_processed() const noexcept;
+    [[nodiscard]] size_t sets_processed() const noexcept;
+    [[nodiscard]] size_t gets_processed() const noexcept;
+    [[nodiscard]] size_t actions_processed() const noexcept;
+    [[nodiscard]] size_t state_changes() const noexcept;
+    [[nodiscard]] size_t cancel_requests() const noexcept;
+
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_create(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_set(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_get(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_action(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> send_n_create_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid,
+        network::dimse::status_code status);
+
+    [[nodiscard]] network::Result<std::monostate> send_n_set_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid,
+        network::dimse::status_code status);
+
+    [[nodiscard]] network::Result<std::monostate> send_n_get_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid,
+        network::dimse::status_code status,
+        core::dicom_dataset* dataset = nullptr);
+
+    [[nodiscard]] network::Result<std::monostate> send_n_action_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid,
+        uint16_t action_type_id,
+        network::dimse::status_code status);
+
+    // =========================================================================
+    // Member Variables
+    // =========================================================================
+
+    ups_create_handler create_handler_;
+    ups_set_handler set_handler_;
+    ups_get_handler get_handler_;
+    ups_change_state_handler change_state_handler_;
+    ups_request_cancel_handler request_cancel_handler_;
+
+    std::atomic<size_t> creates_processed_{0};
+    std::atomic<size_t> sets_processed_{0};
+    std::atomic<size_t> gets_processed_{0};
+    std::atomic<size_t> actions_processed_{0};
+    std::atomic<size_t> state_changes_{0};
+    std::atomic<size_t> cancel_requests_{0};
+};
+
+// =============================================================================
+// UPS DICOM Tags
+// =============================================================================
+
+namespace ups_tags {
+
+/// Procedure Step State (0074,1000)
+inline constexpr core::dicom_tag procedure_step_state{0x0074, 0x1000};
+
+/// Procedure Step Progress (0074,1004)
+inline constexpr core::dicom_tag procedure_step_progress{0x0074, 0x1004};
+
+/// Scheduled Procedure Step Priority (0074,1200)
+inline constexpr core::dicom_tag scheduled_procedure_step_priority{0x0074, 0x1200};
+
+/// Worklist Label (0074,1202)
+inline constexpr core::dicom_tag worklist_label{0x0074, 0x1202};
+
+/// Procedure Step Label (0074,1204)
+inline constexpr core::dicom_tag procedure_step_label{0x0074, 0x1204};
+
+/// Transaction UID (0008,1195)
+inline constexpr core::dicom_tag transaction_uid{0x0008, 0x1195};
+
+/// Input Information Sequence (0040,4021)
+inline constexpr core::dicom_tag input_information_sequence{0x0040, 0x4021};
+
+/// Reason for Cancellation (0074,1238)
+inline constexpr core::dicom_tag reason_for_cancellation{0x0074, 0x1238};
+
+}  // namespace ups_tags
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_UPS_PUSH_SCP_HPP

--- a/src/services/ups/ups_push_scp.cpp
+++ b/src/services/ups/ups_push_scp.cpp
@@ -1,0 +1,576 @@
+/**
+ * @file ups_push_scp.cpp
+ * @brief Implementation of the UPS (Unified Procedure Step) Push SCP service
+ */
+
+#include "pacs/services/ups/ups_push_scp.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/core/result.hpp"
+#include "pacs/encoding/vr_type.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/dimse_message.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+ups_push_scp::ups_push_scp(std::shared_ptr<di::ILogger> logger)
+    : scp_service(std::move(logger)) {}
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+void ups_push_scp::set_create_handler(ups_create_handler handler) {
+    create_handler_ = std::move(handler);
+}
+
+void ups_push_scp::set_set_handler(ups_set_handler handler) {
+    set_handler_ = std::move(handler);
+}
+
+void ups_push_scp::set_get_handler(ups_get_handler handler) {
+    get_handler_ = std::move(handler);
+}
+
+void ups_push_scp::set_change_state_handler(ups_change_state_handler handler) {
+    change_state_handler_ = std::move(handler);
+}
+
+void ups_push_scp::set_request_cancel_handler(ups_request_cancel_handler handler) {
+    request_cancel_handler_ = std::move(handler);
+}
+
+// =============================================================================
+// scp_service Interface Implementation
+// =============================================================================
+
+std::vector<std::string> ups_push_scp::supported_sop_classes() const {
+    return {std::string(ups_push_sop_class_uid)};
+}
+
+network::Result<std::monostate> ups_push_scp::handle_message(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    switch (request.command()) {
+        case command_field::n_create_rq:
+            return handle_n_create(assoc, context_id, request);
+
+        case command_field::n_set_rq:
+            return handle_n_set(assoc, context_id, request);
+
+        case command_field::n_get_rq:
+            return handle_n_get(assoc, context_id, request);
+
+        case command_field::n_action_rq:
+            return handle_n_action(assoc, context_id, request);
+
+        default:
+            return pacs::pacs_void_error(
+                pacs::error_codes::ups_unexpected_command,
+                "Unexpected command for UPS Push SCP: " +
+                std::string(to_string(request.command())));
+    }
+}
+
+std::string_view ups_push_scp::service_name() const noexcept {
+    return "UPS Push SCP";
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t ups_push_scp::creates_processed() const noexcept {
+    return creates_processed_.load();
+}
+
+size_t ups_push_scp::sets_processed() const noexcept {
+    return sets_processed_.load();
+}
+
+size_t ups_push_scp::gets_processed() const noexcept {
+    return gets_processed_.load();
+}
+
+size_t ups_push_scp::actions_processed() const noexcept {
+    return actions_processed_.load();
+}
+
+size_t ups_push_scp::state_changes() const noexcept {
+    return state_changes_.load();
+}
+
+size_t ups_push_scp::cancel_requests() const noexcept {
+    return cancel_requests_.load();
+}
+
+void ups_push_scp::reset_statistics() noexcept {
+    creates_processed_ = 0;
+    sets_processed_ = 0;
+    gets_processed_ = 0;
+    actions_processed_ = 0;
+    state_changes_ = 0;
+    cancel_requests_ = 0;
+}
+
+// =============================================================================
+// Private Implementation - N-CREATE Handler
+// =============================================================================
+
+network::Result<std::monostate> ups_push_scp::handle_n_create(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Verify we have a handler configured
+    if (!create_handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_handler_not_set,
+            "No N-CREATE handler configured for UPS Push SCP");
+    }
+
+    // Verify the SOP Class is UPS Push
+    auto sop_class_uid = request.affected_sop_class_uid();
+    if (sop_class_uid != ups_push_sop_class_uid) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            "", status_refused_sop_class_not_supported);
+    }
+
+    // Get the SOP Instance UID (workitem UID)
+    auto sop_instance_uid = request.affected_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            "", status_error_missing_attribute);
+    }
+
+    // Verify we have a dataset
+    if (!request.has_dataset()) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_cannot_understand);
+    }
+
+    const auto& dataset = request.dataset().value().get();
+
+    // Validate initial state is SCHEDULED (if present in dataset)
+    if (dataset.contains(ups_tags::procedure_step_state)) {
+        auto state_str = dataset.get_string(ups_tags::procedure_step_state);
+        auto parsed_state = storage::parse_ups_state(state_str);
+
+        if (!parsed_state.has_value() ||
+            parsed_state.value() != storage::ups_state::scheduled) {
+            return send_n_create_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, status_error_cannot_understand);
+        }
+    }
+
+    // Build UPS workitem from request data
+    storage::ups_workitem workitem;
+    workitem.workitem_uid = sop_instance_uid;
+    workitem.state = "SCHEDULED";
+
+    // Extract optional fields from dataset
+    if (dataset.contains(ups_tags::procedure_step_label)) {
+        workitem.procedure_step_label =
+            dataset.get_string(ups_tags::procedure_step_label);
+    }
+    if (dataset.contains(ups_tags::worklist_label)) {
+        workitem.worklist_label =
+            dataset.get_string(ups_tags::worklist_label);
+    }
+    if (dataset.contains(ups_tags::scheduled_procedure_step_priority)) {
+        workitem.priority =
+            dataset.get_string(ups_tags::scheduled_procedure_step_priority);
+    }
+
+    // Call the handler to create the workitem
+    auto result = create_handler_(workitem);
+    if (result.is_err()) {
+        return send_n_create_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_unable_to_process);
+    }
+
+    ++creates_processed_;
+
+    return send_n_create_response(
+        assoc, context_id, request.message_id(),
+        sop_instance_uid, status_success);
+}
+
+// =============================================================================
+// Private Implementation - N-SET Handler
+// =============================================================================
+
+network::Result<std::monostate> ups_push_scp::handle_n_set(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Verify we have a handler configured
+    if (!set_handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_handler_not_set,
+            "No N-SET handler configured for UPS Push SCP");
+    }
+
+    // Get SOP Instance UID (from Requested SOP Instance UID for N-SET)
+    auto sop_instance_uid = request.command_set().get_string(
+        tag_requested_sop_instance_uid);
+
+    if (sop_instance_uid.empty()) {
+        sop_instance_uid = request.affected_sop_instance_uid();
+    }
+
+    if (sop_instance_uid.empty()) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            "", status_error_missing_attribute);
+    }
+
+    // Verify we have a dataset with modifications
+    if (!request.has_dataset()) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_cannot_understand);
+    }
+
+    const auto& dataset = request.dataset().value().get();
+
+    // Reject if dataset tries to set a final state directly via N-SET
+    // (state changes must go through N-ACTION)
+    if (dataset.contains(ups_tags::procedure_step_state)) {
+        auto state_str = dataset.get_string(ups_tags::procedure_step_state);
+        auto parsed_state = storage::parse_ups_state(state_str);
+        if (parsed_state.has_value() &&
+            (parsed_state.value() == storage::ups_state::completed ||
+             parsed_state.value() == storage::ups_state::canceled)) {
+            return send_n_set_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, status_error_cannot_understand);
+        }
+    }
+
+    // Call the handler to update the workitem
+    auto result = set_handler_(sop_instance_uid, dataset);
+    if (result.is_err()) {
+        return send_n_set_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_unable_to_process);
+    }
+
+    ++sets_processed_;
+
+    return send_n_set_response(
+        assoc, context_id, request.message_id(),
+        sop_instance_uid, status_success);
+}
+
+// =============================================================================
+// Private Implementation - N-GET Handler
+// =============================================================================
+
+network::Result<std::monostate> ups_push_scp::handle_n_get(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Verify we have a handler configured
+    if (!get_handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_handler_not_set,
+            "No N-GET handler configured for UPS Push SCP");
+    }
+
+    // Extract Requested SOP Instance UID
+    auto sop_instance_uid = request.requested_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        return send_n_get_response(
+            assoc, context_id, request.message_id(),
+            "", status_error_missing_attribute);
+    }
+
+    // Call the handler to retrieve the workitem
+    auto result = get_handler_(sop_instance_uid);
+    if (result.is_err()) {
+        return send_n_get_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, status_error_invalid_object_instance);
+    }
+
+    ++gets_processed_;
+
+    // Build response dataset from workitem
+    const auto& workitem = result.value();
+    core::dicom_dataset response_dataset;
+
+    response_dataset.set_string(
+        ups_tags::procedure_step_state,
+        encoding::vr_type::CS, workitem.state);
+
+    if (!workitem.procedure_step_label.empty()) {
+        response_dataset.set_string(
+            ups_tags::procedure_step_label,
+            encoding::vr_type::LO, workitem.procedure_step_label);
+    }
+    if (!workitem.worklist_label.empty()) {
+        response_dataset.set_string(
+            ups_tags::worklist_label,
+            encoding::vr_type::LO, workitem.worklist_label);
+    }
+    if (!workitem.priority.empty()) {
+        response_dataset.set_string(
+            ups_tags::scheduled_procedure_step_priority,
+            encoding::vr_type::CS, workitem.priority);
+    }
+    if (!workitem.progress_description.empty()) {
+        response_dataset.set_string(
+            ups_tags::procedure_step_progress,
+            encoding::vr_type::DS,
+            std::to_string(workitem.progress_percent));
+    }
+    if (!workitem.transaction_uid.empty()) {
+        response_dataset.set_string(
+            ups_tags::transaction_uid,
+            encoding::vr_type::UI, workitem.transaction_uid);
+    }
+
+    return send_n_get_response(
+        assoc, context_id, request.message_id(),
+        sop_instance_uid, status_success, &response_dataset);
+}
+
+// =============================================================================
+// Private Implementation - N-ACTION Handler
+// =============================================================================
+
+network::Result<std::monostate> ups_push_scp::handle_n_action(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Get Action Type ID
+    auto action_type = request.action_type_id();
+    if (!action_type.has_value()) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_invalid_action_type,
+            "Missing Action Type ID in N-ACTION request");
+    }
+
+    // Get SOP Instance UID
+    auto sop_instance_uid = request.requested_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        sop_instance_uid = request.affected_sop_instance_uid();
+    }
+
+    if (sop_instance_uid.empty()) {
+        return send_n_action_response(
+            assoc, context_id, request.message_id(),
+            "", action_type.value(), status_error_missing_attribute);
+    }
+
+    uint16_t action_id = action_type.value();
+
+    if (action_id == ups_action_change_state) {
+        // N-ACTION Type 1: Change UPS State
+        if (!change_state_handler_) {
+            return pacs::pacs_void_error(
+                pacs::error_codes::ups_handler_not_set,
+                "No Change State handler configured for UPS Push SCP");
+        }
+
+        if (!request.has_dataset()) {
+            return send_n_action_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, action_id, status_error_cannot_understand);
+        }
+
+        const auto& dataset = request.dataset().value().get();
+
+        // Extract new state
+        if (!dataset.contains(ups_tags::procedure_step_state)) {
+            return send_n_action_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, action_id, status_error_missing_attribute);
+        }
+
+        auto new_state = dataset.get_string(ups_tags::procedure_step_state);
+
+        // Validate the state value
+        auto parsed_state = storage::parse_ups_state(new_state);
+        if (!parsed_state.has_value()) {
+            return send_n_action_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, action_id, status_error_cannot_understand);
+        }
+
+        // Extract Transaction UID (required when transitioning to IN PROGRESS)
+        std::string txn_uid;
+        if (dataset.contains(ups_tags::transaction_uid)) {
+            txn_uid = dataset.get_string(ups_tags::transaction_uid);
+        }
+
+        if (parsed_state.value() == storage::ups_state::in_progress &&
+            txn_uid.empty()) {
+            return send_n_action_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, action_id, status_error_missing_attribute);
+        }
+
+        auto result = change_state_handler_(sop_instance_uid, new_state, txn_uid);
+        if (result.is_err()) {
+            return send_n_action_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, action_id, status_error_unable_to_process);
+        }
+
+        ++actions_processed_;
+        ++state_changes_;
+
+        return send_n_action_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, action_id, status_success);
+
+    } else if (action_id == ups_action_request_cancel) {
+        // N-ACTION Type 3: Request Cancellation
+        if (!request_cancel_handler_) {
+            return pacs::pacs_void_error(
+                pacs::error_codes::ups_handler_not_set,
+                "No Request Cancel handler configured for UPS Push SCP");
+        }
+
+        // Extract cancellation reason (optional)
+        std::string reason;
+        if (request.has_dataset()) {
+            const auto& dataset = request.dataset().value().get();
+            if (dataset.contains(ups_tags::reason_for_cancellation)) {
+                reason = dataset.get_string(ups_tags::reason_for_cancellation);
+            }
+        }
+
+        auto result = request_cancel_handler_(sop_instance_uid, reason);
+        if (result.is_err()) {
+            return send_n_action_response(
+                assoc, context_id, request.message_id(),
+                sop_instance_uid, action_id, status_error_unable_to_process);
+        }
+
+        ++actions_processed_;
+        ++cancel_requests_;
+
+        return send_n_action_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, action_id, status_success);
+
+    } else {
+        // Unknown action type
+        return send_n_action_response(
+            assoc, context_id, request.message_id(),
+            sop_instance_uid, action_id, status_error_no_such_action_type);
+    }
+}
+
+// =============================================================================
+// Private Implementation - Response Helpers
+// =============================================================================
+
+network::Result<std::monostate> ups_push_scp::send_n_create_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    dimse_message response{command_field::n_create_rsp, 0};
+    response.set_message_id_responded_to(message_id);
+    response.set_affected_sop_class_uid(ups_push_sop_class_uid);
+    response.set_status(status);
+
+    if (!sop_instance_uid.empty()) {
+        response.set_affected_sop_instance_uid(sop_instance_uid);
+    }
+
+    return assoc.send_dimse(context_id, response);
+}
+
+network::Result<std::monostate> ups_push_scp::send_n_set_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    dimse_message response{command_field::n_set_rsp, 0};
+    response.set_message_id_responded_to(message_id);
+    response.set_affected_sop_class_uid(ups_push_sop_class_uid);
+    response.set_status(status);
+
+    if (!sop_instance_uid.empty()) {
+        response.set_affected_sop_instance_uid(sop_instance_uid);
+    }
+
+    return assoc.send_dimse(context_id, response);
+}
+
+network::Result<std::monostate> ups_push_scp::send_n_get_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid,
+    network::dimse::status_code status,
+    core::dicom_dataset* dataset) {
+
+    using namespace network::dimse;
+
+    auto response = make_n_get_rsp(
+        message_id, ups_push_sop_class_uid, sop_instance_uid, status);
+
+    if (dataset != nullptr) {
+        response.set_dataset(std::move(*dataset));
+    }
+
+    return assoc.send_dimse(context_id, response);
+}
+
+network::Result<std::monostate> ups_push_scp::send_n_action_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid,
+    uint16_t action_type_id,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    auto response = make_n_action_rsp(
+        message_id, ups_push_sop_class_uid, sop_instance_uid,
+        action_type_id, status);
+
+    return assoc.send_dimse(context_id, response);
+}
+
+}  // namespace pacs::services

--- a/tests/services/ups_push_scp_test.cpp
+++ b/tests/services/ups_push_scp_test.cpp
@@ -1,0 +1,399 @@
+/**
+ * @file ups_push_scp_test.cpp
+ * @brief Unit tests for UPS (Unified Procedure Step) Push SCP service
+ */
+
+#include <pacs/services/ups/ups_push_scp.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#include <pacs/storage/ups_workitem.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+using namespace pacs::storage;
+
+// ============================================================================
+// ups_push_scp Construction Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scp construction", "[services][ups]") {
+    ups_push_scp scp;
+
+    SECTION("service name is correct") {
+        CHECK(scp.service_name() == "UPS Push SCP");
+    }
+
+    SECTION("supports exactly one SOP class") {
+        auto classes = scp.supported_sop_classes();
+        CHECK(classes.size() == 1);
+    }
+
+    SECTION("supports UPS Push SOP Class") {
+        auto classes = scp.supported_sop_classes();
+        REQUIRE(classes.size() == 1);
+        CHECK(classes[0] == "1.2.840.10008.5.1.4.34.6.1");
+    }
+}
+
+// ============================================================================
+// SOP Class Support Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scp SOP class support", "[services][ups]") {
+    ups_push_scp scp;
+
+    SECTION("supports UPS Push SOP Class UID") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.1"));
+        CHECK(scp.supports_sop_class(ups_push_sop_class_uid));
+    }
+
+    SECTION("does not support other SOP classes") {
+        // Verification SOP Class
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.1.1"));
+        // MPPS SOP Class
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.3.1.2.3.3"));
+        // UPS Watch SOP Class
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.2"));
+        // UPS Pull SOP Class
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.3"));
+        // Empty string
+        CHECK_FALSE(scp.supports_sop_class(""));
+        // Random UID
+        CHECK_FALSE(scp.supports_sop_class("1.2.3.4.5.6.7.8.9"));
+    }
+}
+
+// ============================================================================
+// UPS Push SOP Class UID Constant Test
+// ============================================================================
+
+TEST_CASE("ups_push_sop_class_uid constant", "[services][ups]") {
+    CHECK(ups_push_sop_class_uid == "1.2.840.10008.5.1.4.34.6.1");
+}
+
+// ============================================================================
+// N-ACTION Type Constants Tests
+// ============================================================================
+
+TEST_CASE("UPS N-ACTION type constants", "[services][ups]") {
+    CHECK(ups_action_change_state == 1);
+    CHECK(ups_action_request_cancel == 3);
+}
+
+// ============================================================================
+// UPS State Tests (from ups_workitem.hpp)
+// ============================================================================
+
+TEST_CASE("ups_state to_string conversion", "[services][ups]") {
+    CHECK(to_string(ups_state::scheduled) == "SCHEDULED");
+    CHECK(to_string(ups_state::in_progress) == "IN PROGRESS");
+    CHECK(to_string(ups_state::completed) == "COMPLETED");
+    CHECK(to_string(ups_state::canceled) == "CANCELED");
+}
+
+TEST_CASE("parse_ups_state conversion", "[services][ups]") {
+    SECTION("valid state strings") {
+        auto scheduled = parse_ups_state("SCHEDULED");
+        REQUIRE(scheduled.has_value());
+        CHECK(scheduled.value() == ups_state::scheduled);
+
+        auto in_progress = parse_ups_state("IN PROGRESS");
+        REQUIRE(in_progress.has_value());
+        CHECK(in_progress.value() == ups_state::in_progress);
+
+        auto completed = parse_ups_state("COMPLETED");
+        REQUIRE(completed.has_value());
+        CHECK(completed.value() == ups_state::completed);
+
+        auto canceled = parse_ups_state("CANCELED");
+        REQUIRE(canceled.has_value());
+        CHECK(canceled.value() == ups_state::canceled);
+    }
+
+    SECTION("invalid state strings return nullopt") {
+        CHECK_FALSE(parse_ups_state("").has_value());
+        CHECK_FALSE(parse_ups_state("INVALID").has_value());
+        CHECK_FALSE(parse_ups_state("scheduled").has_value());  // case sensitive
+        CHECK_FALSE(parse_ups_state("IN_PROGRESS").has_value());  // wrong format
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scp statistics", "[services][ups]") {
+    ups_push_scp scp;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scp.creates_processed() == 0);
+        CHECK(scp.sets_processed() == 0);
+        CHECK(scp.gets_processed() == 0);
+        CHECK(scp.actions_processed() == 0);
+        CHECK(scp.state_changes() == 0);
+        CHECK(scp.cancel_requests() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        scp.reset_statistics();
+        CHECK(scp.creates_processed() == 0);
+        CHECK(scp.sets_processed() == 0);
+        CHECK(scp.gets_processed() == 0);
+        CHECK(scp.actions_processed() == 0);
+        CHECK(scp.state_changes() == 0);
+        CHECK(scp.cancel_requests() == 0);
+    }
+}
+
+// ============================================================================
+// Handler Configuration Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scp handler configuration", "[services][ups]") {
+    ups_push_scp scp;
+
+    SECTION("can set create handler") {
+        bool handler_called = false;
+        scp.set_create_handler([&handler_called](const ups_workitem& /*wi*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set set handler") {
+        bool handler_called = false;
+        scp.set_set_handler([&handler_called](
+            const std::string& /*uid*/,
+            const dicom_dataset& /*mods*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set get handler") {
+        bool handler_called = false;
+        scp.set_get_handler([&handler_called](const std::string& /*uid*/) {
+            handler_called = true;
+            return Result<ups_workitem>{ups_workitem{}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set change state handler") {
+        bool handler_called = false;
+        scp.set_change_state_handler([&handler_called](
+            const std::string& /*uid*/,
+            const std::string& /*state*/,
+            const std::string& /*txn_uid*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("can set request cancel handler") {
+        bool handler_called = false;
+        scp.set_request_cancel_handler([&handler_called](
+            const std::string& /*uid*/,
+            const std::string& /*reason*/) {
+            handler_called = true;
+            return Result<std::monostate>{std::monostate{}};
+        });
+        CHECK_FALSE(handler_called);
+    }
+}
+
+// ============================================================================
+// ups_workitem Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_workitem structure", "[services][ups]") {
+    ups_workitem workitem;
+
+    SECTION("default construction") {
+        CHECK(workitem.workitem_uid.empty());
+        CHECK(workitem.state.empty());
+        CHECK(workitem.pk == 0);
+        CHECK(workitem.progress_percent == 0);
+        CHECK_FALSE(workitem.is_valid());
+    }
+
+    SECTION("can be initialized") {
+        workitem.workitem_uid = "1.2.3.4.5.6";
+        workitem.state = "SCHEDULED";
+        workitem.procedure_step_label = "CT Scan";
+        workitem.priority = "MEDIUM";
+
+        CHECK(workitem.is_valid());
+        CHECK_FALSE(workitem.is_final());
+        CHECK(workitem.get_state().has_value());
+        CHECK(workitem.get_state().value() == ups_state::scheduled);
+    }
+
+    SECTION("is_final for terminal states") {
+        workitem.state = "COMPLETED";
+        CHECK(workitem.is_final());
+
+        workitem.state = "CANCELED";
+        CHECK(workitem.is_final());
+
+        workitem.state = "SCHEDULED";
+        CHECK_FALSE(workitem.is_final());
+
+        workitem.state = "IN PROGRESS";
+        CHECK_FALSE(workitem.is_final());
+    }
+}
+
+// ============================================================================
+// UPS Tags Tests
+// ============================================================================
+
+TEST_CASE("ups_tags namespace contains UPS-specific tags", "[services][ups]") {
+    using namespace ups_tags;
+
+    SECTION("procedure step tags") {
+        CHECK(procedure_step_state == dicom_tag{0x0074, 0x1000});
+        CHECK(procedure_step_progress == dicom_tag{0x0074, 0x1004});
+        CHECK(procedure_step_label == dicom_tag{0x0074, 0x1204});
+    }
+
+    SECTION("scheduling tags") {
+        CHECK(scheduled_procedure_step_priority == dicom_tag{0x0074, 0x1200});
+        CHECK(worklist_label == dicom_tag{0x0074, 0x1202});
+    }
+
+    SECTION("transaction and input tags") {
+        CHECK(transaction_uid == dicom_tag{0x0008, 0x1195});
+        CHECK(input_information_sequence == dicom_tag{0x0040, 0x4021});
+    }
+
+    SECTION("cancellation tags") {
+        CHECK(reason_for_cancellation == dicom_tag{0x0074, 0x1238});
+    }
+}
+
+// ============================================================================
+// scp_service Base Class Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scp is a scp_service", "[services][ups]") {
+    std::unique_ptr<scp_service> base_ptr = std::make_unique<ups_push_scp>();
+
+    CHECK(base_ptr->service_name() == "UPS Push SCP");
+    CHECK(base_ptr->supported_sop_classes().size() == 1);
+    CHECK(base_ptr->supports_sop_class("1.2.840.10008.5.1.4.34.6.1"));
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple ups_push_scp instances are independent", "[services][ups]") {
+    ups_push_scp scp1;
+    ups_push_scp scp2;
+
+    CHECK(scp1.service_name() == scp2.service_name());
+    CHECK(scp1.supported_sop_classes() == scp2.supported_sop_classes());
+    CHECK(scp1.supports_sop_class("1.2.840.10008.5.1.4.34.6.1") ==
+          scp2.supports_sop_class("1.2.840.10008.5.1.4.34.6.1"));
+
+    // Statistics should be independent
+    scp1.reset_statistics();
+    CHECK(scp1.creates_processed() == scp2.creates_processed());
+    CHECK(scp1.actions_processed() == scp2.actions_processed());
+}
+
+// ============================================================================
+// Command Field Tests
+// ============================================================================
+
+TEST_CASE("UPS-relevant DIMSE-N command fields", "[services][ups]") {
+    SECTION("N-CREATE command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_create_rq) == 0x0140);
+        CHECK(static_cast<uint16_t>(command_field::n_create_rsp) == 0x8140);
+        CHECK(is_request(command_field::n_create_rq));
+        CHECK(is_response(command_field::n_create_rsp));
+    }
+
+    SECTION("N-SET command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_set_rq) == 0x0120);
+        CHECK(static_cast<uint16_t>(command_field::n_set_rsp) == 0x8120);
+        CHECK(is_request(command_field::n_set_rq));
+        CHECK(is_response(command_field::n_set_rsp));
+    }
+
+    SECTION("N-GET command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_get_rq) == 0x0110);
+        CHECK(static_cast<uint16_t>(command_field::n_get_rsp) == 0x8110);
+        CHECK(is_request(command_field::n_get_rq));
+        CHECK(is_response(command_field::n_get_rsp));
+    }
+
+    SECTION("N-ACTION command fields") {
+        CHECK(static_cast<uint16_t>(command_field::n_action_rq) == 0x0130);
+        CHECK(static_cast<uint16_t>(command_field::n_action_rsp) == 0x8130);
+        CHECK(is_request(command_field::n_action_rq));
+        CHECK(is_response(command_field::n_action_rsp));
+    }
+
+    SECTION("all are DIMSE-N commands") {
+        CHECK(is_dimse_n(command_field::n_create_rq));
+        CHECK(is_dimse_n(command_field::n_set_rq));
+        CHECK(is_dimse_n(command_field::n_get_rq));
+        CHECK(is_dimse_n(command_field::n_action_rq));
+    }
+}
+
+// ============================================================================
+// UPS Priority Tests
+// ============================================================================
+
+TEST_CASE("ups_priority to_string conversion", "[services][ups]") {
+    CHECK(to_string(ups_priority::low) == "LOW");
+    CHECK(to_string(ups_priority::medium) == "MEDIUM");
+    CHECK(to_string(ups_priority::high) == "HIGH");
+}
+
+TEST_CASE("parse_ups_priority conversion", "[services][ups]") {
+    SECTION("valid priority strings") {
+        auto low = parse_ups_priority("LOW");
+        REQUIRE(low.has_value());
+        CHECK(low.value() == ups_priority::low);
+
+        auto medium = parse_ups_priority("MEDIUM");
+        REQUIRE(medium.has_value());
+        CHECK(medium.value() == ups_priority::medium);
+
+        auto high = parse_ups_priority("HIGH");
+        REQUIRE(high.has_value());
+        CHECK(high.value() == ups_priority::high);
+    }
+
+    SECTION("invalid priority strings return nullopt") {
+        CHECK_FALSE(parse_ups_priority("").has_value());
+        CHECK_FALSE(parse_ups_priority("INVALID").has_value());
+        CHECK_FALSE(parse_ups_priority("low").has_value());  // case sensitive
+    }
+}
+
+// ============================================================================
+// DIMSE Status Code Tests (UPS-relevant)
+// ============================================================================
+
+TEST_CASE("DIMSE status codes used by UPS Push SCP", "[services][ups]") {
+    CHECK(status_success == 0x0000);
+    CHECK(status_refused_sop_class_not_supported == 0x0122);
+    CHECK(status_error_missing_attribute == 0x0120);
+    CHECK(status_error_cannot_understand == 0xC000);
+    CHECK(status_error_unable_to_process == 0xC001);
+    CHECK(status_error_invalid_object_instance == 0x0117);
+    CHECK(status_error_no_such_action_type == 0x0123);
+}


### PR DESCRIPTION
Closes #802
Part of #789

## Summary

- Implement `ups_push_scp` class inheriting `scp_service`, following the established `mpps_scp` pattern
- Add N-CREATE, N-SET, N-GET, and N-ACTION (Type 1 + Type 3) DIMSE-N operation handlers
- Add 5 handler callback types for persistence delegation (create, set, get, change_state, request_cancel)
- Add UPS-specific DICOM tags (group 0x0074), error codes (-895 to -901), and SOP Class UID constant
- Add comprehensive unit tests (16 test cases, 116 assertions)

## Architecture

```
ups_push_scp (inherits scp_service)
├── handle_message() → dispatch on command_field
│   ├── N-CREATE → validate state=SCHEDULED, call create_handler
│   ├── N-SET    → validate not final state via N-SET, call set_handler
│   ├── N-GET    → retrieve workitem, build response dataset
│   └── N-ACTION → dispatch on action_type_id
│       ├── Type 1: Change State (with Transaction UID validation)
│       └── Type 3: Request Cancellation (with optional reason)
└── Atomic statistics counters (creates, sets, gets, actions, state_changes, cancels)
```

## Test Plan

- [x] `services_tests "[ups]"` — 16 test cases, 116 assertions pass
- [x] Full `services_tests` suite — 571 test cases, 8230 assertions pass (no regressions)
- [ ] Integration test with real association (future: UPS Push SCU)