### PR TITLE
feat(network): add HTJ2K Transfer Syntax to SCP/SCU association negotiation

### DIFF
--- a/src/network/dicom_server.cpp
+++ b/src/network/dicom_server.cpp
@@ -621,10 +621,20 @@ Result<associate_ac> dicom_server::simulate_association_request(const associate_
     negotiation_config.implementation_class_uid = config_.implementation_class_uid;
     negotiation_config.implementation_version_name = config_.implementation_version_name;
     negotiation_config.supported_abstract_syntaxes = supported_sop_classes();
-    // For now, accept all transfer syntaxes or define default list
+    // Accept compressed and uncompressed transfer syntaxes
     negotiation_config.supported_transfer_syntaxes = {
-        "1.2.840.10008.1.2.1", // Explicit VR LE
-        "1.2.840.10008.1.2"    // Implicit VR LE
+        "1.2.840.10008.1.2.4.201", // HTJ2K Lossless Only
+        "1.2.840.10008.1.2.4.202", // HTJ2K RPCL (Lossless or Lossy)
+        "1.2.840.10008.1.2.4.203", // HTJ2K Lossy
+        "1.2.840.10008.1.2.4.90",  // JPEG 2000 Lossless
+        "1.2.840.10008.1.2.4.91",  // JPEG 2000 Lossy
+        "1.2.840.10008.1.2.4.80",  // JPEG-LS Lossless
+        "1.2.840.10008.1.2.4.81",  // JPEG-LS Near-Lossless
+        "1.2.840.10008.1.2.4.70",  // JPEG Lossless
+        "1.2.840.10008.1.2.4.50",  // JPEG Baseline
+        "1.2.840.10008.1.2.5",     // RLE Lossless
+        "1.2.840.10008.1.2.1",     // Explicit VR LE
+        "1.2.840.10008.1.2"        // Implicit VR LE
     };
 
     // Accept association

--- a/src/network/v2/dicom_association_handler.cpp
+++ b/src/network/v2/dicom_association_handler.cpp
@@ -473,10 +473,20 @@ void dicom_association_handler::handle_associate_rq(const std::vector<uint8_t>& 
         scp_cfg.supported_abstract_syntaxes.push_back(uid);
     }
 
-    // Add common transfer syntaxes
+    // Accept compressed and uncompressed transfer syntaxes
     scp_cfg.supported_transfer_syntaxes = {
-        "1.2.840.10008.1.2.1",  // Explicit VR Little Endian
-        "1.2.840.10008.1.2",    // Implicit VR Little Endian
+        "1.2.840.10008.1.2.4.201", // HTJ2K Lossless Only
+        "1.2.840.10008.1.2.4.202", // HTJ2K RPCL (Lossless or Lossy)
+        "1.2.840.10008.1.2.4.203", // HTJ2K Lossy
+        "1.2.840.10008.1.2.4.90",  // JPEG 2000 Lossless
+        "1.2.840.10008.1.2.4.91",  // JPEG 2000 Lossy
+        "1.2.840.10008.1.2.4.80",  // JPEG-LS Lossless
+        "1.2.840.10008.1.2.4.81",  // JPEG-LS Near-Lossless
+        "1.2.840.10008.1.2.4.70",  // JPEG Lossless
+        "1.2.840.10008.1.2.4.50",  // JPEG Baseline
+        "1.2.840.10008.1.2.5",     // RLE Lossless
+        "1.2.840.10008.1.2.1",     // Explicit VR Little Endian
+        "1.2.840.10008.1.2",       // Implicit VR Little Endian
     };
 
     // Perform association negotiation

--- a/src/services/sop_classes/dx_storage.cpp
+++ b/src/services/sop_classes/dx_storage.cpp
@@ -49,6 +49,8 @@ std::vector<std::string> get_dx_transfer_syntaxes() {
         "1.2.840.10008.1.2.1",
         // Implicit VR Little Endian (universal baseline)
         "1.2.840.10008.1.2",
+        // HTJ2K Lossless (high-throughput lossless for large DX images)
+        "1.2.840.10008.1.2.4.201",
         // JPEG Lossless (for diagnostic quality - most important for DX)
         "1.2.840.10008.1.2.4.70",
         // JPEG 2000 Lossless (better compression, good for large DX images)

--- a/src/services/sop_classes/mg_storage.cpp
+++ b/src/services/sop_classes/mg_storage.cpp
@@ -351,6 +351,8 @@ bool is_mg_for_presentation_sop_class(std::string_view uid) noexcept {
 
 std::vector<std::string> get_mg_transfer_syntaxes() {
     return {
+        // HTJ2K Lossless - high-throughput lossless for large mammography images
+        "1.2.840.10008.1.2.4.201",
         // JPEG 2000 Lossless - excellent for high-resolution mammography
         "1.2.840.10008.1.2.4.90",
         // JPEG Lossless - widely supported

--- a/src/services/sop_classes/nm_storage.cpp
+++ b/src/services/sop_classes/nm_storage.cpp
@@ -49,6 +49,8 @@ std::vector<std::string> get_nm_transfer_syntaxes() {
         "1.2.840.10008.1.2.1",
         // Implicit VR Little Endian (universal baseline)
         "1.2.840.10008.1.2",
+        // HTJ2K Lossless (high-throughput lossless, preserves count values)
+        "1.2.840.10008.1.2.4.201",
         // JPEG Lossless (for diagnostic quality - important for quantitative data)
         "1.2.840.10008.1.2.4.70",
         // JPEG 2000 Lossless (better compression, preserves count values)

--- a/src/services/sop_classes/pet_storage.cpp
+++ b/src/services/sop_classes/pet_storage.cpp
@@ -49,6 +49,8 @@ std::vector<std::string> get_pet_transfer_syntaxes() {
         "1.2.840.10008.1.2.1",
         // Implicit VR Little Endian (universal baseline)
         "1.2.840.10008.1.2",
+        // HTJ2K Lossless (high-throughput lossless, preserves quantitative data)
+        "1.2.840.10008.1.2.4.201",
         // JPEG Lossless (for diagnostic quality - recommended for quantitative data)
         "1.2.840.10008.1.2.4.70",
         // JPEG 2000 Lossless (better compression, preserves quantitative values)

--- a/src/services/sop_classes/rt_storage.cpp
+++ b/src/services/sop_classes/rt_storage.cpp
@@ -49,6 +49,8 @@ std::vector<std::string> get_rt_transfer_syntaxes() {
         "1.2.840.10008.1.2.1",
         // Implicit VR Little Endian (universal baseline)
         "1.2.840.10008.1.2",
+        // HTJ2K Lossless (high-throughput lossless for dose grids)
+        "1.2.840.10008.1.2.4.201",
         // JPEG Lossless (for RT Image and RT Dose with pixel data)
         "1.2.840.10008.1.2.4.70",
         // JPEG 2000 Lossless (better compression for dose grids)

--- a/src/services/sop_classes/seg_storage.cpp
+++ b/src/services/sop_classes/seg_storage.cpp
@@ -50,6 +50,8 @@ std::vector<std::string> get_seg_transfer_syntaxes() {
         "1.2.840.10008.1.2.1",
         // Implicit VR Little Endian (universal baseline)
         "1.2.840.10008.1.2",
+        // HTJ2K Lossless (high-throughput lossless for segmentation data)
+        "1.2.840.10008.1.2.4.201",
         // JPEG 2000 Lossless (good for binary data)
         "1.2.840.10008.1.2.4.90",
         // RLE Lossless (excellent for binary segmentations)

--- a/src/services/sop_classes/us_storage.cpp
+++ b/src/services/sop_classes/us_storage.cpp
@@ -51,6 +51,8 @@ std::vector<std::string> get_us_transfer_syntaxes() {
         "1.2.840.10008.1.2",
         // JPEG Baseline (lossy, good for color US)
         "1.2.840.10008.1.2.4.50",
+        // HTJ2K Lossless (high-throughput lossless)
+        "1.2.840.10008.1.2.4.201",
         // JPEG Lossless (for diagnostic quality)
         "1.2.840.10008.1.2.4.70",
         // JPEG 2000 Lossless (better compression)

--- a/src/services/sop_classes/xa_storage.cpp
+++ b/src/services/sop_classes/xa_storage.cpp
@@ -50,9 +50,11 @@ std::vector<std::string> get_xa_transfer_syntaxes() {
         "1.2.840.10008.1.2.1",
         // Implicit VR Little Endian (universal baseline)
         "1.2.840.10008.1.2",
-        // JPEG Lossless (for diagnostic quality - future support)
+        // HTJ2K Lossless (high-throughput lossless for multi-frame)
+        "1.2.840.10008.1.2.4.201",
+        // JPEG Lossless (for diagnostic quality)
         "1.2.840.10008.1.2.4.70",
-        // RLE Lossless (for multi-frame - future support)
+        // RLE Lossless (for multi-frame)
         "1.2.840.10008.1.2.5"
     };
 }


### PR DESCRIPTION
Closes #804
Part of #786

## Summary

- Expand SCP `supported_transfer_syntaxes` from 2 to 12 entries in both `dicom_server.cpp` and `dicom_association_handler.cpp` (v2), adding HTJ2K (3 variants), JPEG 2000, JPEG-LS, JPEG, and RLE
- Add HTJ2K Lossless (`1.2.840.10008.1.2.4.201`) to 8 modality-specific SCU proposal lists (MG, DX, US, PET, NM, RT, XA, SEG)
- SR excluded (no pixel data)

## Architecture

The DICOM association negotiation uses a "first match" algorithm in `negotiate_contexts()`. The SCP's `supported_transfer_syntaxes` list acts as a whitelist — any proposed TS in this list is accepted. By expanding it to include all codecs supported by the codec factory, the SCP now accepts compressed transfers from modern modalities.

On the SCU side, modality-specific `get_*_transfer_syntaxes()` functions define the proposal order. HTJ2K Lossless is added after uncompressed formats for backward compatibility — peers that don't support HTJ2K will fall through to JPEG/J2K.

## Test Plan

- [x] `services_tests` — 571 test cases, 8230 assertions pass (no regressions)
- [x] `network_tests` — 191 test cases, 21916 assertions pass (no regressions)
- [ ] Integration test with HTJ2K C-STORE (future: requires HTJ2K test data)