### PR TITLE
feat(web): add HTJ2K (image/jphc) rendered output support in WADO-RS

### DIFF
--- a/include/pacs/web/endpoints/dicomweb_endpoints.hpp
+++ b/include/pacs/web/endpoints/dicomweb_endpoints.hpp
@@ -84,6 +84,7 @@ struct media_type {
     static constexpr std::string_view octet_stream = "application/octet-stream";
     static constexpr std::string_view jpeg = "image/jpeg";
     static constexpr std::string_view png = "image/png";
+    static constexpr std::string_view jphc = "image/jphc";
     static constexpr std::string_view multipart_related = "multipart/related";
 };
 
@@ -479,7 +480,8 @@ struct validation_result {
  */
 enum class rendered_format {
     jpeg,   ///< JPEG format (default)
-    png     ///< PNG format
+    png,    ///< PNG format
+    jphc    ///< HTJ2K format (image/jphc)
 };
 
 /**

--- a/src/web/endpoints/dicomweb_endpoints.cpp
+++ b/src/web/endpoints/dicomweb_endpoints.cpp
@@ -49,6 +49,7 @@
 #include "pacs/core/dicom_element.hpp"
 #include "pacs/core/dicom_file.hpp"
 #include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/encoding/compression/htj2k_codec.hpp"
 #include "pacs/encoding/compression/jpeg_baseline_codec.hpp"
 #include "pacs/encoding/transfer_syntax.hpp"
 #include "pacs/encoding/vr_type.hpp"
@@ -1228,7 +1229,9 @@ auto parse_rendered_params(
     rendered_params params;
 
     // Determine format from Accept header
-    if (accept_header.find("image/png") != std::string_view::npos) {
+    if (accept_header.find("image/jphc") != std::string_view::npos) {
+        params.format = rendered_format::jphc;
+    } else if (accept_header.find("image/png") != std::string_view::npos) {
         params.format = rendered_format::png;
     } else {
         params.format = rendered_format::jpeg;  // Default to JPEG
@@ -1483,20 +1486,32 @@ auto render_dicom_image(
         }
     }
 
-    // Encode to JPEG or PNG
-    if (params.format == rendered_format::jpeg) {
+    // Encode to requested format
+    encoding::compression::image_params img_params;
+    img_params.width = cols;
+    img_params.height = rows;
+    img_params.bits_allocated = 8;
+    img_params.bits_stored = 8;
+    img_params.high_bit = 7;
+    img_params.samples_per_pixel = samples_per_pixel;
+    img_params.photometric =
+        (samples_per_pixel == 1) ?
+        encoding::compression::photometric_interpretation::monochrome2 :
+        encoding::compression::photometric_interpretation::rgb;
+
+    if (params.format == rendered_format::jphc) {
+        encoding::compression::htj2k_codec codec(
+            /*lossless=*/false, /*use_rpcl=*/false);
+
+        auto result = codec.encode(output_pixels, img_params);
+        if (result.is_err()) {
+            return rendered_result::error("HTJ2K encoding failed: " +
+                                          result.error().message);
+        }
+
+        return rendered_result::ok(std::move(result.value().data), media_type::jphc);
+    } else if (params.format == rendered_format::jpeg) {
         encoding::compression::jpeg_baseline_codec codec;
-        encoding::compression::image_params img_params;
-        img_params.width = cols;
-        img_params.height = rows;
-        img_params.bits_allocated = 8;
-        img_params.bits_stored = 8;
-        img_params.high_bit = 7;
-        img_params.samples_per_pixel = samples_per_pixel;
-        img_params.photometric =
-            (samples_per_pixel == 1) ?
-            encoding::compression::photometric_interpretation::monochrome2 :
-            encoding::compression::photometric_interpretation::rgb;
 
         encoding::compression::compression_options opts;
         opts.quality = params.quality;
@@ -1510,7 +1525,6 @@ auto render_dicom_image(
         return rendered_result::ok(std::move(result.value().data), media_type::jpeg);
     } else {
         // PNG encoding - not implemented yet
-        // For now, return JPEG as fallback
         return rendered_result::error("PNG encoding not yet implemented");
     }
 }

--- a/tests/web/dicomweb_endpoints_test.cpp
+++ b/tests/web/dicomweb_endpoints_test.cpp
@@ -1403,6 +1403,54 @@ TEST_CASE("parse_rendered_params - accept header priority",
 }
 
 // ============================================================================
+// HTJ2K (image/jphc) Rendered Output Support
+// ============================================================================
+
+TEST_CASE("media_type::jphc constant", "[dicomweb][htj2k]") {
+    REQUIRE(media_type::jphc == "image/jphc");
+}
+
+TEST_CASE("rendered_format includes jphc value", "[dicomweb][htj2k]") {
+    rendered_format fmt = rendered_format::jphc;
+    REQUIRE(fmt != rendered_format::jpeg);
+    REQUIRE(fmt != rendered_format::png);
+}
+
+TEST_CASE("parse_rendered_params - jphc format from accept header",
+          "[dicomweb][rendered][htj2k]") {
+    auto params = parse_rendered_params("", "image/jphc");
+
+    REQUIRE(params.format == rendered_format::jphc);
+}
+
+TEST_CASE("parse_rendered_params - jphc with quality parameter",
+          "[dicomweb][rendered][htj2k]") {
+    auto params = parse_rendered_params("?quality=85", "image/jphc");
+
+    REQUIRE(params.format == rendered_format::jphc);
+    REQUIRE(params.quality == 85);
+}
+
+TEST_CASE("parse_rendered_params - jphc takes priority over png",
+          "[dicomweb][rendered][htj2k]") {
+    // jphc appears before png in the accept header
+    auto params = parse_rendered_params("", "image/jphc, image/png;q=0.5");
+
+    REQUIRE(params.format == rendered_format::jphc);
+}
+
+TEST_CASE("parse_rendered_params - jphc with viewport and frame",
+          "[dicomweb][rendered][htj2k]") {
+    auto params = parse_rendered_params(
+        "?viewport=256x256&frame=3", "image/jphc");
+
+    REQUIRE(params.format == rendered_format::jphc);
+    REQUIRE(params.viewport_width == 256);
+    REQUIRE(params.viewport_height == 256);
+    REQUIRE(params.frame == 3);
+}
+
+// ============================================================================
 // Performance Tests
 // ============================================================================
 


### PR DESCRIPTION
Closes #806

## Summary
- Add `image/jphc` media type and `rendered_format::jphc` enum value for HTJ2K rendered output
- Handle `Accept: image/jphc` header in WADO-RS rendered endpoints to select HTJ2K encoding
- Integrate `htj2k_codec` in `render_dicom_image()` for on-the-fly HTJ2K encoding of rendered frames

Part of #786

## Test plan
- [x] `media_type::jphc` constant equals `"image/jphc"`
- [x] `rendered_format::jphc` is distinct from jpeg/png
- [x] `parse_rendered_params` selects jphc format from Accept header
- [x] jphc format works with quality, viewport, and frame parameters
- [x] jphc takes priority when it appears before png in Accept header
- [x] All 17 rendered parameter tests pass (11 existing + 6 new)
- [x] All 20 HTJ2K-related tests pass
- [x] Full project builds successfully