### PR TITLE
feat(services): implement UPS Push SCU for client-side workitem management

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1052,6 +1052,7 @@ add_library(pacs_services
     src/services/print_scp.cpp
     src/services/print_scu.cpp
     src/services/ups/ups_push_scp.cpp
+    src/services/ups/ups_push_scu.cpp
     src/services/sop_class_registry.cpp
     src/services/sop_classes/us_storage.cpp
     src/services/sop_classes/dx_storage.cpp
@@ -1861,6 +1862,7 @@ if(PACS_BUILD_TESTS)
         tests/services/print_scp_test.cpp
         tests/services/print_scu_test.cpp
         tests/services/ups_push_scp_test.cpp
+        tests/services/ups_push_scu_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/core/result.hpp
+++ b/include/pacs/core/result.hpp
@@ -238,6 +238,7 @@ namespace error_codes {
     constexpr int ups_workitem_not_found = service_base - 99;
     constexpr int ups_invalid_action_type = service_base - 100;
     constexpr int ups_missing_transaction_uid = service_base - 101;
+    constexpr int ups_context_not_accepted = service_base - 102;
 } // namespace error_codes
 
 // Re-export common utility functions

--- a/include/pacs/services/ups/ups_push_scu.hpp
+++ b/include/pacs/services/ups/ups_push_scu.hpp
@@ -1,0 +1,381 @@
+/**
+ * @file ups_push_scu.hpp
+ * @brief DICOM UPS (Unified Procedure Step) Push SCU service
+ *
+ * This file provides the ups_push_scu class for creating and managing
+ * UPS workitems on remote SCP servers via N-CREATE, N-SET, N-GET,
+ * and N-ACTION operations.
+ *
+ * @see DICOM PS3.4 Annex CC - Unified Procedure Step Service
+ * @see DICOM PS3.7 Section 10 - DIMSE-N Services
+ * @see Issue #809 - UPS Push SCU Implementation
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_UPS_PUSH_SCU_HPP
+#define PACS_SERVICES_UPS_PUSH_SCU_HPP
+
+#include "ups_push_scp.hpp"
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/di/ilogger.hpp"
+#include "pacs/network/association.hpp"
+#include "pacs/network/dimse/dimse_message.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace pacs::services {
+
+// =============================================================================
+// UPS SCU Data Structures
+// =============================================================================
+
+/**
+ * @brief Data for N-CREATE operation (create new workitem)
+ *
+ * Contains attributes required to create a new UPS workitem with
+ * SCHEDULED state on a remote SCP.
+ */
+struct ups_create_data {
+    /// Workitem SOP Instance UID (generated if empty)
+    std::string workitem_uid;
+
+    /// Procedure Step Label (required)
+    std::string procedure_step_label;
+
+    /// Worklist Label
+    std::string worklist_label;
+
+    /// Priority: LOW, MEDIUM, HIGH
+    std::string priority{"MEDIUM"};
+
+    /// Scheduled start date/time (DICOM DT format)
+    std::string scheduled_start_datetime;
+
+    /// Expected completion date/time (DICOM DT format)
+    std::string expected_completion_datetime;
+
+    /// Scheduled Station Name AE
+    std::string scheduled_station_name;
+
+    /// Input Information (JSON serialized sequence data)
+    std::string input_information;
+};
+
+/**
+ * @brief Data for N-SET operation (modify workitem attributes)
+ *
+ * Contains modifications to apply to an existing UPS workitem.
+ */
+struct ups_set_data {
+    /// Workitem SOP Instance UID (required)
+    std::string workitem_uid;
+
+    /// Modification dataset
+    core::dicom_dataset modifications;
+};
+
+/**
+ * @brief Data for N-GET operation (retrieve workitem)
+ */
+struct ups_get_data {
+    /// Workitem SOP Instance UID (required)
+    std::string workitem_uid;
+
+    /// Specific attribute tags to retrieve (empty = all)
+    std::vector<core::dicom_tag> attribute_tags;
+};
+
+/**
+ * @brief Data for N-ACTION Type 1 (change UPS state)
+ */
+struct ups_change_state_data {
+    /// Workitem SOP Instance UID (required)
+    std::string workitem_uid;
+
+    /// Requested new state: "IN PROGRESS", "COMPLETED", "CANCELED"
+    std::string requested_state;
+
+    /// Transaction UID (required for claiming/completing/canceling)
+    std::string transaction_uid;
+};
+
+/**
+ * @brief Data for N-ACTION Type 3 (request cancellation)
+ */
+struct ups_request_cancel_data {
+    /// Workitem SOP Instance UID (required)
+    std::string workitem_uid;
+
+    /// Reason for cancellation request (optional)
+    std::string reason;
+};
+
+/**
+ * @brief Result of a UPS SCU operation
+ *
+ * Contains information about the outcome of any UPS DIMSE-N operation.
+ */
+struct ups_result {
+    /// Workitem SOP Instance UID
+    std::string workitem_uid;
+
+    /// DIMSE status code (0x0000 = success)
+    uint16_t status{0};
+
+    /// Error comment from the SCP (if any)
+    std::string error_comment;
+
+    /// Response dataset (for N-GET operations)
+    core::dicom_dataset attributes;
+
+    /// Time taken for the operation
+    std::chrono::milliseconds elapsed{0};
+
+    /// Check if the operation was successful
+    [[nodiscard]] bool is_success() const noexcept {
+        return status == 0x0000;
+    }
+
+    /// Check if this was a warning status
+    [[nodiscard]] bool is_warning() const noexcept {
+        return (status & 0xF000) == 0xB000;
+    }
+
+    /// Check if this was an error status
+    [[nodiscard]] bool is_error() const noexcept {
+        return !is_success() && !is_warning();
+    }
+};
+
+/**
+ * @brief Configuration for UPS Push SCU service
+ */
+struct ups_push_scu_config {
+    /// Timeout for receiving DIMSE response
+    std::chrono::milliseconds timeout{30000};
+
+    /// Auto-generate workitem UID if not provided
+    bool auto_generate_uid{true};
+};
+
+// =============================================================================
+// UPS Push SCU Class
+// =============================================================================
+
+/**
+ * @brief UPS Push SCU service for managing workitems on remote systems
+ *
+ * The UPS Push SCU (Service Class User) sends N-CREATE, N-SET, N-GET,
+ * and N-ACTION requests to remote UPS Push SCP servers to create and
+ * manage UPS workitems.
+ *
+ * ## UPS Push SCU Message Flow
+ *
+ * ```
+ * UPS Push SCU (This PACS)                  Remote UPS Push SCP
+ *  |                                        |
+ *  |  N-CREATE-RQ (Create workitem)         |
+ *  |  state = "SCHEDULED"                   |
+ *  |--------------------------------------->|
+ *  |  N-CREATE-RSP                          |
+ *  |<---------------------------------------|
+ *  |                                        |
+ *  |  N-ACTION-RQ (Claim: Type 1)           |
+ *  |  state = "IN PROGRESS"                 |
+ *  |--------------------------------------->|
+ *  |  N-ACTION-RSP                          |
+ *  |<---------------------------------------|
+ *  |                                        |
+ *  |  N-GET-RQ (Query progress)             |
+ *  |--------------------------------------->|
+ *  |  N-GET-RSP + attributes                |
+ *  |<---------------------------------------|
+ *  |                                        |
+ *  |  N-ACTION-RQ (Complete: Type 1)        |
+ *  |  state = "COMPLETED"                   |
+ *  |--------------------------------------->|
+ *  |  N-ACTION-RSP                          |
+ *  |<---------------------------------------|
+ * ```
+ *
+ * @example Basic Usage
+ * @code
+ * ups_push_scu scu;
+ *
+ * // Create a workitem
+ * ups_create_data create_data;
+ * create_data.procedure_step_label = "AI Analysis";
+ * create_data.priority = "HIGH";
+ *
+ * auto result = scu.create(assoc, create_data);
+ * if (result.is_ok() && result.value().is_success()) {
+ *     auto uid = result.value().workitem_uid;
+ *
+ *     // Claim the workitem
+ *     ups_change_state_data claim;
+ *     claim.workitem_uid = uid;
+ *     claim.requested_state = "IN PROGRESS";
+ *     claim.transaction_uid = "1.2.3.4.5";
+ *     scu.change_state(assoc, claim);
+ * }
+ * @endcode
+ */
+class ups_push_scu {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct UPS Push SCU with default configuration
+     *
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit ups_push_scu(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    /**
+     * @brief Construct UPS Push SCU with custom configuration
+     *
+     * @param config Configuration options
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit ups_push_scu(const ups_push_scu_config& config,
+                          std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~ups_push_scu() = default;
+
+    // Non-copyable, non-movable (due to atomic members)
+    ups_push_scu(const ups_push_scu&) = delete;
+    ups_push_scu& operator=(const ups_push_scu&) = delete;
+    ups_push_scu(ups_push_scu&&) = delete;
+    ups_push_scu& operator=(ups_push_scu&&) = delete;
+
+    // =========================================================================
+    // N-CREATE Operation
+    // =========================================================================
+
+    /**
+     * @brief Create a new UPS workitem on the remote SCP (N-CREATE)
+     *
+     * Creates a new workitem with SCHEDULED state. If workitem_uid is
+     * empty and auto_generate_uid is true, a unique UID will be generated.
+     *
+     * @param assoc The established association to use
+     * @param data The workitem creation data
+     * @return Result containing ups_result on success, or error
+     */
+    [[nodiscard]] network::Result<ups_result> create(
+        network::association& assoc,
+        const ups_create_data& data);
+
+    // =========================================================================
+    // N-SET Operation
+    // =========================================================================
+
+    /**
+     * @brief Modify an existing UPS workitem (N-SET)
+     *
+     * @param assoc The established association to use
+     * @param data The modification data including workitem UID and dataset
+     * @return Result containing ups_result on success, or error
+     */
+    [[nodiscard]] network::Result<ups_result> set(
+        network::association& assoc,
+        const ups_set_data& data);
+
+    // =========================================================================
+    // N-GET Operation
+    // =========================================================================
+
+    /**
+     * @brief Retrieve UPS workitem attributes from remote SCP (N-GET)
+     *
+     * @param assoc The established association to use
+     * @param data The query data including workitem UID and optional tags
+     * @return Result containing ups_result with attributes on success
+     */
+    [[nodiscard]] network::Result<ups_result> get(
+        network::association& assoc,
+        const ups_get_data& data);
+
+    // =========================================================================
+    // N-ACTION Operations
+    // =========================================================================
+
+    /**
+     * @brief Change UPS workitem state (N-ACTION Type 1)
+     *
+     * Requests a state transition for the specified workitem.
+     * Valid transitions: SCHEDULED→IN PROGRESS, IN PROGRESS→COMPLETED,
+     * IN PROGRESS→CANCELED, SCHEDULED→CANCELED.
+     *
+     * @param assoc The established association to use
+     * @param data The state change data including Transaction UID
+     * @return Result containing ups_result on success, or error
+     */
+    [[nodiscard]] network::Result<ups_result> change_state(
+        network::association& assoc,
+        const ups_change_state_data& data);
+
+    /**
+     * @brief Request cancellation of a UPS workitem (N-ACTION Type 3)
+     *
+     * @param assoc The established association to use
+     * @param data The cancellation request data
+     * @return Result containing ups_result on success, or error
+     */
+    [[nodiscard]] network::Result<ups_result> request_cancel(
+        network::association& assoc,
+        const ups_request_cancel_data& data);
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    [[nodiscard]] size_t creates_performed() const noexcept;
+    [[nodiscard]] size_t sets_performed() const noexcept;
+    [[nodiscard]] size_t gets_performed() const noexcept;
+    [[nodiscard]] size_t actions_performed() const noexcept;
+
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    [[nodiscard]] core::dicom_dataset build_create_dataset(
+        const ups_create_data& data) const;
+
+    [[nodiscard]] core::dicom_dataset build_change_state_dataset(
+        const ups_change_state_data& data) const;
+
+    [[nodiscard]] core::dicom_dataset build_request_cancel_dataset(
+        const ups_request_cancel_data& data) const;
+
+    [[nodiscard]] std::string generate_workitem_uid() const;
+
+    [[nodiscard]] uint16_t next_message_id() noexcept;
+
+    // =========================================================================
+    // Private Members
+    // =========================================================================
+
+    std::shared_ptr<di::ILogger> logger_;
+    ups_push_scu_config config_;
+    std::atomic<uint16_t> message_id_counter_{1};
+    std::atomic<size_t> creates_performed_{0};
+    std::atomic<size_t> sets_performed_{0};
+    std::atomic<size_t> gets_performed_{0};
+    std::atomic<size_t> actions_performed_{0};
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_UPS_PUSH_SCU_HPP

--- a/src/services/ups/ups_push_scu.cpp
+++ b/src/services/ups/ups_push_scu.cpp
@@ -1,0 +1,706 @@
+/**
+ * @file ups_push_scu.cpp
+ * @brief Implementation of the UPS Push SCU service
+ */
+
+#include "pacs/services/ups/ups_push_scu.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/core/result.hpp"
+#include "pacs/encoding/vr_type.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+#include <chrono>
+#include <random>
+#include <sstream>
+
+namespace pacs::services {
+
+// =============================================================================
+// Local Helper Functions
+// =============================================================================
+
+namespace {
+
+/// UID root for auto-generated UPS workitem UIDs
+constexpr const char* uid_root = "1.2.826.0.1.3680043.2.1545.3";
+
+/// Requested SOP Instance UID tag (used in N-SET/N-GET/N-ACTION command set)
+constexpr core::dicom_tag tag_requested_sop_instance_uid{0x0000, 0x1001};
+
+/**
+ * @brief Create N-CREATE request message for UPS
+ */
+network::dimse::dimse_message make_ups_n_create_rq(
+    uint16_t message_id,
+    std::string_view sop_instance_uid,
+    core::dicom_dataset dataset) {
+
+    using namespace network::dimse;
+
+    dimse_message msg{command_field::n_create_rq, message_id};
+    msg.set_affected_sop_class_uid(ups_push_sop_class_uid);
+    msg.set_affected_sop_instance_uid(sop_instance_uid);
+    msg.set_dataset(std::move(dataset));
+
+    return msg;
+}
+
+/**
+ * @brief Create N-SET request message for UPS
+ */
+network::dimse::dimse_message make_ups_n_set_rq(
+    uint16_t message_id,
+    std::string_view sop_instance_uid,
+    core::dicom_dataset modifications) {
+
+    using namespace network::dimse;
+    using namespace encoding;
+
+    dimse_message msg{command_field::n_set_rq, message_id};
+    msg.set_affected_sop_class_uid(ups_push_sop_class_uid);
+    msg.command_set().set_string(
+        tag_requested_sop_instance_uid,
+        vr_type::UI,
+        std::string(sop_instance_uid));
+    msg.set_dataset(std::move(modifications));
+
+    return msg;
+}
+
+}  // namespace
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+ups_push_scu::ups_push_scu(std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()) {}
+
+ups_push_scu::ups_push_scu(const ups_push_scu_config& config,
+                           std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()),
+      config_(config) {}
+
+// =============================================================================
+// N-CREATE Operation
+// =============================================================================
+
+network::Result<ups_result> ups_push_scu::create(
+    network::association& assoc,
+    const ups_create_data& data) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    // Verify association is established
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    // Get accepted presentation context for UPS Push
+    auto context_id = assoc.accepted_context_id(ups_push_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_context_not_accepted,
+            "No accepted presentation context for UPS Push SOP Class");
+    }
+
+    // Generate or use provided workitem UID
+    std::string uid = data.workitem_uid;
+    if (uid.empty() && config_.auto_generate_uid) {
+        uid = generate_workitem_uid();
+    }
+
+    if (uid.empty()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_missing_uid,
+            "Workitem UID is required");
+    }
+
+    // Build the creation dataset
+    auto dataset = build_create_dataset(data);
+
+    // Create the N-CREATE request
+    auto request = make_ups_n_create_rq(next_message_id(), uid, std::move(dataset));
+
+    logger_->debug("Sending N-CREATE request for UPS workitem: " + uid);
+
+    // Send the request
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-CREATE: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    // Receive the response
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-CREATE response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    // Verify it's an N-CREATE response
+    if (response.command() != command_field::n_create_rsp) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-CREATE-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    // Build result
+    ups_result result;
+    result.workitem_uid = uid;
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = elapsed;
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    creates_performed_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-CREATE successful for UPS workitem: " + uid);
+    } else {
+        logger_->warn("N-CREATE returned status 0x" +
+                      std::to_string(result.status) +
+                      " for UPS workitem: " + uid);
+    }
+
+    return result;
+}
+
+// =============================================================================
+// N-SET Operation
+// =============================================================================
+
+network::Result<ups_result> ups_push_scu::set(
+    network::association& assoc,
+    const ups_set_data& data) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    if (data.workitem_uid.empty()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_missing_uid,
+            "Workitem UID is required for N-SET");
+    }
+
+    auto context_id = assoc.accepted_context_id(ups_push_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_context_not_accepted,
+            "No accepted presentation context for UPS Push SOP Class");
+    }
+
+    // Create the N-SET request with modification dataset
+    auto request = make_ups_n_set_rq(
+        next_message_id(),
+        data.workitem_uid,
+        core::dicom_dataset(data.modifications));
+
+    logger_->debug("Sending N-SET request for UPS workitem: " + data.workitem_uid);
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-SET: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-SET response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_set_rsp) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-SET-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    ups_result result;
+    result.workitem_uid = data.workitem_uid;
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = elapsed;
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    sets_performed_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-SET successful for UPS workitem: " + data.workitem_uid);
+    } else {
+        logger_->warn("N-SET returned status 0x" +
+                      std::to_string(result.status) +
+                      " for UPS workitem: " + data.workitem_uid);
+    }
+
+    return result;
+}
+
+// =============================================================================
+// N-GET Operation
+// =============================================================================
+
+network::Result<ups_result> ups_push_scu::get(
+    network::association& assoc,
+    const ups_get_data& data) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    if (data.workitem_uid.empty()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_missing_uid,
+            "Workitem UID is required for N-GET");
+    }
+
+    auto context_id = assoc.accepted_context_id(ups_push_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_context_not_accepted,
+            "No accepted presentation context for UPS Push SOP Class");
+    }
+
+    // Use the global factory function for N-GET
+    auto request = make_n_get_rq(
+        next_message_id(),
+        ups_push_sop_class_uid,
+        data.workitem_uid,
+        data.attribute_tags);
+
+    logger_->debug("Sending N-GET request for UPS workitem: " + data.workitem_uid +
+                   " (attributes: " +
+                   (data.attribute_tags.empty() ? "all" :
+                    std::to_string(data.attribute_tags.size())) + ")");
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-GET: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-GET response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_get_rsp) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-GET-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    ups_result result;
+    result.workitem_uid = data.workitem_uid;
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = elapsed;
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    // Extract returned attributes from response dataset
+    if (response.has_dataset()) {
+        auto dataset_result = response.dataset();
+        if (dataset_result.is_ok()) {
+            result.attributes = dataset_result.value().get();
+        }
+    }
+
+    gets_performed_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-GET successful for UPS workitem: " + data.workitem_uid);
+    } else {
+        logger_->warn("N-GET returned status 0x" +
+                      std::to_string(result.status) +
+                      " for UPS workitem: " + data.workitem_uid);
+    }
+
+    return result;
+}
+
+// =============================================================================
+// N-ACTION Operations
+// =============================================================================
+
+network::Result<ups_result> ups_push_scu::change_state(
+    network::association& assoc,
+    const ups_change_state_data& data) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    if (data.workitem_uid.empty()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_missing_uid,
+            "Workitem UID is required for state change");
+    }
+
+    if (data.transaction_uid.empty()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_missing_transaction_uid,
+            "Transaction UID is required for state change");
+    }
+
+    auto context_id = assoc.accepted_context_id(ups_push_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_context_not_accepted,
+            "No accepted presentation context for UPS Push SOP Class");
+    }
+
+    // Build the N-ACTION request with action dataset
+    auto request = make_n_action_rq(
+        next_message_id(),
+        ups_push_sop_class_uid,
+        data.workitem_uid,
+        ups_action_change_state);
+
+    // Attach dataset with state and transaction UID
+    auto action_dataset = build_change_state_dataset(data);
+    request.set_dataset(std::move(action_dataset));
+
+    logger_->debug("Sending N-ACTION (Change State) for UPS workitem: " +
+                   data.workitem_uid + " -> " + data.requested_state);
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-ACTION: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-ACTION response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_action_rsp) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-ACTION-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    ups_result result;
+    result.workitem_uid = data.workitem_uid;
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = elapsed;
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    actions_performed_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-ACTION (Change State) successful for UPS workitem: " +
+                      data.workitem_uid + " -> " + data.requested_state);
+    } else {
+        logger_->warn("N-ACTION returned status 0x" +
+                      std::to_string(result.status) +
+                      " for UPS workitem: " + data.workitem_uid);
+    }
+
+    return result;
+}
+
+network::Result<ups_result> ups_push_scu::request_cancel(
+    network::association& assoc,
+    const ups_request_cancel_data& data) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    if (data.workitem_uid.empty()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_missing_uid,
+            "Workitem UID is required for cancel request");
+    }
+
+    auto context_id = assoc.accepted_context_id(ups_push_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_context_not_accepted,
+            "No accepted presentation context for UPS Push SOP Class");
+    }
+
+    // Build the N-ACTION request for cancel
+    auto request = make_n_action_rq(
+        next_message_id(),
+        ups_push_sop_class_uid,
+        data.workitem_uid,
+        ups_action_request_cancel);
+
+    // Attach dataset with cancellation reason if provided
+    if (!data.reason.empty()) {
+        auto cancel_dataset = build_request_cancel_dataset(data);
+        request.set_dataset(std::move(cancel_dataset));
+    }
+
+    logger_->debug("Sending N-ACTION (Request Cancel) for UPS workitem: " +
+                   data.workitem_uid);
+
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("Failed to send N-ACTION: " + send_result.error().message);
+        return send_result.error();
+    }
+
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("Failed to receive N-ACTION response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    if (response.command() != command_field::n_action_rsp) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-ACTION-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    ups_result result;
+    result.workitem_uid = data.workitem_uid;
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = elapsed;
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    actions_performed_.fetch_add(1, std::memory_order_relaxed);
+
+    if (result.is_success()) {
+        logger_->info("N-ACTION (Request Cancel) successful for UPS workitem: " +
+                      data.workitem_uid);
+    } else {
+        logger_->warn("N-ACTION (Request Cancel) returned status 0x" +
+                      std::to_string(result.status) +
+                      " for UPS workitem: " + data.workitem_uid);
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t ups_push_scu::creates_performed() const noexcept {
+    return creates_performed_.load(std::memory_order_relaxed);
+}
+
+size_t ups_push_scu::sets_performed() const noexcept {
+    return sets_performed_.load(std::memory_order_relaxed);
+}
+
+size_t ups_push_scu::gets_performed() const noexcept {
+    return gets_performed_.load(std::memory_order_relaxed);
+}
+
+size_t ups_push_scu::actions_performed() const noexcept {
+    return actions_performed_.load(std::memory_order_relaxed);
+}
+
+void ups_push_scu::reset_statistics() noexcept {
+    creates_performed_.store(0, std::memory_order_relaxed);
+    sets_performed_.store(0, std::memory_order_relaxed);
+    gets_performed_.store(0, std::memory_order_relaxed);
+    actions_performed_.store(0, std::memory_order_relaxed);
+}
+
+// =============================================================================
+// Private Implementation - Dataset Building
+// =============================================================================
+
+core::dicom_dataset ups_push_scu::build_create_dataset(
+    const ups_create_data& data) const {
+
+    using namespace core;
+    using namespace encoding;
+
+    dicom_dataset ds;
+
+    // Procedure Step State - always SCHEDULED for N-CREATE
+    ds.set_string(ups_tags::procedure_step_state, vr_type::CS, "SCHEDULED");
+
+    // Procedure Step Label (required)
+    if (!data.procedure_step_label.empty()) {
+        ds.set_string(ups_tags::procedure_step_label, vr_type::LO,
+                      data.procedure_step_label);
+    }
+
+    // Worklist Label
+    if (!data.worklist_label.empty()) {
+        ds.set_string(ups_tags::worklist_label, vr_type::LO,
+                      data.worklist_label);
+    }
+
+    // Priority
+    if (!data.priority.empty()) {
+        ds.set_string(ups_tags::scheduled_procedure_step_priority, vr_type::CS,
+                      data.priority);
+    }
+
+    // Scheduled start datetime
+    if (!data.scheduled_start_datetime.empty()) {
+        ds.set_string(
+            dicom_tag{0x0040, 0x4005}, vr_type::DT,
+            data.scheduled_start_datetime);
+    }
+
+    // Expected completion datetime
+    if (!data.expected_completion_datetime.empty()) {
+        ds.set_string(
+            dicom_tag{0x0040, 0x4011}, vr_type::DT,
+            data.expected_completion_datetime);
+    }
+
+    // Scheduled Station Name
+    if (!data.scheduled_station_name.empty()) {
+        ds.set_string(
+            dicom_tag{0x0040, 0x4001}, vr_type::CS,
+            data.scheduled_station_name);
+    }
+
+    return ds;
+}
+
+core::dicom_dataset ups_push_scu::build_change_state_dataset(
+    const ups_change_state_data& data) const {
+
+    using namespace core;
+    using namespace encoding;
+
+    dicom_dataset ds;
+
+    // Requested state
+    ds.set_string(ups_tags::procedure_step_state, vr_type::CS,
+                  data.requested_state);
+
+    // Transaction UID
+    ds.set_string(ups_tags::transaction_uid, vr_type::UI,
+                  data.transaction_uid);
+
+    return ds;
+}
+
+core::dicom_dataset ups_push_scu::build_request_cancel_dataset(
+    const ups_request_cancel_data& data) const {
+
+    using namespace core;
+    using namespace encoding;
+
+    dicom_dataset ds;
+
+    if (!data.reason.empty()) {
+        ds.set_string(ups_tags::reason_for_cancellation, vr_type::LT,
+                      data.reason);
+    }
+
+    return ds;
+}
+
+// =============================================================================
+// Private Implementation - Utility Functions
+// =============================================================================
+
+std::string ups_push_scu::generate_workitem_uid() const {
+    static std::mt19937_64 gen{std::random_device{}()};
+    static std::uniform_int_distribution<uint64_t> dist;
+
+    auto now = std::chrono::system_clock::now();
+    auto timestamp = std::chrono::duration_cast<std::chrono::milliseconds>(
+        now.time_since_epoch()).count();
+
+    return std::string(uid_root) + "." + std::to_string(timestamp) +
+           "." + std::to_string(dist(gen) % 100000);
+}
+
+uint16_t ups_push_scu::next_message_id() noexcept {
+    uint16_t id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    if (id == 0) {
+        id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    }
+    return id;
+}
+
+}  // namespace pacs::services

--- a/tests/services/ups_push_scu_test.cpp
+++ b/tests/services/ups_push_scu_test.cpp
@@ -1,0 +1,433 @@
+/**
+ * @file ups_push_scu_test.cpp
+ * @brief Unit tests for UPS Push SCU service
+ */
+
+#include <pacs/services/ups/ups_push_scu.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+
+// ============================================================================
+// ups_push_scu Construction Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scu construction", "[services][ups][scu]") {
+    SECTION("default construction succeeds") {
+        ups_push_scu scu;
+        CHECK(scu.creates_performed() == 0);
+        CHECK(scu.sets_performed() == 0);
+        CHECK(scu.gets_performed() == 0);
+        CHECK(scu.actions_performed() == 0);
+    }
+
+    SECTION("construction with config succeeds") {
+        ups_push_scu_config config;
+        config.timeout = std::chrono::milliseconds{60000};
+        config.auto_generate_uid = false;
+
+        ups_push_scu scu(config);
+        CHECK(scu.creates_performed() == 0);
+        CHECK(scu.sets_performed() == 0);
+        CHECK(scu.gets_performed() == 0);
+        CHECK(scu.actions_performed() == 0);
+    }
+
+    SECTION("construction with nullptr logger succeeds") {
+        ups_push_scu scu(nullptr);
+        CHECK(scu.creates_performed() == 0);
+    }
+
+    SECTION("construction with config and nullptr logger succeeds") {
+        ups_push_scu_config config;
+        ups_push_scu scu(config, nullptr);
+        CHECK(scu.creates_performed() == 0);
+    }
+}
+
+// ============================================================================
+// ups_push_scu_config Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scu_config defaults", "[services][ups][scu]") {
+    ups_push_scu_config config;
+
+    CHECK(config.timeout == std::chrono::milliseconds{30000});
+    CHECK(config.auto_generate_uid == true);
+}
+
+TEST_CASE("ups_push_scu_config customization", "[services][ups][scu]") {
+    ups_push_scu_config config;
+    config.timeout = std::chrono::milliseconds{60000};
+    config.auto_generate_uid = false;
+
+    CHECK(config.timeout == std::chrono::milliseconds{60000});
+    CHECK(config.auto_generate_uid == false);
+}
+
+// ============================================================================
+// ups_create_data Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_create_data structure", "[services][ups][scu]") {
+    ups_create_data data;
+
+    SECTION("default construction has correct defaults") {
+        CHECK(data.workitem_uid.empty());
+        CHECK(data.procedure_step_label.empty());
+        CHECK(data.worklist_label.empty());
+        CHECK(data.priority == "MEDIUM");
+        CHECK(data.scheduled_start_datetime.empty());
+        CHECK(data.expected_completion_datetime.empty());
+        CHECK(data.scheduled_station_name.empty());
+        CHECK(data.input_information.empty());
+    }
+
+    SECTION("can be initialized with values") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        data.procedure_step_label = "AI Analysis";
+        data.priority = "HIGH";
+        data.scheduled_station_name = "AI_ENGINE_01";
+
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(data.procedure_step_label == "AI Analysis");
+        CHECK(data.priority == "HIGH");
+        CHECK(data.scheduled_station_name == "AI_ENGINE_01");
+    }
+}
+
+// ============================================================================
+// ups_set_data Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_set_data structure", "[services][ups][scu]") {
+    ups_set_data data;
+
+    SECTION("default construction") {
+        CHECK(data.workitem_uid.empty());
+    }
+
+    SECTION("can be initialized with modifications") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+    }
+}
+
+// ============================================================================
+// ups_get_data Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_get_data structure", "[services][ups][scu]") {
+    ups_get_data data;
+
+    SECTION("default construction") {
+        CHECK(data.workitem_uid.empty());
+        CHECK(data.attribute_tags.empty());
+    }
+
+    SECTION("can specify attribute tags") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        data.attribute_tags = {
+            ups_tags::procedure_step_state,
+            ups_tags::procedure_step_label,
+            ups_tags::procedure_step_progress
+        };
+
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(data.attribute_tags.size() == 3);
+    }
+}
+
+// ============================================================================
+// ups_change_state_data Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_change_state_data structure", "[services][ups][scu]") {
+    ups_change_state_data data;
+
+    SECTION("default construction") {
+        CHECK(data.workitem_uid.empty());
+        CHECK(data.requested_state.empty());
+        CHECK(data.transaction_uid.empty());
+    }
+
+    SECTION("can be initialized for claiming") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        data.requested_state = "IN PROGRESS";
+        data.transaction_uid = "1.2.3.4.5.6.7.8.9";
+
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(data.requested_state == "IN PROGRESS");
+        CHECK(data.transaction_uid == "1.2.3.4.5.6.7.8.9");
+    }
+
+    SECTION("can be initialized for completion") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        data.requested_state = "COMPLETED";
+        data.transaction_uid = "1.2.3.4.5.6.7.8.9";
+
+        CHECK(data.requested_state == "COMPLETED");
+    }
+
+    SECTION("can be initialized for cancellation") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        data.requested_state = "CANCELED";
+        data.transaction_uid = "1.2.3.4.5.6.7.8.9";
+
+        CHECK(data.requested_state == "CANCELED");
+    }
+}
+
+// ============================================================================
+// ups_request_cancel_data Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_request_cancel_data structure", "[services][ups][scu]") {
+    ups_request_cancel_data data;
+
+    SECTION("default construction") {
+        CHECK(data.workitem_uid.empty());
+        CHECK(data.reason.empty());
+    }
+
+    SECTION("can be initialized with reason") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        data.reason = "Patient refused procedure";
+
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(data.reason == "Patient refused procedure");
+    }
+
+    SECTION("can be initialized without reason") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(data.reason.empty());
+    }
+}
+
+// ============================================================================
+// ups_result Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_result structure", "[services][ups][scu]") {
+    ups_result result;
+
+    SECTION("default construction") {
+        CHECK(result.workitem_uid.empty());
+        CHECK(result.status == 0);
+        CHECK(result.error_comment.empty());
+        CHECK(result.elapsed == std::chrono::milliseconds{0});
+    }
+
+    SECTION("is_success returns true for status 0x0000") {
+        result.status = 0x0000;
+        CHECK(result.is_success());
+        CHECK_FALSE(result.is_warning());
+        CHECK_FALSE(result.is_error());
+    }
+
+    SECTION("is_warning returns true for 0xBxxx status") {
+        result.status = 0xB000;
+        CHECK_FALSE(result.is_success());
+        CHECK(result.is_warning());
+        CHECK_FALSE(result.is_error());
+
+        result.status = 0xB123;
+        CHECK(result.is_warning());
+
+        result.status = 0xBFFF;
+        CHECK(result.is_warning());
+    }
+
+    SECTION("is_error returns true for error status codes") {
+        result.status = 0xC310;
+        CHECK_FALSE(result.is_success());
+        CHECK_FALSE(result.is_warning());
+        CHECK(result.is_error());
+
+        result.status = 0xA700;
+        CHECK(result.is_error());
+
+        result.status = 0x0110;
+        CHECK(result.is_error());
+    }
+
+    SECTION("can store elapsed time") {
+        result.elapsed = std::chrono::milliseconds{250};
+        CHECK(result.elapsed.count() == 250);
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("ups_push_scu statistics", "[services][ups][scu]") {
+    ups_push_scu scu;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scu.creates_performed() == 0);
+        CHECK(scu.sets_performed() == 0);
+        CHECK(scu.gets_performed() == 0);
+        CHECK(scu.actions_performed() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        scu.reset_statistics();
+        CHECK(scu.creates_performed() == 0);
+        CHECK(scu.sets_performed() == 0);
+        CHECK(scu.gets_performed() == 0);
+        CHECK(scu.actions_performed() == 0);
+    }
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple ups_push_scu instances are independent", "[services][ups][scu]") {
+    ups_push_scu scu1;
+    ups_push_scu scu2;
+
+    CHECK(scu1.creates_performed() == scu2.creates_performed());
+    CHECK(scu1.sets_performed() == scu2.sets_performed());
+    CHECK(scu1.gets_performed() == scu2.gets_performed());
+    CHECK(scu1.actions_performed() == scu2.actions_performed());
+
+    scu1.reset_statistics();
+    CHECK(scu1.creates_performed() == 0);
+    CHECK(scu2.creates_performed() == 0);
+}
+
+// ============================================================================
+// SOP Class UID Constant Test
+// ============================================================================
+
+TEST_CASE("ups_push_sop_class_uid is correct", "[services][ups][scu]") {
+    CHECK(ups_push_sop_class_uid == "1.2.840.10008.5.1.4.34.6.1");
+}
+
+// ============================================================================
+// N-ACTION Type Constants Test
+// ============================================================================
+
+TEST_CASE("UPS N-ACTION type constants", "[services][ups][scu]") {
+    CHECK(ups_action_change_state == 1);
+    CHECK(ups_action_request_cancel == 3);
+}
+
+// ============================================================================
+// UPS Tags Tests
+// ============================================================================
+
+TEST_CASE("ups_tags namespace contains UPS-specific tags", "[services][ups][scu]") {
+    using namespace ups_tags;
+
+    SECTION("procedure step state tag") {
+        CHECK(procedure_step_state == dicom_tag{0x0074, 0x1000});
+    }
+
+    SECTION("procedure step progress tag") {
+        CHECK(procedure_step_progress == dicom_tag{0x0074, 0x1004});
+    }
+
+    SECTION("scheduled procedure step priority tag") {
+        CHECK(scheduled_procedure_step_priority == dicom_tag{0x0074, 0x1200});
+    }
+
+    SECTION("worklist label tag") {
+        CHECK(worklist_label == dicom_tag{0x0074, 0x1202});
+    }
+
+    SECTION("procedure step label tag") {
+        CHECK(procedure_step_label == dicom_tag{0x0074, 0x1204});
+    }
+
+    SECTION("transaction uid tag") {
+        CHECK(transaction_uid == dicom_tag{0x0008, 0x1195});
+    }
+
+    SECTION("input information sequence tag") {
+        CHECK(input_information_sequence == dicom_tag{0x0040, 0x4021});
+    }
+
+    SECTION("reason for cancellation tag") {
+        CHECK(reason_for_cancellation == dicom_tag{0x0074, 0x1238});
+    }
+}
+
+// ============================================================================
+// Data Structure Copy and Move Tests
+// ============================================================================
+
+TEST_CASE("ups_create_data is copyable and movable", "[services][ups][scu]") {
+    ups_create_data data;
+    data.workitem_uid = "1.2.3.4.5.6.7.8";
+    data.procedure_step_label = "AI Analysis";
+    data.priority = "HIGH";
+
+    SECTION("copy construction") {
+        ups_create_data copy = data;
+        CHECK(copy.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(copy.procedure_step_label == "AI Analysis");
+        CHECK(copy.priority == "HIGH");
+    }
+
+    SECTION("move construction") {
+        ups_create_data moved = std::move(data);
+        CHECK(moved.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(moved.procedure_step_label == "AI Analysis");
+        CHECK(moved.priority == "HIGH");
+    }
+}
+
+TEST_CASE("ups_change_state_data is copyable and movable", "[services][ups][scu]") {
+    ups_change_state_data data;
+    data.workitem_uid = "1.2.3.4.5.6.7.8";
+    data.requested_state = "IN PROGRESS";
+    data.transaction_uid = "1.2.3.4.5.6.7.8.9";
+
+    SECTION("copy construction") {
+        ups_change_state_data copy = data;
+        CHECK(copy.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(copy.requested_state == "IN PROGRESS");
+        CHECK(copy.transaction_uid == "1.2.3.4.5.6.7.8.9");
+    }
+
+    SECTION("move construction") {
+        ups_change_state_data moved = std::move(data);
+        CHECK(moved.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(moved.requested_state == "IN PROGRESS");
+        CHECK(moved.transaction_uid == "1.2.3.4.5.6.7.8.9");
+    }
+}
+
+TEST_CASE("ups_result is copyable and movable", "[services][ups][scu]") {
+    ups_result result;
+    result.workitem_uid = "1.2.3.4.5.6.7.8";
+    result.status = 0x0000;
+    result.elapsed = std::chrono::milliseconds{100};
+
+    SECTION("copy construction") {
+        ups_result copy = result;
+        CHECK(copy.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(copy.status == 0x0000);
+        CHECK(copy.elapsed.count() == 100);
+    }
+
+    SECTION("move construction") {
+        ups_result moved = std::move(result);
+        CHECK(moved.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(moved.status == 0x0000);
+        CHECK(moved.elapsed.count() == 100);
+    }
+}


### PR DESCRIPTION
Closes #809
Part of #789

## Summary

- Add `ups_push_scu` class following the established `mpps_scu` pattern
- Support 5 DIMSE-N operations: N-CREATE, N-SET, N-GET, N-ACTION (Type 1: state change, Type 3: cancel request)
- Add data structures: `ups_create_data`, `ups_set_data`, `ups_get_data`, `ups_change_state_data`, `ups_request_cancel_data`, `ups_result`
- Add `ups_push_scu_config` with timeout and auto-UID generation options
- Add `ups_context_not_accepted` error code in `result.hpp`
- Add 17 unit test cases (107 assertions) covering construction, data structures, statistics, constants, and copy/move semantics

## Files

### New
- `include/pacs/services/ups/ups_push_scu.hpp` — Class declaration and data structures
- `src/services/ups/ups_push_scu.cpp` — Implementation (N-CREATE, N-SET, N-GET, N-ACTION)
- `tests/services/ups_push_scu_test.cpp` — Unit tests

### Modified
- `CMakeLists.txt` — Register source and test files
- `include/pacs/core/result.hpp` — Add `ups_context_not_accepted` error code

## Test Plan

- [x] 17/17 UPS Push SCU tests pass (107 assertions)
- [x] 32/32 all UPS-related tests pass (no regressions)
- [x] Full project builds successfully