### PR TITLE
feat(services): implement UPS Query SCP for C-FIND workitem search

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1053,6 +1053,7 @@ add_library(pacs_services
     src/services/print_scu.cpp
     src/services/ups/ups_push_scp.cpp
     src/services/ups/ups_push_scu.cpp
+    src/services/ups/ups_query_scp.cpp
     src/services/sop_class_registry.cpp
     src/services/sop_classes/us_storage.cpp
     src/services/sop_classes/dx_storage.cpp
@@ -1863,6 +1864,7 @@ if(PACS_BUILD_TESTS)
         tests/services/print_scu_test.cpp
         tests/services/ups_push_scp_test.cpp
         tests/services/ups_push_scu_test.cpp
+        tests/services/ups_query_scp_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/services/ups/ups_query_scp.hpp
+++ b/include/pacs/services/ups/ups_query_scp.hpp
@@ -1,0 +1,182 @@
+/**
+ * @file ups_query_scp.hpp
+ * @brief DICOM UPS Query SCP service (C-FIND handler for UPS workitems)
+ *
+ * This file provides the ups_query_scp class for handling C-FIND requests
+ * to search UPS workitems by state, priority, label, and other criteria.
+ *
+ * @see DICOM PS3.4 Annex CC - Unified Procedure Step Service
+ * @see DICOM PS3.7 Section 9.1 - C-FIND Service
+ * @see Issue #811 - UPS Query SCP Implementation
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_UPS_QUERY_SCP_HPP
+#define PACS_SERVICES_UPS_QUERY_SCP_HPP
+
+#include "../scp_service.hpp"
+
+#include <atomic>
+#include <functional>
+
+namespace pacs::services {
+
+// =============================================================================
+// SOP Class UID
+// =============================================================================
+
+/// UPS Query Information Model - FIND SOP Class UID (PS3.4 Table CC.2-1)
+inline constexpr std::string_view ups_query_find_sop_class_uid =
+    "1.2.840.10008.5.1.4.34.6.4";
+
+// =============================================================================
+// Handler Types
+// =============================================================================
+
+/**
+ * @brief UPS query handler function type
+ *
+ * Called by ups_query_scp to retrieve matching UPS workitems for a
+ * C-FIND query. The handler should query the database using the
+ * provided query keys and return matching workitem datasets.
+ *
+ * @param query_keys The query dataset containing search criteria:
+ *   - Procedure Step State (0074,1000)
+ *   - Scheduled Procedure Step Priority (0074,1200)
+ *   - Procedure Step Label (0074,1204)
+ *   - Worklist Label (0074,1202)
+ *   - SOP Instance UID (0008,0018) for unique key match
+ * @param calling_ae The calling AE title of the requesting system
+ * @return Vector of matching workitem datasets (empty if no matches)
+ */
+using ups_query_handler = std::function<std::vector<core::dicom_dataset>(
+    const core::dicom_dataset& query_keys,
+    const std::string& calling_ae)>;
+
+/**
+ * @brief Cancel check function type for UPS queries
+ *
+ * Called periodically during query processing to check if a C-CANCEL
+ * request has been received.
+ *
+ * @return true if cancel has been requested
+ */
+using ups_query_cancel_check = std::function<bool()>;
+
+// =============================================================================
+// UPS Query SCP Class
+// =============================================================================
+
+/**
+ * @brief UPS Query SCP service for handling workitem C-FIND requests
+ *
+ * The UPS Query SCP (Service Class Provider) responds to C-FIND
+ * requests to search for UPS workitems. It follows the same
+ * pending/final response pattern as the Modality Worklist SCP.
+ *
+ * ## UPS C-FIND Message Flow
+ *
+ * ```
+ * SCU (Scheduler/Performer)              UPS Query SCP
+ *  |                                     |
+ *  |  C-FIND-RQ                          |
+ *  |  +-------------------------------+  |
+ *  |  | SOPClass: ...34.6.4           |  |
+ *  |  | ProcedureStepState: SCHEDULED |  |
+ *  |  | Priority: HIGH               |  |
+ *  |  +-------------------------------+  |
+ *  |------------------------------------>|
+ *  |                                     |
+ *  |  C-FIND-RSP (Pending, 0xFF00)       |
+ *  |  +-------------------------------+  |
+ *  |  | WorkitemUID: 1.2.3.4...       |  |
+ *  |  | Label: "AI Analysis"         |  |
+ *  |  | State: SCHEDULED             |  |
+ *  |  +-------------------------------+  |
+ *  |<------------------------------------|
+ *  |                                     |
+ *  |  ... (repeat for each match)        |
+ *  |                                     |
+ *  |  C-FIND-RSP (Success, 0x0000)       |
+ *  |  (No dataset)                       |
+ *  |<------------------------------------|
+ * ```
+ */
+class ups_query_scp final : public scp_service {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct UPS Query SCP with optional logger
+     *
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit ups_query_scp(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~ups_query_scp() override = default;
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    void set_handler(ups_query_handler handler);
+    void set_max_results(size_t max) noexcept;
+    [[nodiscard]] size_t max_results() const noexcept;
+    void set_cancel_check(ups_query_cancel_check check);
+
+    // =========================================================================
+    // scp_service Interface Implementation
+    // =========================================================================
+
+    [[nodiscard]] std::vector<std::string> supported_sop_classes() const override;
+
+    [[nodiscard]] network::Result<std::monostate> handle_message(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request) override;
+
+    [[nodiscard]] std::string_view service_name() const noexcept override;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    [[nodiscard]] size_t queries_processed() const noexcept;
+    [[nodiscard]] size_t items_returned() const noexcept;
+
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    [[nodiscard]] network::Result<std::monostate> send_pending_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const core::dicom_dataset& result);
+
+    [[nodiscard]] network::Result<std::monostate> send_final_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        network::dimse::status_code status);
+
+    // =========================================================================
+    // Member Variables
+    // =========================================================================
+
+    ups_query_handler handler_;
+    ups_query_cancel_check cancel_check_;
+    size_t max_results_{0};  // 0 = unlimited
+    std::atomic<size_t> queries_processed_{0};
+    std::atomic<size_t> items_returned_{0};
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_UPS_QUERY_SCP_HPP

--- a/src/services/ups/ups_query_scp.cpp
+++ b/src/services/ups/ups_query_scp.cpp
@@ -1,0 +1,203 @@
+/**
+ * @file ups_query_scp.cpp
+ * @brief Implementation of the UPS Query SCP service (C-FIND for workitems)
+ */
+
+#include "pacs/services/ups/ups_query_scp.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/core/result.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+ups_query_scp::ups_query_scp(std::shared_ptr<di::ILogger> logger)
+    : scp_service(std::move(logger)) {}
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+void ups_query_scp::set_handler(ups_query_handler handler) {
+    handler_ = std::move(handler);
+}
+
+void ups_query_scp::set_max_results(size_t max) noexcept {
+    max_results_ = max;
+}
+
+size_t ups_query_scp::max_results() const noexcept {
+    return max_results_;
+}
+
+void ups_query_scp::set_cancel_check(ups_query_cancel_check check) {
+    cancel_check_ = std::move(check);
+}
+
+// =============================================================================
+// scp_service Interface Implementation
+// =============================================================================
+
+std::vector<std::string> ups_query_scp::supported_sop_classes() const {
+    return {
+        std::string(ups_query_find_sop_class_uid)
+    };
+}
+
+network::Result<std::monostate> ups_query_scp::handle_message(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Verify the message is a C-FIND request
+    if (request.command() != command_field::c_find_rq) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected C-FIND-RQ but received " +
+            std::string(to_string(request.command())));
+    }
+
+    // Verify we have a handler
+    if (!handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_handler_not_set,
+            "No UPS query handler configured");
+    }
+
+    // Get the SOP Class UID from the request
+    auto sop_class_uid = request.affected_sop_class_uid();
+
+    // Verify the SOP Class is UPS Query FIND
+    if (sop_class_uid != ups_query_find_sop_class_uid) {
+        return send_final_response(
+            assoc, context_id, request.message_id(),
+            status_refused_sop_class_not_supported);
+    }
+
+    // Verify we have a dataset (query keys)
+    if (!request.has_dataset()) {
+        return send_final_response(
+            assoc, context_id, request.message_id(),
+            status_error_cannot_understand);
+    }
+
+    // Get the query keys from the request
+    const auto& query_keys = request.dataset().value().get();
+
+    // Get calling AE for logging and access control
+    std::string calling_ae{assoc.calling_ae()};
+
+    logger_->debug("Processing UPS C-FIND query from " + calling_ae);
+
+    // Call the handler to get matching workitems
+    auto results = handler_(query_keys, calling_ae);
+
+    // Apply max results limit if configured
+    if (max_results_ > 0 && results.size() > max_results_) {
+        results.resize(max_results_);
+    }
+
+    // Send pending responses for each result
+    for (const auto& result : results) {
+        // Check for cancel request
+        if (cancel_check_ && cancel_check_()) {
+            ++queries_processed_;
+
+            return send_final_response(
+                assoc, context_id, request.message_id(),
+                status_cancel);
+        }
+
+        // Send pending response with matching workitem
+        auto send_result = send_pending_response(
+            assoc, context_id, request.message_id(),
+            result);
+
+        if (send_result.is_err()) {
+            return send_result;
+        }
+
+        ++items_returned_;
+    }
+
+    // Increment statistics
+    ++queries_processed_;
+
+    logger_->info("UPS C-FIND completed: " + std::to_string(results.size()) +
+                  " workitems matched");
+
+    // Send final success response (no dataset)
+    return send_final_response(
+        assoc, context_id, request.message_id(),
+        status_success);
+}
+
+std::string_view ups_query_scp::service_name() const noexcept {
+    return "UPS Query SCP";
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t ups_query_scp::queries_processed() const noexcept {
+    return queries_processed_.load();
+}
+
+size_t ups_query_scp::items_returned() const noexcept {
+    return items_returned_.load();
+}
+
+void ups_query_scp::reset_statistics() noexcept {
+    queries_processed_ = 0;
+    items_returned_ = 0;
+}
+
+// =============================================================================
+// Private Implementation
+// =============================================================================
+
+network::Result<std::monostate> ups_query_scp::send_pending_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const core::dicom_dataset& result) {
+
+    using namespace network::dimse;
+
+    auto response = make_c_find_rsp(
+        message_id,
+        ups_query_find_sop_class_uid,
+        status_pending
+    );
+
+    response.set_dataset(result);
+
+    return assoc.send_dimse(context_id, response);
+}
+
+network::Result<std::monostate> ups_query_scp::send_final_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    auto response = make_c_find_rsp(
+        message_id,
+        ups_query_find_sop_class_uid,
+        status
+    );
+
+    return assoc.send_dimse(context_id, response);
+}
+
+}  // namespace pacs::services

--- a/tests/services/ups_query_scp_test.cpp
+++ b/tests/services/ups_query_scp_test.cpp
@@ -1,0 +1,353 @@
+/**
+ * @file ups_query_scp_test.cpp
+ * @brief Unit tests for UPS Query SCP service (C-FIND for workitems)
+ */
+
+#include <pacs/services/ups/ups_query_scp.hpp>
+#include <pacs/services/ups/ups_push_scp.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+// ============================================================================
+// ups_query_scp Construction Tests
+// ============================================================================
+
+TEST_CASE("ups_query_scp construction", "[services][ups][query]") {
+    ups_query_scp scp;
+
+    SECTION("service name is correct") {
+        CHECK(scp.service_name() == "UPS Query SCP");
+    }
+
+    SECTION("supports one SOP class") {
+        auto classes = scp.supported_sop_classes();
+        CHECK(classes.size() == 1);
+    }
+
+    SECTION("default max_results is unlimited (0)") {
+        CHECK(scp.max_results() == 0);
+    }
+
+    SECTION("initial queries_processed is zero") {
+        CHECK(scp.queries_processed() == 0);
+    }
+
+    SECTION("initial items_returned is zero") {
+        CHECK(scp.items_returned() == 0);
+    }
+}
+
+// ============================================================================
+// SOP Class Support Tests
+// ============================================================================
+
+TEST_CASE("ups_query_scp SOP class support", "[services][ups][query]") {
+    ups_query_scp scp;
+
+    SECTION("supports UPS Query FIND") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.4"));
+        CHECK(scp.supports_sop_class(ups_query_find_sop_class_uid));
+    }
+
+    SECTION("does not support UPS Push SOP Class") {
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.1"));
+    }
+
+    SECTION("does not support Modality Worklist FIND") {
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.31"));
+    }
+
+    SECTION("does not support non-UPS SOP classes") {
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.1.1"));
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.1.1.2"));
+        CHECK_FALSE(scp.supports_sop_class(""));
+    }
+}
+
+// ============================================================================
+// SOP Class UID Constant Tests
+// ============================================================================
+
+TEST_CASE("ups_query_find_sop_class_uid constant", "[services][ups][query]") {
+    CHECK(ups_query_find_sop_class_uid == "1.2.840.10008.5.1.4.34.6.4");
+}
+
+// ============================================================================
+// Configuration Tests
+// ============================================================================
+
+TEST_CASE("ups_query_scp configuration", "[services][ups][query]") {
+    ups_query_scp scp;
+
+    SECTION("set_max_results updates max_results") {
+        scp.set_max_results(50);
+        CHECK(scp.max_results() == 50);
+
+        scp.set_max_results(0);
+        CHECK(scp.max_results() == 0);
+
+        scp.set_max_results(1000);
+        CHECK(scp.max_results() == 1000);
+    }
+
+    SECTION("set_handler accepts lambda") {
+        bool handler_called = false;
+        scp.set_handler([&handler_called](
+            [[maybe_unused]] const dicom_dataset& keys,
+            [[maybe_unused]] const std::string& ae) {
+            handler_called = true;
+            return std::vector<dicom_dataset>{};
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("set_cancel_check accepts lambda") {
+        bool cancel_called = false;
+        scp.set_cancel_check([&cancel_called]() {
+            cancel_called = true;
+            return false;
+        });
+        CHECK_FALSE(cancel_called);
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("ups_query_scp statistics", "[services][ups][query]") {
+    ups_query_scp scp;
+
+    SECTION("queries_processed starts at zero") {
+        CHECK(scp.queries_processed() == 0);
+    }
+
+    SECTION("items_returned starts at zero") {
+        CHECK(scp.items_returned() == 0);
+    }
+
+    SECTION("reset_statistics resets all counters") {
+        scp.reset_statistics();
+        CHECK(scp.queries_processed() == 0);
+        CHECK(scp.items_returned() == 0);
+    }
+}
+
+// ============================================================================
+// C-FIND Message Factory Tests (with UPS Query SOP Class)
+// ============================================================================
+
+TEST_CASE("make_c_find_rq for UPS Query creates valid request", "[services][ups][query]") {
+    auto request = make_c_find_rq(42, ups_query_find_sop_class_uid);
+
+    CHECK(request.command() == command_field::c_find_rq);
+    CHECK(request.message_id() == 42);
+    CHECK(request.affected_sop_class_uid() == "1.2.840.10008.5.1.4.34.6.4");
+    CHECK(request.is_request());
+    CHECK_FALSE(request.is_response());
+}
+
+TEST_CASE("make_c_find_rsp for UPS Query creates valid response", "[services][ups][query]") {
+    SECTION("pending response") {
+        auto response = make_c_find_rsp(42, ups_query_find_sop_class_uid, status_pending);
+
+        CHECK(response.command() == command_field::c_find_rsp);
+        CHECK(response.message_id_responded_to() == 42);
+        CHECK(response.affected_sop_class_uid() == "1.2.840.10008.5.1.4.34.6.4");
+        CHECK(response.status() == status_pending);
+        CHECK(response.is_response());
+    }
+
+    SECTION("success response") {
+        auto response = make_c_find_rsp(123, ups_query_find_sop_class_uid, status_success);
+
+        CHECK(response.status() == status_success);
+    }
+
+    SECTION("cancel response") {
+        auto response = make_c_find_rsp(456, ups_query_find_sop_class_uid, status_cancel);
+
+        CHECK(response.status() == status_cancel);
+    }
+}
+
+// ============================================================================
+// Handler Tests
+// ============================================================================
+
+TEST_CASE("ups_query_handler function type", "[services][ups][query]") {
+    ups_query_handler handler = [](
+        [[maybe_unused]] const dicom_dataset& query_keys,
+        [[maybe_unused]] const std::string& calling_ae) {
+        std::vector<dicom_dataset> results;
+
+        dicom_dataset item;
+        item.set_string(ups_tags::procedure_step_state, vr_type::CS, "SCHEDULED");
+        item.set_string(ups_tags::procedure_step_label, vr_type::LO, "AI Analysis");
+        item.set_string(ups_tags::scheduled_procedure_step_priority, vr_type::CS, "HIGH");
+        results.push_back(item);
+
+        return results;
+    };
+
+    dicom_dataset query;
+    std::string ae = "AI_ENGINE";
+
+    auto results = handler(query, ae);
+
+    CHECK(results.size() == 1);
+    CHECK(results[0].get_string(ups_tags::procedure_step_state) == "SCHEDULED");
+    CHECK(results[0].get_string(ups_tags::procedure_step_label) == "AI Analysis");
+    CHECK(results[0].get_string(ups_tags::scheduled_procedure_step_priority) == "HIGH");
+}
+
+TEST_CASE("ups_query_cancel_check function type", "[services][ups][query]") {
+    SECTION("returns false by default") {
+        ups_query_cancel_check check = []() {
+            return false;
+        };
+        CHECK_FALSE(check());
+    }
+
+    SECTION("can return true to indicate cancel") {
+        ups_query_cancel_check check = []() {
+            return true;
+        };
+        CHECK(check());
+    }
+}
+
+TEST_CASE("ups_query_scp handler integration", "[services][ups][query]") {
+    ups_query_scp scp;
+    std::vector<dicom_dataset> test_results;
+
+    dicom_dataset item1;
+    item1.set_string(ups_tags::procedure_step_state, vr_type::CS, "SCHEDULED");
+    item1.set_string(ups_tags::procedure_step_label, vr_type::LO, "CT Review");
+    item1.set_string(ups_tags::scheduled_procedure_step_priority, vr_type::CS, "MEDIUM");
+
+    dicom_dataset item2;
+    item2.set_string(ups_tags::procedure_step_state, vr_type::CS, "SCHEDULED");
+    item2.set_string(ups_tags::procedure_step_label, vr_type::LO, "MR Analysis");
+    item2.set_string(ups_tags::scheduled_procedure_step_priority, vr_type::CS, "HIGH");
+
+    test_results.push_back(item1);
+    test_results.push_back(item2);
+
+    std::string captured_ae;
+    bool handler_called = false;
+
+    scp.set_handler([&](
+                        [[maybe_unused]] const dicom_dataset& keys,
+                        const std::string& ae) {
+        handler_called = true;
+        captured_ae = ae;
+        return test_results;
+    });
+
+    SECTION("handler is stored but not called until handle_message") {
+        CHECK_FALSE(handler_called);
+    }
+}
+
+// ============================================================================
+// scp_service Base Class Tests
+// ============================================================================
+
+TEST_CASE("ups_query_scp is a scp_service", "[services][ups][query]") {
+    std::unique_ptr<scp_service> base_ptr = std::make_unique<ups_query_scp>();
+
+    CHECK(base_ptr->service_name() == "UPS Query SCP");
+    CHECK(base_ptr->supported_sop_classes().size() == 1);
+    CHECK(base_ptr->supports_sop_class(ups_query_find_sop_class_uid));
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple ups_query_scp instances are independent", "[services][ups][query]") {
+    ups_query_scp scp1;
+    ups_query_scp scp2;
+
+    scp1.set_max_results(50);
+    scp2.set_max_results(200);
+
+    CHECK(scp1.max_results() == 50);
+    CHECK(scp2.max_results() == 200);
+
+    scp1.reset_statistics();
+    CHECK(scp1.queries_processed() == 0);
+    CHECK(scp1.items_returned() == 0);
+    CHECK(scp2.queries_processed() == 0);
+    CHECK(scp2.items_returned() == 0);
+}
+
+// ============================================================================
+// UPS Query Key Dataset Creation Tests
+// ============================================================================
+
+TEST_CASE("create UPS query keys dataset", "[services][ups][query]") {
+    dicom_dataset query_keys;
+
+    SECTION("query by state") {
+        query_keys.set_string(ups_tags::procedure_step_state, vr_type::CS, "SCHEDULED");
+
+        CHECK(query_keys.get_string(ups_tags::procedure_step_state) == "SCHEDULED");
+    }
+
+    SECTION("query by priority") {
+        query_keys.set_string(ups_tags::scheduled_procedure_step_priority, vr_type::CS, "HIGH");
+
+        CHECK(query_keys.get_string(ups_tags::scheduled_procedure_step_priority) == "HIGH");
+    }
+
+    SECTION("query by label with wildcard") {
+        query_keys.set_string(ups_tags::procedure_step_label, vr_type::LO, "AI*");
+
+        CHECK(query_keys.get_string(ups_tags::procedure_step_label) == "AI*");
+    }
+
+    SECTION("query with multiple criteria") {
+        query_keys.set_string(ups_tags::procedure_step_state, vr_type::CS, "SCHEDULED");
+        query_keys.set_string(ups_tags::scheduled_procedure_step_priority, vr_type::CS, "HIGH");
+        query_keys.set_string(ups_tags::worklist_label, vr_type::LO, "");
+
+        CHECK(query_keys.get_string(ups_tags::procedure_step_state) == "SCHEDULED");
+        CHECK(query_keys.get_string(ups_tags::scheduled_procedure_step_priority) == "HIGH");
+        CHECK(query_keys.get_string(ups_tags::worklist_label).empty());
+    }
+}
+
+// ============================================================================
+// UPS Workitem Result Dataset Tests
+// ============================================================================
+
+TEST_CASE("create UPS workitem result dataset", "[services][ups][query]") {
+    dicom_dataset workitem;
+
+    workitem.set_string(tags::sop_instance_uid, vr_type::UI, "1.2.3.4.5.6.7.8");
+    workitem.set_string(ups_tags::procedure_step_state, vr_type::CS, "SCHEDULED");
+    workitem.set_string(ups_tags::procedure_step_label, vr_type::LO, "CT Chest Review");
+    workitem.set_string(ups_tags::scheduled_procedure_step_priority, vr_type::CS, "MEDIUM");
+    workitem.set_string(ups_tags::worklist_label, vr_type::LO, "Radiology");
+
+    SECTION("workitem attributes are set correctly") {
+        CHECK(workitem.get_string(tags::sop_instance_uid) == "1.2.3.4.5.6.7.8");
+        CHECK(workitem.get_string(ups_tags::procedure_step_state) == "SCHEDULED");
+        CHECK(workitem.get_string(ups_tags::procedure_step_label) == "CT Chest Review");
+        CHECK(workitem.get_string(ups_tags::scheduled_procedure_step_priority) == "MEDIUM");
+        CHECK(workitem.get_string(ups_tags::worklist_label) == "Radiology");
+    }
+}


### PR DESCRIPTION
Closes #811

## Summary
- Add `ups_query_scp` class that handles C-FIND requests to search UPS workitems
- Support UPS Query FIND SOP Class UID (`1.2.840.10008.5.1.4.34.6.4`) per DICOM PS3.4 Annex CC
- Follow the same pending/final response pattern as the existing Modality Worklist SCP
- Include configurable max results limiting and cancel check support
- Add atomic statistics counters (`queries_processed`, `items_returned`)

## Files Changed
- `include/pacs/services/ups/ups_query_scp.hpp` — Header with class declaration, handler types, SOP Class UID constant
- `src/services/ups/ups_query_scp.cpp` — Implementation with C-FIND message handling
- `tests/services/ups_query_scp_test.cpp` — 14 test cases (construction, SOP class, config, stats, message factory, handlers)
- `CMakeLists.txt` — Register source and test files

## Test Plan
- [x] All 10 UPS Query SCP tests pass (100%)
- [x] All 69 UPS-related tests pass (Push SCP + Push SCU + Query SCP + storage layer)
- [x] Full project builds cleanly with no errors