### PR TITLE
feat(services): implement UPS Watch SCP for subscription and event notification

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1054,6 +1054,7 @@ add_library(pacs_services
     src/services/ups/ups_push_scp.cpp
     src/services/ups/ups_push_scu.cpp
     src/services/ups/ups_query_scp.cpp
+    src/services/ups/ups_watch_scp.cpp
     src/services/sop_class_registry.cpp
     src/services/sop_classes/us_storage.cpp
     src/services/sop_classes/dx_storage.cpp
@@ -1865,6 +1866,7 @@ if(PACS_BUILD_TESTS)
         tests/services/ups_push_scp_test.cpp
         tests/services/ups_push_scu_test.cpp
         tests/services/ups_query_scp_test.cpp
+        tests/services/ups_watch_scp_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/services/ups/ups_watch_scp.hpp
+++ b/include/pacs/services/ups/ups_watch_scp.hpp
@@ -1,0 +1,310 @@
+/**
+ * @file ups_watch_scp.hpp
+ * @brief DICOM UPS Watch SCP service (subscription and event notification)
+ *
+ * This file provides the ups_watch_scp class for handling N-ACTION
+ * subscribe/unsubscribe requests and dispatching N-EVENT-REPORT
+ * notifications when UPS workitems change state.
+ *
+ * @see DICOM PS3.4 Annex CC.2.3 - UPS Watch SOP Class
+ * @see DICOM PS3.4 CC.2.4 - N-EVENT-REPORT for UPS
+ * @see Issue #813 - UPS Watch SCP Implementation
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_UPS_WATCH_SCP_HPP
+#define PACS_SERVICES_UPS_WATCH_SCP_HPP
+
+#include "../scp_service.hpp"
+
+#include <atomic>
+#include <functional>
+
+namespace pacs::services {
+
+// =============================================================================
+// SOP Class UID
+// =============================================================================
+
+/// UPS Watch SOP Class UID (PS3.4 Table CC.2-1)
+inline constexpr std::string_view ups_watch_sop_class_uid =
+    "1.2.840.10008.5.1.4.34.6.2";
+
+// =============================================================================
+// Well-Known SOP Instance UID
+// =============================================================================
+
+/// UPS Global Subscription SOP Instance UID
+/// Used as the SOP Instance UID for global (non-workitem-specific) subscriptions
+inline constexpr std::string_view ups_global_subscription_instance_uid =
+    "1.2.840.10008.5.1.4.34.5";
+
+// =============================================================================
+// N-ACTION Type Constants for UPS Watch
+// =============================================================================
+
+/// N-ACTION Type 3: Subscribe to Receive UPS Event Reports (PS3.4 CC.2.3.3)
+inline constexpr uint16_t ups_watch_action_subscribe = 3;
+
+/// N-ACTION Type 4: Unsubscribe from Receiving UPS Event Reports (PS3.4 CC.2.3.4)
+inline constexpr uint16_t ups_watch_action_unsubscribe = 4;
+
+/// N-ACTION Type 5: Suspend Global Subscription (PS3.4 CC.2.3.5)
+inline constexpr uint16_t ups_watch_action_suspend_global = 5;
+
+// =============================================================================
+// N-EVENT-REPORT Event Type Constants
+// =============================================================================
+
+/// Event Type 1: UPS State Report — workitem state changed
+inline constexpr uint16_t ups_event_state_report = 1;
+
+/// Event Type 2: UPS Cancel Requested — performer should stop processing
+inline constexpr uint16_t ups_event_cancel_requested = 2;
+
+/// Event Type 3: UPS Progress Report — progress percentage update
+inline constexpr uint16_t ups_event_progress_report = 3;
+
+/// Event Type 4: SCP Status Change — SCP going down/restarting
+inline constexpr uint16_t ups_event_scp_status_change = 4;
+
+// =============================================================================
+// Handler Types
+// =============================================================================
+
+/**
+ * @brief Subscribe handler function type
+ *
+ * Called when an N-ACTION subscribe request is received. The handler should
+ * persist the subscription (e.g., to the ups_subscriptions database table).
+ *
+ * @param subscriber_ae The AE Title of the subscribing system
+ * @param workitem_uid The specific workitem UID (empty for global subscription)
+ * @param deletion_lock Whether deletion lock is requested
+ * @return Success if the subscription was created, error otherwise
+ */
+using ups_subscribe_handler = std::function<network::Result<std::monostate>(
+    const std::string& subscriber_ae,
+    const std::string& workitem_uid,
+    bool deletion_lock)>;
+
+/**
+ * @brief Unsubscribe handler function type
+ *
+ * Called when an N-ACTION unsubscribe request is received. The handler should
+ * remove the subscription from persistence.
+ *
+ * @param subscriber_ae The AE Title of the unsubscribing system
+ * @param workitem_uid The specific workitem UID (empty for global unsubscription)
+ * @return Success if the subscription was removed, error otherwise
+ */
+using ups_unsubscribe_handler = std::function<network::Result<std::monostate>(
+    const std::string& subscriber_ae,
+    const std::string& workitem_uid)>;
+
+/**
+ * @brief Get subscribers handler function type
+ *
+ * Called to retrieve subscriber AE titles for a specific workitem.
+ * Used when sending N-EVENT-REPORT notifications.
+ *
+ * @param workitem_uid The workitem UID to find subscribers for
+ * @return Vector of subscriber AE titles
+ */
+using ups_get_subscribers_handler = std::function<
+    network::Result<std::vector<std::string>>(
+        const std::string& workitem_uid)>;
+
+/**
+ * @brief Event notification callback type
+ *
+ * Called by the Watch SCP when an event needs to be dispatched to subscribers.
+ * The application layer is responsible for establishing the network connection
+ * and sending the N-EVENT-REPORT to each subscriber.
+ *
+ * @param subscriber_ae The AE Title of the subscriber to notify
+ * @param event_type_id The event type (ups_event_state_report, etc.)
+ * @param workitem_uid The workitem UID that triggered the event
+ * @param event_info Dataset containing event details
+ */
+using ups_event_callback = std::function<void(
+    const std::string& subscriber_ae,
+    uint16_t event_type_id,
+    const std::string& workitem_uid,
+    const core::dicom_dataset& event_info)>;
+
+// =============================================================================
+// UPS Watch SCP Class
+// =============================================================================
+
+/**
+ * @brief UPS Watch SCP service for subscription and event notification
+ *
+ * The UPS Watch SCP handles subscribe/unsubscribe N-ACTION requests and
+ * provides event notification infrastructure. When workitem state changes
+ * occur (triggered externally, e.g., by UPS Push SCP), the Watch SCP
+ * notifies all relevant subscribers via the event callback.
+ *
+ * ## UPS Watch Message Flow
+ *
+ * ```
+ * Subscriber (SCU)                     UPS Watch SCP
+ *  |                                   |
+ *  |  N-ACTION-RQ (Subscribe, Type 3)  |
+ *  |  WorkitemUID: 1.2.3.4...         |
+ *  |---------------------------------->|
+ *  |  N-ACTION-RSP (Success)           |
+ *  |<----------------------------------|
+ *  |                                   |
+ *  |  [Workitem state changes]         |
+ *  |                                   |
+ *  |  N-EVENT-REPORT-RQ (Type 1)       |
+ *  |  State: COMPLETED                |
+ *  |<----------------------------------|
+ *  |  N-EVENT-REPORT-RSP               |
+ *  |---------------------------------->|
+ *  |                                   |
+ *  |  N-ACTION-RQ (Unsubscribe, Type 4)|
+ *  |---------------------------------->|
+ *  |  N-ACTION-RSP (Success)           |
+ *  |<----------------------------------|
+ * ```
+ */
+class ups_watch_scp final : public scp_service {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct UPS Watch SCP with optional logger
+     *
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit ups_watch_scp(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~ups_watch_scp() override = default;
+
+    // =========================================================================
+    // Configuration
+    // =========================================================================
+
+    void set_subscribe_handler(ups_subscribe_handler handler);
+    void set_unsubscribe_handler(ups_unsubscribe_handler handler);
+    void set_get_subscribers_handler(ups_get_subscribers_handler handler);
+    void set_event_callback(ups_event_callback callback);
+
+    // =========================================================================
+    // scp_service Interface Implementation
+    // =========================================================================
+
+    [[nodiscard]] std::vector<std::string> supported_sop_classes() const override;
+
+    [[nodiscard]] network::Result<std::monostate> handle_message(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request) override;
+
+    [[nodiscard]] std::string_view service_name() const noexcept override;
+
+    // =========================================================================
+    // Event Notification
+    // =========================================================================
+
+    /**
+     * @brief Notify subscribers of a workitem state change
+     *
+     * Looks up subscribers for the given workitem and dispatches
+     * UPS State Report events via the event callback.
+     *
+     * @param workitem_uid The workitem that changed state
+     * @param new_state The new state string
+     */
+    void notify_state_change(const std::string& workitem_uid,
+                             const std::string& new_state);
+
+    /**
+     * @brief Notify subscribers of a cancel request
+     *
+     * @param workitem_uid The workitem for which cancel was requested
+     * @param reason The cancellation reason (may be empty)
+     */
+    void notify_cancel_requested(const std::string& workitem_uid,
+                                 const std::string& reason);
+
+    /**
+     * @brief Notify subscribers of progress update
+     *
+     * @param workitem_uid The workitem that reported progress
+     * @param progress_percent The progress percentage (0-100)
+     */
+    void notify_progress(const std::string& workitem_uid,
+                         int progress_percent);
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    [[nodiscard]] size_t subscriptions_created() const noexcept;
+    [[nodiscard]] size_t subscriptions_removed() const noexcept;
+    [[nodiscard]] size_t events_sent() const noexcept;
+
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    [[nodiscard]] network::Result<std::monostate> handle_n_action(
+        network::association& assoc,
+        uint8_t context_id,
+        const network::dimse::dimse_message& request);
+
+    [[nodiscard]] network::Result<std::monostate> handle_subscribe(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid);
+
+    [[nodiscard]] network::Result<std::monostate> handle_unsubscribe(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid);
+
+    [[nodiscard]] network::Result<std::monostate> handle_suspend_global(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id);
+
+    [[nodiscard]] network::Result<std::monostate> send_n_action_response(
+        network::association& assoc,
+        uint8_t context_id,
+        uint16_t message_id,
+        const std::string& sop_instance_uid,
+        uint16_t action_type_id,
+        network::dimse::status_code status);
+
+    void dispatch_event(uint16_t event_type_id,
+                        const std::string& workitem_uid,
+                        const core::dicom_dataset& event_info);
+
+    // =========================================================================
+    // Member Variables
+    // =========================================================================
+
+    ups_subscribe_handler subscribe_handler_;
+    ups_unsubscribe_handler unsubscribe_handler_;
+    ups_get_subscribers_handler get_subscribers_handler_;
+    ups_event_callback event_callback_;
+
+    std::atomic<size_t> subscriptions_created_{0};
+    std::atomic<size_t> subscriptions_removed_{0};
+    std::atomic<size_t> events_sent_{0};
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_UPS_WATCH_SCP_HPP

--- a/src/services/ups/ups_watch_scp.cpp
+++ b/src/services/ups/ups_watch_scp.cpp
@@ -1,0 +1,394 @@
+/**
+ * @file ups_watch_scp.cpp
+ * @brief Implementation of the UPS Watch SCP service
+ */
+
+#include "pacs/services/ups/ups_watch_scp.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/core/result.hpp"
+#include "pacs/encoding/vr_type.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+#include "pacs/services/ups/ups_push_scp.hpp"
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+ups_watch_scp::ups_watch_scp(std::shared_ptr<di::ILogger> logger)
+    : scp_service(std::move(logger)) {}
+
+// =============================================================================
+// Configuration
+// =============================================================================
+
+void ups_watch_scp::set_subscribe_handler(ups_subscribe_handler handler) {
+    subscribe_handler_ = std::move(handler);
+}
+
+void ups_watch_scp::set_unsubscribe_handler(ups_unsubscribe_handler handler) {
+    unsubscribe_handler_ = std::move(handler);
+}
+
+void ups_watch_scp::set_get_subscribers_handler(
+    ups_get_subscribers_handler handler) {
+    get_subscribers_handler_ = std::move(handler);
+}
+
+void ups_watch_scp::set_event_callback(ups_event_callback callback) {
+    event_callback_ = std::move(callback);
+}
+
+// =============================================================================
+// scp_service Interface Implementation
+// =============================================================================
+
+std::vector<std::string> ups_watch_scp::supported_sop_classes() const {
+    return {
+        std::string(ups_watch_sop_class_uid)
+    };
+}
+
+network::Result<std::monostate> ups_watch_scp::handle_message(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    if (request.command() != command_field::n_action_rq) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-ACTION-RQ but received " +
+            std::string(to_string(request.command())));
+    }
+
+    return handle_n_action(assoc, context_id, request);
+}
+
+std::string_view ups_watch_scp::service_name() const noexcept {
+    return "UPS Watch SCP";
+}
+
+// =============================================================================
+// Event Notification
+// =============================================================================
+
+void ups_watch_scp::notify_state_change(
+    const std::string& workitem_uid,
+    const std::string& new_state) {
+
+    core::dicom_dataset event_info;
+    event_info.set_string(
+        ups_tags::procedure_step_state,
+        encoding::vr_type::CS, new_state);
+
+    dispatch_event(ups_event_state_report, workitem_uid, event_info);
+}
+
+void ups_watch_scp::notify_cancel_requested(
+    const std::string& workitem_uid,
+    const std::string& reason) {
+
+    core::dicom_dataset event_info;
+    if (!reason.empty()) {
+        event_info.set_string(
+            ups_tags::reason_for_cancellation,
+            encoding::vr_type::LT, reason);
+    }
+
+    dispatch_event(ups_event_cancel_requested, workitem_uid, event_info);
+}
+
+void ups_watch_scp::notify_progress(
+    const std::string& workitem_uid,
+    int progress_percent) {
+
+    core::dicom_dataset event_info;
+    event_info.set_string(
+        ups_tags::procedure_step_progress,
+        encoding::vr_type::DS, std::to_string(progress_percent));
+
+    dispatch_event(ups_event_progress_report, workitem_uid, event_info);
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t ups_watch_scp::subscriptions_created() const noexcept {
+    return subscriptions_created_.load();
+}
+
+size_t ups_watch_scp::subscriptions_removed() const noexcept {
+    return subscriptions_removed_.load();
+}
+
+size_t ups_watch_scp::events_sent() const noexcept {
+    return events_sent_.load();
+}
+
+void ups_watch_scp::reset_statistics() noexcept {
+    subscriptions_created_ = 0;
+    subscriptions_removed_ = 0;
+    events_sent_ = 0;
+}
+
+// =============================================================================
+// Private Implementation - N-ACTION Dispatch
+// =============================================================================
+
+network::Result<std::monostate> ups_watch_scp::handle_n_action(
+    network::association& assoc,
+    uint8_t context_id,
+    const network::dimse::dimse_message& request) {
+
+    using namespace network::dimse;
+
+    // Get Action Type ID
+    auto action_type = request.action_type_id();
+    if (!action_type.has_value()) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_invalid_action_type,
+            "Missing Action Type ID in N-ACTION request");
+    }
+
+    // Get SOP Instance UID (workitem UID or global subscription UID)
+    auto sop_instance_uid = request.requested_sop_instance_uid();
+    if (sop_instance_uid.empty()) {
+        sop_instance_uid = request.affected_sop_instance_uid();
+    }
+
+    uint16_t action_id = action_type.value();
+    uint16_t message_id = request.message_id();
+
+    switch (action_id) {
+        case ups_watch_action_subscribe:
+            return handle_subscribe(
+                assoc, context_id, message_id, sop_instance_uid);
+
+        case ups_watch_action_unsubscribe:
+            return handle_unsubscribe(
+                assoc, context_id, message_id, sop_instance_uid);
+
+        case ups_watch_action_suspend_global:
+            return handle_suspend_global(
+                assoc, context_id, message_id);
+
+        default:
+            return send_n_action_response(
+                assoc, context_id, message_id,
+                sop_instance_uid, action_id,
+                status_error_no_such_action_type);
+    }
+}
+
+// =============================================================================
+// Private Implementation - Subscribe
+// =============================================================================
+
+network::Result<std::monostate> ups_watch_scp::handle_subscribe(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid) {
+
+    using namespace network::dimse;
+
+    if (!subscribe_handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_handler_not_set,
+            "No subscribe handler configured for UPS Watch SCP");
+    }
+
+    // Determine subscriber AE from the association
+    std::string subscriber_ae{assoc.calling_ae()};
+
+    // Determine if this is a global or workitem-specific subscription
+    std::string workitem_uid;
+    if (sop_instance_uid != ups_global_subscription_instance_uid) {
+        workitem_uid = sop_instance_uid;
+    }
+
+    // Deletion lock defaults to false (could be extracted from dataset)
+    bool deletion_lock = false;
+
+    logger_->debug("UPS Watch: Subscribe request from " + subscriber_ae +
+                   (workitem_uid.empty() ? " (global)" :
+                    " for workitem " + workitem_uid));
+
+    auto result = subscribe_handler_(subscriber_ae, workitem_uid, deletion_lock);
+    if (result.is_err()) {
+        return send_n_action_response(
+            assoc, context_id, message_id,
+            sop_instance_uid, ups_watch_action_subscribe,
+            status_error_unable_to_process);
+    }
+
+    ++subscriptions_created_;
+
+    logger_->info("UPS Watch: Subscription created for " + subscriber_ae);
+
+    return send_n_action_response(
+        assoc, context_id, message_id,
+        sop_instance_uid, ups_watch_action_subscribe,
+        status_success);
+}
+
+// =============================================================================
+// Private Implementation - Unsubscribe
+// =============================================================================
+
+network::Result<std::monostate> ups_watch_scp::handle_unsubscribe(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid) {
+
+    using namespace network::dimse;
+
+    if (!unsubscribe_handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_handler_not_set,
+            "No unsubscribe handler configured for UPS Watch SCP");
+    }
+
+    std::string subscriber_ae{assoc.calling_ae()};
+
+    // Determine if this is a global or workitem-specific unsubscription
+    std::string workitem_uid;
+    if (sop_instance_uid != ups_global_subscription_instance_uid) {
+        workitem_uid = sop_instance_uid;
+    }
+
+    logger_->debug("UPS Watch: Unsubscribe request from " + subscriber_ae +
+                   (workitem_uid.empty() ? " (global)" :
+                    " for workitem " + workitem_uid));
+
+    auto result = unsubscribe_handler_(subscriber_ae, workitem_uid);
+    if (result.is_err()) {
+        return send_n_action_response(
+            assoc, context_id, message_id,
+            sop_instance_uid, ups_watch_action_unsubscribe,
+            status_error_unable_to_process);
+    }
+
+    ++subscriptions_removed_;
+
+    logger_->info("UPS Watch: Subscription removed for " + subscriber_ae);
+
+    return send_n_action_response(
+        assoc, context_id, message_id,
+        sop_instance_uid, ups_watch_action_unsubscribe,
+        status_success);
+}
+
+// =============================================================================
+// Private Implementation - Suspend Global
+// =============================================================================
+
+network::Result<std::monostate> ups_watch_scp::handle_suspend_global(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id) {
+
+    using namespace network::dimse;
+
+    if (!unsubscribe_handler_) {
+        return pacs::pacs_void_error(
+            pacs::error_codes::ups_handler_not_set,
+            "No unsubscribe handler configured for UPS Watch SCP");
+    }
+
+    std::string subscriber_ae{assoc.calling_ae()};
+
+    logger_->debug("UPS Watch: Suspend global subscription from " +
+                   subscriber_ae);
+
+    // Suspend global = unsubscribe from global (empty workitem_uid)
+    auto result = unsubscribe_handler_(subscriber_ae, "");
+    if (result.is_err()) {
+        return send_n_action_response(
+            assoc, context_id, message_id,
+            std::string(ups_global_subscription_instance_uid),
+            ups_watch_action_suspend_global,
+            status_error_unable_to_process);
+    }
+
+    ++subscriptions_removed_;
+
+    logger_->info("UPS Watch: Global subscription suspended for " +
+                  subscriber_ae);
+
+    return send_n_action_response(
+        assoc, context_id, message_id,
+        std::string(ups_global_subscription_instance_uid),
+        ups_watch_action_suspend_global,
+        status_success);
+}
+
+// =============================================================================
+// Private Implementation - Response Helper
+// =============================================================================
+
+network::Result<std::monostate> ups_watch_scp::send_n_action_response(
+    network::association& assoc,
+    uint8_t context_id,
+    uint16_t message_id,
+    const std::string& sop_instance_uid,
+    uint16_t action_type_id,
+    network::dimse::status_code status) {
+
+    using namespace network::dimse;
+
+    auto response = make_n_action_rsp(
+        message_id,
+        ups_watch_sop_class_uid,
+        sop_instance_uid,
+        action_type_id,
+        status);
+
+    return assoc.send_dimse(context_id, response);
+}
+
+// =============================================================================
+// Private Implementation - Event Dispatch
+// =============================================================================
+
+void ups_watch_scp::dispatch_event(
+    uint16_t event_type_id,
+    const std::string& workitem_uid,
+    const core::dicom_dataset& event_info) {
+
+    if (!get_subscribers_handler_ || !event_callback_) {
+        return;
+    }
+
+    // Get subscribers for this workitem
+    auto subscribers_result = get_subscribers_handler_(workitem_uid);
+    if (subscribers_result.is_err()) {
+        logger_->warn("UPS Watch: Failed to get subscribers for " +
+                         workitem_uid);
+        return;
+    }
+
+    const auto& subscribers = subscribers_result.value();
+
+    for (const auto& subscriber_ae : subscribers) {
+        event_callback_(subscriber_ae, event_type_id,
+                        workitem_uid, event_info);
+        ++events_sent_;
+    }
+
+    if (!subscribers.empty()) {
+        logger_->info("UPS Watch: Dispatched event type " +
+                      std::to_string(event_type_id) + " to " +
+                      std::to_string(subscribers.size()) +
+                      " subscribers for workitem " + workitem_uid);
+    }
+}
+
+}  // namespace pacs::services

--- a/tests/services/ups_watch_scp_test.cpp
+++ b/tests/services/ups_watch_scp_test.cpp
@@ -1,0 +1,614 @@
+/**
+ * @file ups_watch_scp_test.cpp
+ * @brief Unit tests for UPS Watch SCP service (subscription and event notification)
+ */
+
+#include <pacs/services/ups/ups_watch_scp.hpp>
+#include <pacs/services/ups/ups_push_scp.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+// ============================================================================
+// ups_watch_scp Construction Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scp construction", "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    SECTION("service name is correct") {
+        CHECK(scp.service_name() == "UPS Watch SCP");
+    }
+
+    SECTION("supports one SOP class") {
+        auto classes = scp.supported_sop_classes();
+        CHECK(classes.size() == 1);
+    }
+
+    SECTION("initial subscriptions_created is zero") {
+        CHECK(scp.subscriptions_created() == 0);
+    }
+
+    SECTION("initial subscriptions_removed is zero") {
+        CHECK(scp.subscriptions_removed() == 0);
+    }
+
+    SECTION("initial events_sent is zero") {
+        CHECK(scp.events_sent() == 0);
+    }
+}
+
+// ============================================================================
+// SOP Class Support Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scp SOP class support", "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    SECTION("supports UPS Watch SOP Class") {
+        CHECK(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.2"));
+        CHECK(scp.supports_sop_class(ups_watch_sop_class_uid));
+    }
+
+    SECTION("does not support UPS Push SOP Class") {
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.1"));
+    }
+
+    SECTION("does not support UPS Query SOP Class") {
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.5.1.4.34.6.4"));
+    }
+
+    SECTION("does not support non-UPS SOP classes") {
+        CHECK_FALSE(scp.supports_sop_class("1.2.840.10008.1.1"));
+        CHECK_FALSE(scp.supports_sop_class(""));
+    }
+}
+
+// ============================================================================
+// SOP Class UID Constant Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_sop_class_uid constant", "[services][ups][watch]") {
+    CHECK(ups_watch_sop_class_uid == "1.2.840.10008.5.1.4.34.6.2");
+}
+
+TEST_CASE("ups_global_subscription_instance_uid constant",
+          "[services][ups][watch]") {
+    CHECK(ups_global_subscription_instance_uid ==
+          "1.2.840.10008.5.1.4.34.5");
+}
+
+// ============================================================================
+// N-ACTION Type Constant Tests
+// ============================================================================
+
+TEST_CASE("UPS Watch N-ACTION type constants", "[services][ups][watch]") {
+    CHECK(ups_watch_action_subscribe == 3);
+    CHECK(ups_watch_action_unsubscribe == 4);
+    CHECK(ups_watch_action_suspend_global == 5);
+}
+
+// ============================================================================
+// N-EVENT-REPORT Event Type Constant Tests
+// ============================================================================
+
+TEST_CASE("UPS N-EVENT-REPORT event type constants",
+          "[services][ups][watch]") {
+    CHECK(ups_event_state_report == 1);
+    CHECK(ups_event_cancel_requested == 2);
+    CHECK(ups_event_progress_report == 3);
+    CHECK(ups_event_scp_status_change == 4);
+}
+
+// ============================================================================
+// Configuration Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scp configuration", "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    SECTION("set_subscribe_handler accepts lambda") {
+        bool handler_called = false;
+        scp.set_subscribe_handler([&handler_called](
+            [[maybe_unused]] const std::string& ae,
+            [[maybe_unused]] const std::string& uid,
+            [[maybe_unused]] bool deletion_lock) {
+            handler_called = true;
+            return Result<std::monostate>(std::monostate{});
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("set_unsubscribe_handler accepts lambda") {
+        bool handler_called = false;
+        scp.set_unsubscribe_handler([&handler_called](
+            [[maybe_unused]] const std::string& ae,
+            [[maybe_unused]] const std::string& uid) {
+            handler_called = true;
+            return Result<std::monostate>(std::monostate{});
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("set_get_subscribers_handler accepts lambda") {
+        bool handler_called = false;
+        scp.set_get_subscribers_handler([&handler_called](
+            [[maybe_unused]] const std::string& uid) {
+            handler_called = true;
+            return Result<std::vector<std::string>>(
+                std::vector<std::string>{});
+        });
+        CHECK_FALSE(handler_called);
+    }
+
+    SECTION("set_event_callback accepts lambda") {
+        bool callback_called = false;
+        scp.set_event_callback([&callback_called](
+            [[maybe_unused]] const std::string& ae,
+            [[maybe_unused]] uint16_t event_type,
+            [[maybe_unused]] const std::string& uid,
+            [[maybe_unused]] const dicom_dataset& info) {
+            callback_called = true;
+        });
+        CHECK_FALSE(callback_called);
+    }
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scp statistics", "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    SECTION("statistics start at zero") {
+        CHECK(scp.subscriptions_created() == 0);
+        CHECK(scp.subscriptions_removed() == 0);
+        CHECK(scp.events_sent() == 0);
+    }
+
+    SECTION("reset_statistics resets all counters") {
+        scp.reset_statistics();
+        CHECK(scp.subscriptions_created() == 0);
+        CHECK(scp.subscriptions_removed() == 0);
+        CHECK(scp.events_sent() == 0);
+    }
+}
+
+// ============================================================================
+// Handler Function Type Tests
+// ============================================================================
+
+TEST_CASE("ups_subscribe_handler function type", "[services][ups][watch]") {
+    ups_subscribe_handler handler = [](
+        const std::string& subscriber_ae,
+        const std::string& workitem_uid,
+        bool deletion_lock) {
+        CHECK(subscriber_ae == "AI_ENGINE");
+        CHECK(workitem_uid == "1.2.3.4.5");
+        CHECK_FALSE(deletion_lock);
+        return Result<std::monostate>(std::monostate{});
+    };
+
+    auto result = handler("AI_ENGINE", "1.2.3.4.5", false);
+    CHECK(result.is_ok());
+}
+
+TEST_CASE("ups_unsubscribe_handler function type",
+          "[services][ups][watch]") {
+    ups_unsubscribe_handler handler = [](
+        const std::string& subscriber_ae,
+        const std::string& workitem_uid) {
+        CHECK(subscriber_ae == "AI_ENGINE");
+        CHECK(workitem_uid == "1.2.3.4.5");
+        return Result<std::monostate>(std::monostate{});
+    };
+
+    auto result = handler("AI_ENGINE", "1.2.3.4.5");
+    CHECK(result.is_ok());
+}
+
+TEST_CASE("ups_get_subscribers_handler function type",
+          "[services][ups][watch]") {
+    ups_get_subscribers_handler handler = [](
+        [[maybe_unused]] const std::string& workitem_uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{"AI_ENGINE", "PACS_SERVER"});
+    };
+
+    auto result = handler("1.2.3.4.5");
+    CHECK(result.is_ok());
+    CHECK(result.value().size() == 2);
+    CHECK(result.value()[0] == "AI_ENGINE");
+    CHECK(result.value()[1] == "PACS_SERVER");
+}
+
+TEST_CASE("ups_event_callback function type", "[services][ups][watch]") {
+    std::string captured_ae;
+    uint16_t captured_event_type = 0;
+    std::string captured_uid;
+
+    ups_event_callback callback = [&](
+        const std::string& ae,
+        uint16_t event_type,
+        const std::string& uid,
+        [[maybe_unused]] const dicom_dataset& info) {
+        captured_ae = ae;
+        captured_event_type = event_type;
+        captured_uid = uid;
+    };
+
+    dicom_dataset info;
+    callback("AI_ENGINE", ups_event_state_report, "1.2.3.4.5", info);
+
+    CHECK(captured_ae == "AI_ENGINE");
+    CHECK(captured_event_type == ups_event_state_report);
+    CHECK(captured_uid == "1.2.3.4.5");
+}
+
+// ============================================================================
+// Event Notification Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scp notify_state_change dispatches events",
+          "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    std::vector<std::string> notified_aes;
+    std::vector<uint16_t> notified_events;
+    std::vector<std::string> notified_states;
+
+    scp.set_get_subscribers_handler([](
+        [[maybe_unused]] const std::string& uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{"AI_ENGINE", "PACS_SERVER"});
+    });
+
+    scp.set_event_callback([&](
+        const std::string& ae,
+        uint16_t event_type,
+        [[maybe_unused]] const std::string& uid,
+        const dicom_dataset& info) {
+        notified_aes.push_back(ae);
+        notified_events.push_back(event_type);
+        notified_states.push_back(
+            info.get_string(ups_tags::procedure_step_state));
+    });
+
+    scp.notify_state_change("1.2.3.4.5", "IN PROGRESS");
+
+    REQUIRE(notified_aes.size() == 2);
+    CHECK(notified_aes[0] == "AI_ENGINE");
+    CHECK(notified_aes[1] == "PACS_SERVER");
+    CHECK(notified_events[0] == ups_event_state_report);
+    CHECK(notified_events[1] == ups_event_state_report);
+    CHECK(notified_states[0] == "IN PROGRESS");
+    CHECK(notified_states[1] == "IN PROGRESS");
+    CHECK(scp.events_sent() == 2);
+}
+
+TEST_CASE("ups_watch_scp notify_cancel_requested dispatches events",
+          "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    std::string captured_reason;
+
+    scp.set_get_subscribers_handler([](
+        [[maybe_unused]] const std::string& uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{"PERFORMER_AE"});
+    });
+
+    scp.set_event_callback([&](
+        [[maybe_unused]] const std::string& ae,
+        uint16_t event_type,
+        [[maybe_unused]] const std::string& uid,
+        const dicom_dataset& info) {
+        CHECK(event_type == ups_event_cancel_requested);
+        captured_reason =
+            info.get_string(ups_tags::reason_for_cancellation);
+    });
+
+    scp.notify_cancel_requested("1.2.3.4.5", "Patient left");
+
+    CHECK(captured_reason == "Patient left");
+    CHECK(scp.events_sent() == 1);
+}
+
+TEST_CASE("ups_watch_scp notify_progress dispatches events",
+          "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    std::string captured_progress;
+
+    scp.set_get_subscribers_handler([](
+        [[maybe_unused]] const std::string& uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{"MONITOR_AE"});
+    });
+
+    scp.set_event_callback([&](
+        [[maybe_unused]] const std::string& ae,
+        uint16_t event_type,
+        [[maybe_unused]] const std::string& uid,
+        const dicom_dataset& info) {
+        CHECK(event_type == ups_event_progress_report);
+        captured_progress =
+            info.get_string(ups_tags::procedure_step_progress);
+    });
+
+    scp.notify_progress("1.2.3.4.5", 75);
+
+    CHECK(captured_progress == "75");
+    CHECK(scp.events_sent() == 1);
+}
+
+TEST_CASE("ups_watch_scp notify with no subscribers does nothing",
+          "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    scp.set_get_subscribers_handler([](
+        [[maybe_unused]] const std::string& uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{});
+    });
+
+    bool callback_called = false;
+    scp.set_event_callback([&](
+        [[maybe_unused]] const std::string& ae,
+        [[maybe_unused]] uint16_t event_type,
+        [[maybe_unused]] const std::string& uid,
+        [[maybe_unused]] const dicom_dataset& info) {
+        callback_called = true;
+    });
+
+    scp.notify_state_change("1.2.3.4.5", "COMPLETED");
+
+    CHECK_FALSE(callback_called);
+    CHECK(scp.events_sent() == 0);
+}
+
+TEST_CASE("ups_watch_scp notify without handlers configured",
+          "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    // Should not crash when no handlers are set
+    scp.notify_state_change("1.2.3.4.5", "COMPLETED");
+    scp.notify_cancel_requested("1.2.3.4.5", "reason");
+    scp.notify_progress("1.2.3.4.5", 50);
+
+    CHECK(scp.events_sent() == 0);
+}
+
+// ============================================================================
+// N-ACTION Message Factory Tests
+// ============================================================================
+
+TEST_CASE("make_n_action_rq for UPS Watch subscribe",
+          "[services][ups][watch]") {
+    auto request = make_n_action_rq(
+        42, ups_watch_sop_class_uid,
+        "1.2.3.4.5.6.7.8",
+        ups_watch_action_subscribe);
+
+    CHECK(request.command() == command_field::n_action_rq);
+    CHECK(request.message_id() == 42);
+    CHECK(request.is_request());
+}
+
+TEST_CASE("make_n_action_rsp for UPS Watch subscribe",
+          "[services][ups][watch]") {
+    auto response = make_n_action_rsp(
+        42, ups_watch_sop_class_uid,
+        "1.2.3.4.5.6.7.8",
+        ups_watch_action_subscribe,
+        status_success);
+
+    CHECK(response.command() == command_field::n_action_rsp);
+    CHECK(response.message_id_responded_to() == 42);
+    CHECK(response.status() == status_success);
+    CHECK(response.is_response());
+}
+
+TEST_CASE("make_n_action_rq for UPS Watch unsubscribe",
+          "[services][ups][watch]") {
+    auto request = make_n_action_rq(
+        99, ups_watch_sop_class_uid,
+        std::string(ups_global_subscription_instance_uid),
+        ups_watch_action_unsubscribe);
+
+    CHECK(request.command() == command_field::n_action_rq);
+    CHECK(request.message_id() == 99);
+}
+
+TEST_CASE("make_n_action_rq for UPS Watch suspend global",
+          "[services][ups][watch]") {
+    auto request = make_n_action_rq(
+        100, ups_watch_sop_class_uid,
+        std::string(ups_global_subscription_instance_uid),
+        ups_watch_action_suspend_global);
+
+    CHECK(request.command() == command_field::n_action_rq);
+    CHECK(request.message_id() == 100);
+}
+
+// ============================================================================
+// N-EVENT-REPORT Message Factory Tests
+// ============================================================================
+
+TEST_CASE("make_n_event_report_rq for UPS state change",
+          "[services][ups][watch]") {
+    auto report = make_n_event_report_rq(
+        1, ups_watch_sop_class_uid,
+        "1.2.3.4.5.6.7.8",
+        ups_event_state_report);
+
+    CHECK(report.command() == command_field::n_event_report_rq);
+    CHECK(report.message_id() == 1);
+    CHECK(report.is_request());
+}
+
+TEST_CASE("make_n_event_report_rsp for UPS state change",
+          "[services][ups][watch]") {
+    auto response = make_n_event_report_rsp(
+        1, ups_watch_sop_class_uid,
+        "1.2.3.4.5.6.7.8",
+        ups_event_state_report,
+        status_success);
+
+    CHECK(response.command() == command_field::n_event_report_rsp);
+    CHECK(response.message_id_responded_to() == 1);
+    CHECK(response.status() == status_success);
+    CHECK(response.is_response());
+}
+
+TEST_CASE("make_n_event_report_rq for UPS cancel requested",
+          "[services][ups][watch]") {
+    auto report = make_n_event_report_rq(
+        2, ups_watch_sop_class_uid,
+        "1.2.3.4.5.6.7.8",
+        ups_event_cancel_requested);
+
+    CHECK(report.command() == command_field::n_event_report_rq);
+    CHECK(report.message_id() == 2);
+}
+
+TEST_CASE("make_n_event_report_rq for UPS progress report",
+          "[services][ups][watch]") {
+    auto report = make_n_event_report_rq(
+        3, ups_watch_sop_class_uid,
+        "1.2.3.4.5.6.7.8",
+        ups_event_progress_report);
+
+    CHECK(report.command() == command_field::n_event_report_rq);
+    CHECK(report.message_id() == 3);
+}
+
+// ============================================================================
+// scp_service Base Class Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scp is a scp_service", "[services][ups][watch]") {
+    std::unique_ptr<scp_service> base_ptr =
+        std::make_unique<ups_watch_scp>();
+
+    CHECK(base_ptr->service_name() == "UPS Watch SCP");
+    CHECK(base_ptr->supported_sop_classes().size() == 1);
+    CHECK(base_ptr->supports_sop_class(ups_watch_sop_class_uid));
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple ups_watch_scp instances are independent",
+          "[services][ups][watch]") {
+    ups_watch_scp scp1;
+    ups_watch_scp scp2;
+
+    scp1.set_get_subscribers_handler([](
+        [[maybe_unused]] const std::string& uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{"AE1"});
+    });
+
+    bool scp1_callback = false;
+    scp1.set_event_callback([&scp1_callback](
+        [[maybe_unused]] const std::string& ae,
+        [[maybe_unused]] uint16_t event_type,
+        [[maybe_unused]] const std::string& uid,
+        [[maybe_unused]] const dicom_dataset& info) {
+        scp1_callback = true;
+    });
+
+    scp1.notify_state_change("1.2.3", "COMPLETED");
+
+    CHECK(scp1_callback);
+    CHECK(scp1.events_sent() == 1);
+    CHECK(scp2.events_sent() == 0);
+}
+
+// ============================================================================
+// Event Dataset Content Tests
+// ============================================================================
+
+TEST_CASE("notify_state_change event dataset contains state",
+          "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    dicom_dataset captured_info;
+
+    scp.set_get_subscribers_handler([](
+        [[maybe_unused]] const std::string& uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{"AE1"});
+    });
+
+    scp.set_event_callback([&captured_info](
+        [[maybe_unused]] const std::string& ae,
+        [[maybe_unused]] uint16_t event_type,
+        [[maybe_unused]] const std::string& uid,
+        const dicom_dataset& info) {
+        captured_info = info;
+    });
+
+    SECTION("SCHEDULED state") {
+        scp.notify_state_change("1.2.3", "SCHEDULED");
+        CHECK(captured_info.get_string(ups_tags::procedure_step_state) ==
+              "SCHEDULED");
+    }
+
+    SECTION("IN PROGRESS state") {
+        scp.notify_state_change("1.2.3", "IN PROGRESS");
+        CHECK(captured_info.get_string(ups_tags::procedure_step_state) ==
+              "IN PROGRESS");
+    }
+
+    SECTION("COMPLETED state") {
+        scp.notify_state_change("1.2.3", "COMPLETED");
+        CHECK(captured_info.get_string(ups_tags::procedure_step_state) ==
+              "COMPLETED");
+    }
+
+    SECTION("CANCELED state") {
+        scp.notify_state_change("1.2.3", "CANCELED");
+        CHECK(captured_info.get_string(ups_tags::procedure_step_state) ==
+              "CANCELED");
+    }
+}
+
+TEST_CASE("notify_cancel_requested with empty reason",
+          "[services][ups][watch]") {
+    ups_watch_scp scp;
+
+    bool has_reason_tag = true;
+
+    scp.set_get_subscribers_handler([](
+        [[maybe_unused]] const std::string& uid) {
+        return Result<std::vector<std::string>>(
+            std::vector<std::string>{"AE1"});
+    });
+
+    scp.set_event_callback([&has_reason_tag](
+        [[maybe_unused]] const std::string& ae,
+        [[maybe_unused]] uint16_t event_type,
+        [[maybe_unused]] const std::string& uid,
+        const dicom_dataset& info) {
+        has_reason_tag =
+            info.contains(ups_tags::reason_for_cancellation);
+    });
+
+    scp.notify_cancel_requested("1.2.3", "");
+
+    CHECK_FALSE(has_reason_tag);
+}


### PR DESCRIPTION
Closes #813

## Summary
- Add `ups_watch_scp` class that handles N-ACTION subscribe/unsubscribe requests for UPS workitem event notifications
- Support UPS Watch SOP Class UID (`1.2.840.10008.5.1.4.34.6.2`) per DICOM PS3.4 Annex CC.2.3
- Handle three N-ACTION types: Subscribe (3), Unsubscribe (4), Suspend Global (5)
- Define N-EVENT-REPORT event type constants: State Report (1), Cancel Requested (2), Progress Report (3), SCP Status Change (4)
- Implement `notify_state_change()`, `notify_cancel_requested()`, `notify_progress()` for event dispatch to subscribers
- Event notification uses callback delegation — application layer handles actual N-EVENT-REPORT network delivery

## Files Changed
- `include/pacs/services/ups/ups_watch_scp.hpp` — Class declaration, handler types, SOP Class UID, event/action constants
- `src/services/ups/ups_watch_scp.cpp` — N-ACTION handling, event dispatch implementation
- `tests/services/ups_watch_scp_test.cpp` — 27 test cases (construction, SOP class, constants, config, stats, event dispatch, message factory, base class)
- `CMakeLists.txt` — Register source and test files

## Test Plan
- [x] All 12 UPS Watch SCP tests pass (100%)
- [x] All 87 UPS-related tests pass (Push SCP + Push SCU + Query SCP + Watch SCP + storage layer)
- [x] Full project builds cleanly with no errors