### PR TITLE
feat(services): implement UPS Watch SCU for event subscription and reception

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1055,6 +1055,7 @@ add_library(pacs_services
     src/services/ups/ups_push_scu.cpp
     src/services/ups/ups_query_scp.cpp
     src/services/ups/ups_watch_scp.cpp
+    src/services/ups/ups_watch_scu.cpp
     src/services/sop_class_registry.cpp
     src/services/sop_classes/us_storage.cpp
     src/services/sop_classes/dx_storage.cpp
@@ -1867,6 +1868,7 @@ if(PACS_BUILD_TESTS)
         tests/services/ups_push_scu_test.cpp
         tests/services/ups_query_scp_test.cpp
         tests/services/ups_watch_scp_test.cpp
+        tests/services/ups_watch_scu_test.cpp
         tests/services/us_storage_test.cpp
         tests/services/dx_storage_test.cpp
         tests/services/mg_storage_test.cpp

--- a/include/pacs/services/ups/ups_watch_scu.hpp
+++ b/include/pacs/services/ups/ups_watch_scu.hpp
@@ -1,0 +1,274 @@
+/**
+ * @file ups_watch_scu.hpp
+ * @brief DICOM UPS Watch SCU service (subscription client and event receiver)
+ *
+ * This file provides the ups_watch_scu class for subscribing to UPS workitem
+ * events on remote SCP servers and receiving N-EVENT-REPORT notifications.
+ *
+ * @see DICOM PS3.4 Annex CC.2.3 - UPS Watch SOP Class
+ * @see DICOM PS3.4 CC.2.4 - N-EVENT-REPORT for UPS
+ * @see Issue #815 - UPS Watch SCU Implementation
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_UPS_WATCH_SCU_HPP
+#define PACS_SERVICES_UPS_WATCH_SCU_HPP
+
+#include "ups_push_scu.hpp"
+#include "ups_watch_scp.hpp"
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/di/ilogger.hpp"
+#include "pacs/network/association.hpp"
+#include "pacs/network/dimse/dimse_message.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+namespace pacs::services {
+
+// =============================================================================
+// UPS Watch SCU Data Structures
+// =============================================================================
+
+/**
+ * @brief Data for N-ACTION subscribe request
+ *
+ * Contains parameters for subscribing to UPS workitem events on a remote SCP.
+ */
+struct ups_subscribe_data {
+    /// Workitem SOP Instance UID (empty for global subscription)
+    std::string workitem_uid;
+
+    /// Whether to request a deletion lock
+    bool deletion_lock{false};
+};
+
+/**
+ * @brief Data for N-ACTION unsubscribe request
+ */
+struct ups_unsubscribe_data {
+    /// Workitem SOP Instance UID (empty for global unsubscription)
+    std::string workitem_uid;
+};
+
+/**
+ * @brief Parsed UPS event notification received from SCP
+ *
+ * Represents the content of an N-EVENT-REPORT received from the Watch SCP.
+ */
+struct ups_watch_event {
+    /// Event type ID (ups_event_state_report, ups_event_cancel_requested, etc.)
+    uint16_t event_type_id{0};
+
+    /// Workitem SOP Instance UID that triggered the event
+    std::string workitem_uid;
+
+    /// New procedure step state (for state report events)
+    std::string procedure_step_state;
+
+    /// Progress percentage (for progress report events)
+    std::string progress;
+
+    /// Cancellation reason (for cancel requested events)
+    std::string cancellation_reason;
+
+    /// Full event dataset (for custom processing)
+    core::dicom_dataset event_info;
+
+    /// Timestamp when the event was received
+    std::chrono::system_clock::time_point timestamp;
+};
+
+/**
+ * @brief Configuration for UPS Watch SCU service
+ */
+struct ups_watch_scu_config {
+    /// Timeout for receiving DIMSE response
+    std::chrono::milliseconds timeout{30000};
+};
+
+// =============================================================================
+// UPS Watch SCU Class
+// =============================================================================
+
+/**
+ * @brief UPS Watch SCU service for subscribing to events on remote systems
+ *
+ * The UPS Watch SCU (Service Class User) sends N-ACTION requests to remote
+ * UPS Watch SCP servers to subscribe/unsubscribe from workitem events, and
+ * handles incoming N-EVENT-REPORT notifications.
+ *
+ * ## UPS Watch SCU Message Flow
+ *
+ * ```
+ * UPS Watch SCU (This PACS)               Remote UPS Watch SCP
+ *  |                                       |
+ *  |  N-ACTION-RQ (Subscribe, Type 3)      |
+ *  |  WorkitemUID: 1.2.3.4...             |
+ *  |-------------------------------------->|
+ *  |  N-ACTION-RSP (Success)              |
+ *  |<--------------------------------------|
+ *  |                                       |
+ *  |  [Workitem state changes on SCP]      |
+ *  |                                       |
+ *  |  N-EVENT-REPORT-RQ (Type 1)          |
+ *  |  State: COMPLETED                    |
+ *  |<--------------------------------------|
+ *  |  N-EVENT-REPORT-RSP                  |
+ *  |-------------------------------------->|
+ *  |                                       |
+ *  |  N-ACTION-RQ (Unsubscribe, Type 4)   |
+ *  |-------------------------------------->|
+ *  |  N-ACTION-RSP (Success)              |
+ *  |<--------------------------------------|
+ * ```
+ */
+class ups_watch_scu {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct UPS Watch SCU with default configuration
+     *
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit ups_watch_scu(std::shared_ptr<di::ILogger> logger = nullptr);
+
+    /**
+     * @brief Construct UPS Watch SCU with custom configuration
+     *
+     * @param config Configuration options
+     * @param logger Logger instance (nullptr uses null_logger)
+     */
+    explicit ups_watch_scu(const ups_watch_scu_config& config,
+                           std::shared_ptr<di::ILogger> logger = nullptr);
+
+    ~ups_watch_scu() = default;
+
+    // Non-copyable, non-movable (due to atomic members)
+    ups_watch_scu(const ups_watch_scu&) = delete;
+    ups_watch_scu& operator=(const ups_watch_scu&) = delete;
+    ups_watch_scu(ups_watch_scu&&) = delete;
+    ups_watch_scu& operator=(ups_watch_scu&&) = delete;
+
+    // =========================================================================
+    // Callback Configuration
+    // =========================================================================
+
+    /**
+     * @brief Callback type for received event notifications
+     *
+     * Invoked when an N-EVENT-REPORT is received from the SCP.
+     */
+    using event_received_callback = std::function<void(
+        const ups_watch_event& event)>;
+
+    /**
+     * @brief Set callback for received event notifications
+     * @param cb The callback function
+     */
+    void set_event_received_callback(event_received_callback cb);
+
+    // =========================================================================
+    // N-ACTION Operations
+    // =========================================================================
+
+    /**
+     * @brief Subscribe to UPS workitem events (N-ACTION Type 3)
+     *
+     * Sends a subscribe request to the remote UPS Watch SCP.
+     * Use empty workitem_uid for global subscription.
+     *
+     * @param assoc The established association to use
+     * @param data The subscription parameters
+     * @return Result containing ups_result on success, or error
+     */
+    [[nodiscard]] network::Result<ups_result> subscribe(
+        network::association& assoc,
+        const ups_subscribe_data& data);
+
+    /**
+     * @brief Unsubscribe from UPS workitem events (N-ACTION Type 4)
+     *
+     * @param assoc The established association to use
+     * @param data The unsubscription parameters
+     * @return Result containing ups_result on success, or error
+     */
+    [[nodiscard]] network::Result<ups_result> unsubscribe(
+        network::association& assoc,
+        const ups_unsubscribe_data& data);
+
+    /**
+     * @brief Suspend global subscription (N-ACTION Type 5)
+     *
+     * @param assoc The established association to use
+     * @return Result containing ups_result on success, or error
+     */
+    [[nodiscard]] network::Result<ups_result> suspend_global(
+        network::association& assoc);
+
+    // =========================================================================
+    // N-EVENT-REPORT Handler
+    // =========================================================================
+
+    /**
+     * @brief Handle an N-EVENT-REPORT-RQ received from the SCP
+     *
+     * Parses the event dataset and invokes the registered callback.
+     *
+     * @param event_rq The N-EVENT-REPORT-RQ message
+     * @return The parsed event notification
+     */
+    [[nodiscard]] network::Result<ups_watch_event> handle_event_report(
+        const network::dimse::dimse_message& event_rq);
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    [[nodiscard]] size_t subscribes_performed() const noexcept;
+    [[nodiscard]] size_t unsubscribes_performed() const noexcept;
+    [[nodiscard]] size_t events_received() const noexcept;
+
+    void reset_statistics() noexcept;
+
+private:
+    // =========================================================================
+    // Private Implementation
+    // =========================================================================
+
+    [[nodiscard]] network::Result<ups_result> send_watch_action(
+        network::association& assoc,
+        const std::string& sop_instance_uid,
+        uint16_t action_type_id);
+
+    [[nodiscard]] static ups_watch_event parse_event_dataset(
+        uint16_t event_type_id,
+        const std::string& workitem_uid,
+        const core::dicom_dataset& dataset);
+
+    [[nodiscard]] uint16_t next_message_id() noexcept;
+
+    // =========================================================================
+    // Private Members
+    // =========================================================================
+
+    std::shared_ptr<di::ILogger> logger_;
+    ups_watch_scu_config config_;
+    event_received_callback event_callback_;
+    std::atomic<uint16_t> message_id_counter_{1};
+    std::atomic<size_t> subscribes_performed_{0};
+    std::atomic<size_t> unsubscribes_performed_{0};
+    std::atomic<size_t> events_received_{0};
+};
+
+}  // namespace pacs::services
+
+#endif  // PACS_SERVICES_UPS_WATCH_SCU_HPP

--- a/src/services/ups/ups_watch_scu.cpp
+++ b/src/services/ups/ups_watch_scu.cpp
@@ -1,0 +1,328 @@
+/**
+ * @file ups_watch_scu.cpp
+ * @brief Implementation of the UPS Watch SCU service
+ */
+
+#include "pacs/services/ups/ups_watch_scu.hpp"
+
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/core/result.hpp"
+#include "pacs/encoding/vr_type.hpp"
+#include "pacs/network/dimse/command_field.hpp"
+#include "pacs/network/dimse/status_codes.hpp"
+
+#include <chrono>
+
+namespace pacs::services {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+ups_watch_scu::ups_watch_scu(std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()) {}
+
+ups_watch_scu::ups_watch_scu(const ups_watch_scu_config& config,
+                             std::shared_ptr<di::ILogger> logger)
+    : logger_(logger ? std::move(logger) : di::null_logger()),
+      config_(config) {}
+
+// =============================================================================
+// Callback Configuration
+// =============================================================================
+
+void ups_watch_scu::set_event_received_callback(event_received_callback cb) {
+    event_callback_ = std::move(cb);
+}
+
+// =============================================================================
+// N-ACTION Operations
+// =============================================================================
+
+network::Result<ups_result> ups_watch_scu::subscribe(
+    network::association& assoc,
+    const ups_subscribe_data& data) {
+
+    // Determine the SOP Instance UID: workitem-specific or global
+    std::string sop_instance_uid = data.workitem_uid.empty()
+        ? std::string(ups_global_subscription_instance_uid)
+        : data.workitem_uid;
+
+    logger_->debug("UPS Watch SCU: Subscribe request" +
+                   (data.workitem_uid.empty() ? std::string(" (global)") :
+                    " for workitem " + data.workitem_uid));
+
+    auto result = send_watch_action(
+        assoc, sop_instance_uid, ups_watch_action_subscribe);
+
+    if (result.is_ok() && result.value().is_success()) {
+        subscribes_performed_.fetch_add(1, std::memory_order_relaxed);
+        logger_->info("UPS Watch SCU: Subscribe successful" +
+                      (data.workitem_uid.empty() ? std::string(" (global)") :
+                       " for workitem " + data.workitem_uid));
+    }
+
+    return result;
+}
+
+network::Result<ups_result> ups_watch_scu::unsubscribe(
+    network::association& assoc,
+    const ups_unsubscribe_data& data) {
+
+    std::string sop_instance_uid = data.workitem_uid.empty()
+        ? std::string(ups_global_subscription_instance_uid)
+        : data.workitem_uid;
+
+    logger_->debug("UPS Watch SCU: Unsubscribe request" +
+                   (data.workitem_uid.empty() ? std::string(" (global)") :
+                    " for workitem " + data.workitem_uid));
+
+    auto result = send_watch_action(
+        assoc, sop_instance_uid, ups_watch_action_unsubscribe);
+
+    if (result.is_ok() && result.value().is_success()) {
+        unsubscribes_performed_.fetch_add(1, std::memory_order_relaxed);
+        logger_->info("UPS Watch SCU: Unsubscribe successful" +
+                      (data.workitem_uid.empty() ? std::string(" (global)") :
+                       " for workitem " + data.workitem_uid));
+    }
+
+    return result;
+}
+
+network::Result<ups_result> ups_watch_scu::suspend_global(
+    network::association& assoc) {
+
+    logger_->debug("UPS Watch SCU: Suspend global subscription");
+
+    auto result = send_watch_action(
+        assoc,
+        std::string(ups_global_subscription_instance_uid),
+        ups_watch_action_suspend_global);
+
+    if (result.is_ok() && result.value().is_success()) {
+        unsubscribes_performed_.fetch_add(1, std::memory_order_relaxed);
+        logger_->info("UPS Watch SCU: Global subscription suspended");
+    }
+
+    return result;
+}
+
+// =============================================================================
+// N-EVENT-REPORT Handler
+// =============================================================================
+
+network::Result<ups_watch_event> ups_watch_scu::handle_event_report(
+    const network::dimse::dimse_message& event_rq) {
+
+    using namespace network::dimse;
+
+    // Verify command is N-EVENT-REPORT-RQ
+    if (event_rq.command() != command_field::n_event_report_rq) {
+        return pacs::pacs_error<ups_watch_event>(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-EVENT-REPORT-RQ, got: " +
+            std::string(to_string(event_rq.command())));
+    }
+
+    // Get event type ID
+    auto event_type = event_rq.event_type_id();
+    if (!event_type.has_value()) {
+        return pacs::pacs_error<ups_watch_event>(
+            pacs::error_codes::ups_invalid_action_type,
+            "Missing Event Type ID in N-EVENT-REPORT");
+    }
+
+    // Get workitem UID from the affected SOP Instance UID
+    std::string workitem_uid{event_rq.affected_sop_instance_uid()};
+
+    // Parse dataset if present
+    ups_watch_event event;
+    if (event_rq.has_dataset()) {
+        auto dataset_result = event_rq.dataset();
+        if (dataset_result.is_ok()) {
+            event = parse_event_dataset(
+                event_type.value(), workitem_uid,
+                dataset_result.value().get());
+        } else {
+            event.event_type_id = event_type.value();
+            event.workitem_uid = workitem_uid;
+            event.timestamp = std::chrono::system_clock::now();
+        }
+    } else {
+        event.event_type_id = event_type.value();
+        event.workitem_uid = workitem_uid;
+        event.timestamp = std::chrono::system_clock::now();
+    }
+
+    events_received_.fetch_add(1, std::memory_order_relaxed);
+
+    logger_->info("UPS Watch SCU: Received event type " +
+                  std::to_string(event.event_type_id) +
+                  " for workitem " + event.workitem_uid);
+
+    // Invoke callback if registered
+    if (event_callback_) {
+        event_callback_(event);
+    }
+
+    return pacs::Result<ups_watch_event>::ok(std::move(event));
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t ups_watch_scu::subscribes_performed() const noexcept {
+    return subscribes_performed_.load(std::memory_order_relaxed);
+}
+
+size_t ups_watch_scu::unsubscribes_performed() const noexcept {
+    return unsubscribes_performed_.load(std::memory_order_relaxed);
+}
+
+size_t ups_watch_scu::events_received() const noexcept {
+    return events_received_.load(std::memory_order_relaxed);
+}
+
+void ups_watch_scu::reset_statistics() noexcept {
+    subscribes_performed_.store(0, std::memory_order_relaxed);
+    unsubscribes_performed_.store(0, std::memory_order_relaxed);
+    events_received_.store(0, std::memory_order_relaxed);
+}
+
+// =============================================================================
+// Private Implementation - Send Watch Action
+// =============================================================================
+
+network::Result<ups_result> ups_watch_scu::send_watch_action(
+    network::association& assoc,
+    const std::string& sop_instance_uid,
+    uint16_t action_type_id) {
+
+    using namespace network::dimse;
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    // Verify association is established
+    if (!assoc.is_established()) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::association_not_established,
+            "Association not established");
+    }
+
+    // Get accepted presentation context for UPS Watch
+    auto context_id = assoc.accepted_context_id(ups_watch_sop_class_uid);
+    if (!context_id) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_context_not_accepted,
+            "No accepted presentation context for UPS Watch SOP Class");
+    }
+
+    // Build the N-ACTION request
+    auto request = make_n_action_rq(
+        next_message_id(),
+        ups_watch_sop_class_uid,
+        sop_instance_uid,
+        action_type_id);
+
+    // Send the request
+    auto send_result = assoc.send_dimse(*context_id, request);
+    if (send_result.is_err()) {
+        logger_->error("UPS Watch SCU: Failed to send N-ACTION: " +
+                       send_result.error().message);
+        return send_result.error();
+    }
+
+    // Receive the response
+    auto recv_result = assoc.receive_dimse(config_.timeout);
+    if (recv_result.is_err()) {
+        logger_->error("UPS Watch SCU: Failed to receive N-ACTION response: " +
+                       recv_result.error().message);
+        return recv_result.error();
+    }
+
+    const auto& [recv_context_id, response] = recv_result.value();
+
+    // Verify it's an N-ACTION response
+    if (response.command() != command_field::n_action_rsp) {
+        return pacs::pacs_error<ups_result>(
+            pacs::error_codes::ups_unexpected_command,
+            "Expected N-ACTION-RSP but received " +
+            std::string(to_string(response.command())));
+    }
+
+    auto end_time = std::chrono::steady_clock::now();
+    auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+        end_time - start_time);
+
+    // Build result
+    ups_result result;
+    result.workitem_uid = sop_instance_uid;
+    result.status = static_cast<uint16_t>(response.status());
+    result.elapsed = elapsed;
+
+    if (response.command_set().contains(tag_error_comment)) {
+        result.error_comment = response.command_set().get_string(tag_error_comment);
+    }
+
+    if (!result.is_success()) {
+        logger_->warn("UPS Watch SCU: N-ACTION returned status 0x" +
+                      std::to_string(result.status));
+    }
+
+    return result;
+}
+
+// =============================================================================
+// Private Implementation - Event Parsing
+// =============================================================================
+
+ups_watch_event ups_watch_scu::parse_event_dataset(
+    uint16_t event_type_id,
+    const std::string& workitem_uid,
+    const core::dicom_dataset& dataset) {
+
+    ups_watch_event event;
+    event.event_type_id = event_type_id;
+    event.workitem_uid = workitem_uid;
+    event.event_info = dataset;
+    event.timestamp = std::chrono::system_clock::now();
+
+    // Extract fields based on event type
+    switch (event_type_id) {
+        case ups_event_state_report:
+            event.procedure_step_state = dataset.get_string(
+                ups_tags::procedure_step_state);
+            break;
+
+        case ups_event_cancel_requested:
+            event.cancellation_reason = dataset.get_string(
+                ups_tags::reason_for_cancellation);
+            break;
+
+        case ups_event_progress_report:
+            event.progress = dataset.get_string(
+                ups_tags::procedure_step_progress);
+            break;
+
+        default:
+            break;
+    }
+
+    return event;
+}
+
+// =============================================================================
+// Private Implementation - Utility Functions
+// =============================================================================
+
+uint16_t ups_watch_scu::next_message_id() noexcept {
+    uint16_t id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    if (id == 0) {
+        id = message_id_counter_.fetch_add(1, std::memory_order_relaxed);
+    }
+    return id;
+}
+
+}  // namespace pacs::services

--- a/tests/services/ups_watch_scu_test.cpp
+++ b/tests/services/ups_watch_scu_test.cpp
@@ -1,0 +1,458 @@
+/**
+ * @file ups_watch_scu_test.cpp
+ * @brief Unit tests for UPS Watch SCU service
+ */
+
+#include <pacs/services/ups/ups_watch_scu.hpp>
+#include <pacs/network/dimse/command_field.hpp>
+#include <pacs/network/dimse/dimse_message.hpp>
+#include <pacs/network/dimse/status_codes.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services;
+using namespace pacs::network;
+using namespace pacs::network::dimse;
+using namespace pacs::core;
+
+// ============================================================================
+// ups_watch_scu Construction Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scu construction", "[services][ups][watch-scu]") {
+    SECTION("default construction succeeds") {
+        ups_watch_scu scu;
+        CHECK(scu.subscribes_performed() == 0);
+        CHECK(scu.unsubscribes_performed() == 0);
+        CHECK(scu.events_received() == 0);
+    }
+
+    SECTION("construction with config succeeds") {
+        ups_watch_scu_config config;
+        config.timeout = std::chrono::milliseconds{60000};
+
+        ups_watch_scu scu(config);
+        CHECK(scu.subscribes_performed() == 0);
+        CHECK(scu.unsubscribes_performed() == 0);
+        CHECK(scu.events_received() == 0);
+    }
+
+    SECTION("construction with nullptr logger succeeds") {
+        ups_watch_scu scu(nullptr);
+        CHECK(scu.subscribes_performed() == 0);
+    }
+
+    SECTION("construction with config and nullptr logger succeeds") {
+        ups_watch_scu_config config;
+        ups_watch_scu scu(config, nullptr);
+        CHECK(scu.subscribes_performed() == 0);
+    }
+}
+
+// ============================================================================
+// ups_watch_scu_config Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scu_config defaults", "[services][ups][watch-scu]") {
+    ups_watch_scu_config config;
+    CHECK(config.timeout == std::chrono::milliseconds{30000});
+}
+
+TEST_CASE("ups_watch_scu_config customization", "[services][ups][watch-scu]") {
+    ups_watch_scu_config config;
+    config.timeout = std::chrono::milliseconds{60000};
+    CHECK(config.timeout == std::chrono::milliseconds{60000});
+}
+
+// ============================================================================
+// ups_subscribe_data Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_subscribe_data structure", "[services][ups][watch-scu]") {
+    ups_subscribe_data data;
+
+    SECTION("default construction has correct defaults") {
+        CHECK(data.workitem_uid.empty());
+        CHECK(data.deletion_lock == false);
+    }
+
+    SECTION("can be initialized for workitem subscription") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        data.deletion_lock = true;
+
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(data.deletion_lock == true);
+    }
+
+    SECTION("empty workitem_uid means global subscription") {
+        CHECK(data.workitem_uid.empty());
+    }
+}
+
+// ============================================================================
+// ups_unsubscribe_data Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_unsubscribe_data structure", "[services][ups][watch-scu]") {
+    ups_unsubscribe_data data;
+
+    SECTION("default construction") {
+        CHECK(data.workitem_uid.empty());
+    }
+
+    SECTION("can be initialized for workitem unsubscription") {
+        data.workitem_uid = "1.2.3.4.5.6.7.8";
+        CHECK(data.workitem_uid == "1.2.3.4.5.6.7.8");
+    }
+}
+
+// ============================================================================
+// ups_watch_event Structure Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_event structure", "[services][ups][watch-scu]") {
+    ups_watch_event event;
+
+    SECTION("default construction") {
+        CHECK(event.event_type_id == 0);
+        CHECK(event.workitem_uid.empty());
+        CHECK(event.procedure_step_state.empty());
+        CHECK(event.progress.empty());
+        CHECK(event.cancellation_reason.empty());
+    }
+
+    SECTION("can be initialized for state report") {
+        event.event_type_id = ups_event_state_report;
+        event.workitem_uid = "1.2.3.4.5.6.7.8";
+        event.procedure_step_state = "COMPLETED";
+        event.timestamp = std::chrono::system_clock::now();
+
+        CHECK(event.event_type_id == 1);
+        CHECK(event.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(event.procedure_step_state == "COMPLETED");
+    }
+
+    SECTION("can be initialized for cancel requested") {
+        event.event_type_id = ups_event_cancel_requested;
+        event.workitem_uid = "1.2.3.4.5.6.7.8";
+        event.cancellation_reason = "Patient refused";
+
+        CHECK(event.event_type_id == 2);
+        CHECK(event.cancellation_reason == "Patient refused");
+    }
+
+    SECTION("can be initialized for progress report") {
+        event.event_type_id = ups_event_progress_report;
+        event.workitem_uid = "1.2.3.4.5.6.7.8";
+        event.progress = "75";
+
+        CHECK(event.event_type_id == 3);
+        CHECK(event.progress == "75");
+    }
+}
+
+// ============================================================================
+// SOP Class UID and Constant Tests
+// ============================================================================
+
+TEST_CASE("UPS Watch SOP Class UID constant", "[services][ups][watch-scu]") {
+    CHECK(ups_watch_sop_class_uid == "1.2.840.10008.5.1.4.34.6.2");
+}
+
+TEST_CASE("UPS Global Subscription Instance UID constant",
+          "[services][ups][watch-scu]") {
+    CHECK(ups_global_subscription_instance_uid == "1.2.840.10008.5.1.4.34.5");
+}
+
+TEST_CASE("UPS Watch N-ACTION type constants", "[services][ups][watch-scu]") {
+    CHECK(ups_watch_action_subscribe == 3);
+    CHECK(ups_watch_action_unsubscribe == 4);
+    CHECK(ups_watch_action_suspend_global == 5);
+}
+
+TEST_CASE("UPS N-EVENT-REPORT type constants", "[services][ups][watch-scu]") {
+    CHECK(ups_event_state_report == 1);
+    CHECK(ups_event_cancel_requested == 2);
+    CHECK(ups_event_progress_report == 3);
+    CHECK(ups_event_scp_status_change == 4);
+}
+
+// ============================================================================
+// Statistics Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scu statistics", "[services][ups][watch-scu]") {
+    ups_watch_scu scu;
+
+    SECTION("initial statistics are zero") {
+        CHECK(scu.subscribes_performed() == 0);
+        CHECK(scu.unsubscribes_performed() == 0);
+        CHECK(scu.events_received() == 0);
+    }
+
+    SECTION("reset_statistics clears all counters") {
+        scu.reset_statistics();
+        CHECK(scu.subscribes_performed() == 0);
+        CHECK(scu.unsubscribes_performed() == 0);
+        CHECK(scu.events_received() == 0);
+    }
+}
+
+// ============================================================================
+// Multiple Instance Tests
+// ============================================================================
+
+TEST_CASE("multiple ups_watch_scu instances are independent",
+          "[services][ups][watch-scu]") {
+    ups_watch_scu scu1;
+    ups_watch_scu scu2;
+
+    CHECK(scu1.subscribes_performed() == scu2.subscribes_performed());
+    CHECK(scu1.unsubscribes_performed() == scu2.unsubscribes_performed());
+    CHECK(scu1.events_received() == scu2.events_received());
+
+    scu1.reset_statistics();
+    CHECK(scu1.subscribes_performed() == 0);
+    CHECK(scu2.subscribes_performed() == 0);
+}
+
+// ============================================================================
+// Callback Configuration Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scu callback configuration", "[services][ups][watch-scu]") {
+    ups_watch_scu scu;
+
+    SECTION("can set event received callback") {
+        bool called = false;
+        scu.set_event_received_callback([&](const ups_watch_event&) {
+            called = true;
+        });
+        // Callback is stored but not yet invoked
+        CHECK_FALSE(called);
+    }
+
+    SECTION("can replace callback") {
+        int count = 0;
+        scu.set_event_received_callback([&](const ups_watch_event&) {
+            count = 1;
+        });
+        scu.set_event_received_callback([&](const ups_watch_event&) {
+            count = 2;
+        });
+        // Replacement is valid
+        CHECK(count == 0);
+    }
+}
+
+// ============================================================================
+// N-EVENT-REPORT Handler Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_scu handle_event_report", "[services][ups][watch-scu]") {
+    ups_watch_scu scu;
+
+    SECTION("rejects non-N-EVENT-REPORT commands") {
+        dimse_message msg{command_field::n_action_rq, 1};
+        auto result = scu.handle_event_report(msg);
+        CHECK(result.is_err());
+    }
+
+    SECTION("processes state report event") {
+        dimse_message msg{command_field::n_event_report_rq, 1};
+        msg.set_affected_sop_class_uid(ups_watch_sop_class_uid);
+        msg.set_affected_sop_instance_uid("1.2.3.4.5");
+        msg.set_event_type_id(ups_event_state_report);
+
+        dicom_dataset ds;
+        ds.set_string(ups_tags::procedure_step_state,
+                      pacs::encoding::vr_type::CS, "COMPLETED");
+        msg.set_dataset(std::move(ds));
+
+        auto result = scu.handle_event_report(msg);
+        REQUIRE(result.is_ok());
+        CHECK(result.value().event_type_id == ups_event_state_report);
+        CHECK(result.value().workitem_uid == "1.2.3.4.5");
+        CHECK(result.value().procedure_step_state == "COMPLETED");
+        CHECK(scu.events_received() == 1);
+    }
+
+    SECTION("processes cancel requested event") {
+        dimse_message msg{command_field::n_event_report_rq, 1};
+        msg.set_affected_sop_class_uid(ups_watch_sop_class_uid);
+        msg.set_affected_sop_instance_uid("1.2.3.4.5");
+        msg.set_event_type_id(ups_event_cancel_requested);
+
+        dicom_dataset ds;
+        ds.set_string(ups_tags::reason_for_cancellation,
+                      pacs::encoding::vr_type::LT, "Patient refused");
+        msg.set_dataset(std::move(ds));
+
+        auto result = scu.handle_event_report(msg);
+        REQUIRE(result.is_ok());
+        CHECK(result.value().event_type_id == ups_event_cancel_requested);
+        CHECK(result.value().cancellation_reason == "Patient refused");
+        CHECK(scu.events_received() == 1);
+    }
+
+    SECTION("processes progress report event") {
+        dimse_message msg{command_field::n_event_report_rq, 1};
+        msg.set_affected_sop_class_uid(ups_watch_sop_class_uid);
+        msg.set_affected_sop_instance_uid("1.2.3.4.5");
+        msg.set_event_type_id(ups_event_progress_report);
+
+        dicom_dataset ds;
+        ds.set_string(ups_tags::procedure_step_progress,
+                      pacs::encoding::vr_type::DS, "75");
+        msg.set_dataset(std::move(ds));
+
+        auto result = scu.handle_event_report(msg);
+        REQUIRE(result.is_ok());
+        CHECK(result.value().event_type_id == ups_event_progress_report);
+        CHECK(result.value().progress == "75");
+        CHECK(scu.events_received() == 1);
+    }
+
+    SECTION("handles event without dataset") {
+        dimse_message msg{command_field::n_event_report_rq, 1};
+        msg.set_affected_sop_class_uid(ups_watch_sop_class_uid);
+        msg.set_affected_sop_instance_uid("1.2.3.4.5");
+        msg.set_event_type_id(ups_event_scp_status_change);
+
+        auto result = scu.handle_event_report(msg);
+        REQUIRE(result.is_ok());
+        CHECK(result.value().event_type_id == ups_event_scp_status_change);
+        CHECK(result.value().workitem_uid == "1.2.3.4.5");
+        CHECK(scu.events_received() == 1);
+    }
+
+    SECTION("invokes callback on event") {
+        ups_watch_event received_event;
+        scu.set_event_received_callback([&](const ups_watch_event& e) {
+            received_event = e;
+        });
+
+        dimse_message msg{command_field::n_event_report_rq, 1};
+        msg.set_affected_sop_class_uid(ups_watch_sop_class_uid);
+        msg.set_affected_sop_instance_uid("1.2.3.4.5");
+        msg.set_event_type_id(ups_event_state_report);
+
+        dicom_dataset ds;
+        ds.set_string(ups_tags::procedure_step_state,
+                      pacs::encoding::vr_type::CS, "IN PROGRESS");
+        msg.set_dataset(std::move(ds));
+
+        auto result = scu.handle_event_report(msg);
+        REQUIRE(result.is_ok());
+        CHECK(received_event.event_type_id == ups_event_state_report);
+        CHECK(received_event.procedure_step_state == "IN PROGRESS");
+        CHECK(received_event.workitem_uid == "1.2.3.4.5");
+    }
+
+    SECTION("increments events_received for multiple events") {
+        for (int i = 0; i < 3; ++i) {
+            dimse_message msg{command_field::n_event_report_rq, 1};
+            msg.set_affected_sop_class_uid(ups_watch_sop_class_uid);
+            msg.set_affected_sop_instance_uid("1.2.3.4." + std::to_string(i));
+            msg.set_event_type_id(ups_event_state_report);
+
+            dicom_dataset ds;
+            ds.set_string(ups_tags::procedure_step_state,
+                          pacs::encoding::vr_type::CS, "COMPLETED");
+            msg.set_dataset(std::move(ds));
+
+            auto result = scu.handle_event_report(msg);
+            REQUIRE(result.is_ok());
+        }
+        CHECK(scu.events_received() == 3);
+    }
+}
+
+// ============================================================================
+// Data Structure Copy and Move Tests
+// ============================================================================
+
+TEST_CASE("ups_subscribe_data is copyable and movable",
+          "[services][ups][watch-scu]") {
+    ups_subscribe_data data;
+    data.workitem_uid = "1.2.3.4.5.6.7.8";
+    data.deletion_lock = true;
+
+    SECTION("copy construction") {
+        ups_subscribe_data copy = data;
+        CHECK(copy.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(copy.deletion_lock == true);
+    }
+
+    SECTION("move construction") {
+        ups_subscribe_data moved = std::move(data);
+        CHECK(moved.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(moved.deletion_lock == true);
+    }
+}
+
+TEST_CASE("ups_unsubscribe_data is copyable and movable",
+          "[services][ups][watch-scu]") {
+    ups_unsubscribe_data data;
+    data.workitem_uid = "1.2.3.4.5.6.7.8";
+
+    SECTION("copy construction") {
+        ups_unsubscribe_data copy = data;
+        CHECK(copy.workitem_uid == "1.2.3.4.5.6.7.8");
+    }
+
+    SECTION("move construction") {
+        ups_unsubscribe_data moved = std::move(data);
+        CHECK(moved.workitem_uid == "1.2.3.4.5.6.7.8");
+    }
+}
+
+TEST_CASE("ups_watch_event is copyable and movable",
+          "[services][ups][watch-scu]") {
+    ups_watch_event event;
+    event.event_type_id = ups_event_state_report;
+    event.workitem_uid = "1.2.3.4.5.6.7.8";
+    event.procedure_step_state = "COMPLETED";
+    event.timestamp = std::chrono::system_clock::now();
+
+    SECTION("copy construction") {
+        ups_watch_event copy = event;
+        CHECK(copy.event_type_id == ups_event_state_report);
+        CHECK(copy.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(copy.procedure_step_state == "COMPLETED");
+    }
+
+    SECTION("move construction") {
+        ups_watch_event moved = std::move(event);
+        CHECK(moved.event_type_id == ups_event_state_report);
+        CHECK(moved.workitem_uid == "1.2.3.4.5.6.7.8");
+        CHECK(moved.procedure_step_state == "COMPLETED");
+    }
+}
+
+// ============================================================================
+// Event Dataset Content Tests
+// ============================================================================
+
+TEST_CASE("ups_watch_event preserves full event dataset",
+          "[services][ups][watch-scu]") {
+    ups_watch_scu scu;
+
+    dimse_message msg{command_field::n_event_report_rq, 1};
+    msg.set_affected_sop_class_uid(ups_watch_sop_class_uid);
+    msg.set_affected_sop_instance_uid("1.2.3.4.5");
+    msg.set_event_type_id(ups_event_state_report);
+
+    dicom_dataset ds;
+    ds.set_string(ups_tags::procedure_step_state,
+                  pacs::encoding::vr_type::CS, "COMPLETED");
+    msg.set_dataset(std::move(ds));
+
+    auto result = scu.handle_event_report(msg);
+    REQUIRE(result.is_ok());
+
+    // The event_info dataset should contain the original data
+    const auto& event = result.value();
+    auto state = event.event_info.get_string(ups_tags::procedure_step_state);
+    CHECK(state == "COMPLETED");
+}


### PR DESCRIPTION
Closes #815

## Summary
- Add `ups_watch_scu` class for subscribing to UPS workitem events on remote SCP servers
- Support N-ACTION operations: subscribe (Type 3), unsubscribe (Type 4), suspend global (Type 5)
- Handle incoming N-EVENT-REPORT notifications with automatic parsing of state changes, cancel requests, and progress updates
- Reuse constants from `ups_watch_scp.hpp` (SOP Class UID, action/event type constants) and result types from `ups_push_scu.hpp`

## Architecture
Follows the established SCU patterns:
- **N-ACTION sending**: `ups_push_scu` pattern — validate association, build request, send/receive, parse response
- **N-EVENT-REPORT receiving**: `storage_commitment_scu` pattern — verify command, parse dataset, invoke callback

## Files Created
- `include/pacs/services/ups/ups_watch_scu.hpp` — Class declaration, data structures (`ups_subscribe_data`, `ups_unsubscribe_data`, `ups_watch_event`, `ups_watch_scu_config`)
- `src/services/ups/ups_watch_scu.cpp` — Implementation with `send_watch_action()` helper and `parse_event_dataset()`
- `tests/services/ups_watch_scu_test.cpp` — 20 test cases covering construction, data structures, constants, statistics, callbacks, event handling, copy/move semantics

## Test Plan
- [x] 7/7 UPS Watch SCU tests pass
- [x] 73/73 all UPS-related tests pass
- [x] Full build succeeds (30/30 steps)