### PR TITLE
feat(security): implement ATNA audit message generator (RFC 3881 XML)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1136,6 +1136,7 @@ set(PACS_SECURITY_SOURCES
     src/security/tag_action.cpp
     src/security/uid_mapping.cpp
     src/security/anonymizer.cpp
+    src/security/atna_audit_logger.cpp
 )
 
 # Digital signature sources (requires OpenSSL - Issue #191)
@@ -1917,6 +1918,7 @@ if(PACS_BUILD_TESTS)
         tests/security/sqlite_security_storage_test.cpp
         tests/security/uid_mapping_test.cpp
         tests/security/anonymizer_test.cpp
+        tests/security/atna_audit_logger_test.cpp
     )
 
     # Add digital signature tests if OpenSSL is available (Issue #191)

--- a/include/pacs/security/atna_audit_logger.hpp
+++ b/include/pacs/security/atna_audit_logger.hpp
@@ -1,0 +1,609 @@
+/**
+ * @file atna_audit_logger.hpp
+ * @brief IHE ATNA-compliant audit message generator (RFC 3881 XML format)
+ *
+ * Generates RFC 3881 / DICOM PS3.15 Annex A.5 compliant XML audit messages
+ * for security-relevant events in DICOM systems.
+ *
+ * @see DICOM PS3.15 Annex A.5 — Audit Trail Message Format Profile
+ * @see IHE ITI TF-1 Section 9 — Audit Trail and Node Authentication (ATNA)
+ * @see RFC 3881 — Security Audit and Access Accountability Message XML
+ * @see Issue #817 - ATNA Audit Message Generator
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SECURITY_ATNA_AUDIT_LOGGER_HPP
+#define PACS_SECURITY_ATNA_AUDIT_LOGGER_HPP
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace pacs::security {
+
+// =============================================================================
+// RFC 3881 Coded Value
+// =============================================================================
+
+/**
+ * @brief A coded value with code, code system name, and display name
+ *
+ * Used for EventID, EventTypeCode, RoleIDCode, and ParticipantObjectIDTypeCode.
+ */
+struct atna_coded_value {
+    /// Code value (e.g., "110114")
+    std::string code;
+
+    /// Code system name (e.g., "DCM" for DICOM)
+    std::string code_system_name;
+
+    /// Human-readable display name (e.g., "UserAuthentication")
+    std::string display_name;
+};
+
+// =============================================================================
+// Event Action Code (RFC 3881 Section 5.1)
+// =============================================================================
+
+/**
+ * @brief Action that triggered the audit event
+ */
+enum class atna_event_action : char {
+    create = 'C',
+    read = 'R',
+    update = 'U',
+    delete_action = 'D',
+    execute = 'E'
+};
+
+// =============================================================================
+// Event Outcome Indicator (RFC 3881 Section 5.1)
+// =============================================================================
+
+/**
+ * @brief Outcome of the audited event
+ */
+enum class atna_event_outcome : uint8_t {
+    success = 0,
+    minor_failure = 4,
+    serious_failure = 8,
+    major_failure = 12
+};
+
+// =============================================================================
+// Network Access Point Type Code (RFC 3881 Section 5.2)
+// =============================================================================
+
+/**
+ * @brief Type of network access point identifier
+ */
+enum class atna_network_access_type : uint8_t {
+    machine_name = 1,
+    ip_address = 2,
+    phone_number = 3
+};
+
+// =============================================================================
+// Participant Object Type Code (RFC 3881 Section 5.5)
+// =============================================================================
+
+/**
+ * @brief Type of participant object
+ */
+enum class atna_object_type : uint8_t {
+    person = 1,
+    system_object = 2,
+    organization = 3,
+    other = 4
+};
+
+/**
+ * @brief Role of the participant object in the event
+ */
+enum class atna_object_role : uint8_t {
+    patient = 1,
+    location = 2,
+    report = 3,
+    resource = 4,
+    master_file = 5,
+    user = 6,
+    list = 7,
+    doctor = 8,
+    subscriber = 9,
+    guarantor = 10,
+    security_user_entity = 11,
+    security_user_group = 12,
+    security_resource = 13,
+    security_granularity_def = 14,
+    provider = 15,
+    data_destination = 16,
+    data_repository = 17,
+    schedule = 18,
+    customer = 19,
+    job = 20,
+    job_stream = 21,
+    table = 22,
+    routing_criteria = 23,
+    query = 24
+};
+
+// =============================================================================
+// Active Participant (RFC 3881 Section 5.2)
+// =============================================================================
+
+/**
+ * @brief An active participant in the audit event
+ *
+ * Represents a user, process, or system involved in the audited event.
+ */
+struct atna_active_participant {
+    /// User or process identifier
+    std::string user_id;
+
+    /// Alternative user ID (e.g., process name)
+    std::string alternative_user_id;
+
+    /// Human-readable user name
+    std::string user_name;
+
+    /// Whether this participant initiated the event
+    bool user_is_requestor{false};
+
+    /// Network access point (hostname or IP)
+    std::string network_access_point_id;
+
+    /// Type of network access point
+    atna_network_access_type network_access_point_type{
+        atna_network_access_type::ip_address};
+
+    /// Role(s) of this participant
+    std::vector<atna_coded_value> role_id_codes;
+};
+
+// =============================================================================
+// Audit Source Identification (RFC 3881 Section 5.4)
+// =============================================================================
+
+/**
+ * @brief Identifies the audit source system
+ */
+struct atna_audit_source {
+    /// Unique identifier for the audit source
+    std::string audit_source_id;
+
+    /// Enterprise site identifier (optional)
+    std::string audit_enterprise_site_id;
+
+    /// Audit source type codes (optional)
+    std::vector<uint8_t> audit_source_type_codes;
+};
+
+// =============================================================================
+// Participant Object Detail (RFC 3881 Section 5.5)
+// =============================================================================
+
+/**
+ * @brief Additional detail about a participant object
+ */
+struct atna_object_detail {
+    /// Detail type
+    std::string type;
+
+    /// Detail value
+    std::string value;
+};
+
+// =============================================================================
+// Participant Object Identification (RFC 3881 Section 5.5)
+// =============================================================================
+
+/**
+ * @brief An object (patient, study, query) involved in the event
+ */
+struct atna_participant_object {
+    /// Object type
+    atna_object_type object_type{atna_object_type::system_object};
+
+    /// Role of the object in the event
+    atna_object_role object_role{atna_object_role::resource};
+
+    /// Object ID type code
+    atna_coded_value object_id_type_code;
+
+    /// Object identifier (e.g., Patient ID, Study UID)
+    std::string object_id;
+
+    /// Human-readable object name
+    std::string object_name;
+
+    /// Query data (base64 encoded, for query events)
+    std::string object_query;
+
+    /// Additional details
+    std::vector<atna_object_detail> object_details;
+};
+
+// =============================================================================
+// Audit Message (RFC 3881 Section 5)
+// =============================================================================
+
+/**
+ * @brief Complete RFC 3881 audit message
+ */
+struct atna_audit_message {
+    // -- Event Identification --
+
+    /// Event ID coded value (e.g., DCM 110114 = UserAuthentication)
+    atna_coded_value event_id;
+
+    /// Event type codes for sub-classification
+    std::vector<atna_coded_value> event_type_codes;
+
+    /// Action that triggered the event
+    atna_event_action event_action{atna_event_action::execute};
+
+    /// When the event occurred
+    std::chrono::system_clock::time_point event_date_time;
+
+    /// Outcome of the event
+    atna_event_outcome event_outcome{atna_event_outcome::success};
+
+    // -- Participants --
+
+    /// Active participants (users/processes)
+    std::vector<atna_active_participant> active_participants;
+
+    /// Audit source identification
+    atna_audit_source audit_source;
+
+    /// Participant objects (patients/studies/queries)
+    std::vector<atna_participant_object> participant_objects;
+};
+
+// =============================================================================
+// Well-Known DCM Event IDs (DICOM PS3.15 A.5.3)
+// =============================================================================
+
+namespace atna_event_ids {
+
+/// Application Activity (110100) — Start/Stop
+inline const atna_coded_value application_activity{
+    "110100", "DCM", "Application Activity"};
+
+/// Audit Log Used (110101)
+inline const atna_coded_value audit_log_used{
+    "110101", "DCM", "Audit Log Used"};
+
+/// Begin Transferring DICOM Instances (110102)
+inline const atna_coded_value begin_transferring{
+    "110102", "DCM", "Begin Transferring DICOM Instances"};
+
+/// DICOM Instances Accessed (110103)
+inline const atna_coded_value dicom_instances_accessed{
+    "110103", "DCM", "DICOM Instances Accessed"};
+
+/// DICOM Instances Transferred (110104)
+inline const atna_coded_value dicom_instances_transferred{
+    "110104", "DCM", "DICOM Instances Transferred"};
+
+/// DICOM Study Deleted (110105)
+inline const atna_coded_value dicom_study_deleted{
+    "110105", "DCM", "DICOM Study Deleted"};
+
+/// Export (110106)
+inline const atna_coded_value data_export{
+    "110106", "DCM", "Export"};
+
+/// Import (110107)
+inline const atna_coded_value data_import{
+    "110107", "DCM", "Import"};
+
+/// Network Entry (110108)
+inline const atna_coded_value network_entry{
+    "110108", "DCM", "Network Entry"};
+
+/// Order Record (110109)
+inline const atna_coded_value order_record{
+    "110109", "DCM", "Order Record"};
+
+/// Patient Record (110110)
+inline const atna_coded_value patient_record{
+    "110110", "DCM", "Patient Record"};
+
+/// Procedure Record (110111)
+inline const atna_coded_value procedure_record{
+    "110111", "DCM", "Procedure Record"};
+
+/// Query (110112)
+inline const atna_coded_value query{
+    "110112", "DCM", "Query"};
+
+/// Security Alert (110113)
+inline const atna_coded_value security_alert{
+    "110113", "DCM", "Security Alert"};
+
+/// User Authentication (110114)
+inline const atna_coded_value user_authentication{
+    "110114", "DCM", "User Authentication"};
+
+}  // namespace atna_event_ids
+
+// =============================================================================
+// Well-Known Event Type Codes
+// =============================================================================
+
+namespace atna_event_types {
+
+/// Application Start
+inline const atna_coded_value application_start{
+    "110120", "DCM", "Application Start"};
+
+/// Application Stop
+inline const atna_coded_value application_stop{
+    "110121", "DCM", "Application Stop"};
+
+/// Login
+inline const atna_coded_value login{
+    "110122", "DCM", "Login"};
+
+/// Logout
+inline const atna_coded_value logout{
+    "110123", "DCM", "Logout"};
+
+}  // namespace atna_event_types
+
+// =============================================================================
+// Well-Known Role ID Codes
+// =============================================================================
+
+namespace atna_role_ids {
+
+/// Application (110150)
+inline const atna_coded_value application{
+    "110150", "DCM", "Application"};
+
+/// Application Launcher (110151)
+inline const atna_coded_value application_launcher{
+    "110151", "DCM", "Application Launcher"};
+
+/// Destination Role ID (110152)
+inline const atna_coded_value destination{
+    "110152", "DCM", "Destination Role ID"};
+
+/// Source Role ID (110153)
+inline const atna_coded_value source{
+    "110153", "DCM", "Source Role ID"};
+
+/// Destination Media (110154)
+inline const atna_coded_value destination_media{
+    "110154", "DCM", "Destination Media"};
+
+/// Source Media (110155)
+inline const atna_coded_value source_media{
+    "110155", "DCM", "Source Media"};
+
+}  // namespace atna_role_ids
+
+// =============================================================================
+// Well-Known Participant Object ID Type Codes
+// =============================================================================
+
+namespace atna_object_id_types {
+
+/// Patient Number (RFC 3881 defined)
+inline const atna_coded_value patient_number{
+    "2", "RFC-3881", "Patient Number"};
+
+/// Study Instance UID
+inline const atna_coded_value study_instance_uid{
+    "110180", "DCM", "Study Instance UID"};
+
+/// SOP Class UID
+inline const atna_coded_value sop_class_uid{
+    "110181", "DCM", "SOP Class UID"};
+
+/// Node ID
+inline const atna_coded_value node_id{
+    "110182", "DCM", "Node ID"};
+
+}  // namespace atna_object_id_types
+
+// =============================================================================
+// ATNA Audit Logger
+// =============================================================================
+
+/**
+ * @brief RFC 3881 XML audit message generator
+ *
+ * Generates well-formed XML audit messages compliant with
+ * DICOM PS3.15 Annex A.5 / RFC 3881.
+ */
+class atna_audit_logger {
+public:
+    // =========================================================================
+    // XML Generation
+    // =========================================================================
+
+    /**
+     * @brief Serialize an audit message to RFC 3881 XML
+     *
+     * @param message The audit message to serialize
+     * @return Well-formed XML string
+     */
+    [[nodiscard]] static std::string to_xml(const atna_audit_message& message);
+
+    // =========================================================================
+    // Event Factory Methods
+    // =========================================================================
+
+    /**
+     * @brief Build Application Activity audit message (start/stop)
+     *
+     * @param source_id Audit source identifier
+     * @param app_name Application name
+     * @param is_start true for application start, false for stop
+     * @param outcome Event outcome
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_application_activity(
+        const std::string& source_id,
+        const std::string& app_name,
+        bool is_start,
+        atna_event_outcome outcome = atna_event_outcome::success);
+
+    /**
+     * @brief Build DICOM Instances Accessed audit message (C-FIND, QIDO-RS)
+     *
+     * @param source_id Audit source identifier
+     * @param user_id User/AE Title that performed the access
+     * @param user_ip Source IP address
+     * @param study_uid Study Instance UID accessed
+     * @param patient_id Patient ID (if available)
+     * @param outcome Event outcome
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_dicom_instances_accessed(
+        const std::string& source_id,
+        const std::string& user_id,
+        const std::string& user_ip,
+        const std::string& study_uid,
+        const std::string& patient_id = "",
+        atna_event_outcome outcome = atna_event_outcome::success);
+
+    /**
+     * @brief Build DICOM Instances Transferred audit message (C-STORE, C-MOVE)
+     *
+     * @param source_id Audit source identifier
+     * @param source_ae Source AE Title
+     * @param source_ip Source IP address
+     * @param dest_ae Destination AE Title
+     * @param dest_ip Destination IP address
+     * @param study_uid Study Instance UID
+     * @param patient_id Patient ID (if available)
+     * @param is_import true if receiving (import), false if sending (export)
+     * @param outcome Event outcome
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_dicom_instances_transferred(
+        const std::string& source_id,
+        const std::string& source_ae,
+        const std::string& source_ip,
+        const std::string& dest_ae,
+        const std::string& dest_ip,
+        const std::string& study_uid,
+        const std::string& patient_id = "",
+        bool is_import = true,
+        atna_event_outcome outcome = atna_event_outcome::success);
+
+    /**
+     * @brief Build Study Deleted audit message
+     *
+     * @param source_id Audit source identifier
+     * @param user_id User/AE Title that deleted the study
+     * @param user_ip Source IP address
+     * @param study_uid Deleted Study Instance UID
+     * @param patient_id Patient ID
+     * @param outcome Event outcome
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_study_deleted(
+        const std::string& source_id,
+        const std::string& user_id,
+        const std::string& user_ip,
+        const std::string& study_uid,
+        const std::string& patient_id = "",
+        atna_event_outcome outcome = atna_event_outcome::success);
+
+    /**
+     * @brief Build Security Alert audit message
+     *
+     * @param source_id Audit source identifier
+     * @param user_id User/system that triggered the alert
+     * @param user_ip Source IP address
+     * @param alert_description Description of the security alert
+     * @param outcome Event outcome
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_security_alert(
+        const std::string& source_id,
+        const std::string& user_id,
+        const std::string& user_ip,
+        const std::string& alert_description,
+        atna_event_outcome outcome = atna_event_outcome::serious_failure);
+
+    /**
+     * @brief Build User Authentication audit message (login/logout)
+     *
+     * @param source_id Audit source identifier
+     * @param user_id User that authenticated
+     * @param user_ip Source IP address
+     * @param is_login true for login, false for logout
+     * @param outcome Event outcome (success/failure)
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_user_authentication(
+        const std::string& source_id,
+        const std::string& user_id,
+        const std::string& user_ip,
+        bool is_login,
+        atna_event_outcome outcome = atna_event_outcome::success);
+
+    /**
+     * @brief Build Query audit message (C-FIND, QIDO-RS)
+     *
+     * @param source_id Audit source identifier
+     * @param user_id User/AE Title that performed the query
+     * @param user_ip Source IP address
+     * @param query_data The query parameters (will be encoded)
+     * @param patient_id Patient ID from query (if available)
+     * @param outcome Event outcome
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_query(
+        const std::string& source_id,
+        const std::string& user_id,
+        const std::string& user_ip,
+        const std::string& query_data,
+        const std::string& patient_id = "",
+        atna_event_outcome outcome = atna_event_outcome::success);
+
+    /**
+     * @brief Build Export audit message (media/network export)
+     *
+     * @param source_id Audit source identifier
+     * @param user_id User/AE Title that exported data
+     * @param user_ip Source IP address
+     * @param dest_id Destination identifier
+     * @param study_uid Study Instance UID
+     * @param patient_id Patient ID
+     * @param outcome Event outcome
+     * @return Complete audit message
+     */
+    [[nodiscard]] static atna_audit_message build_export(
+        const std::string& source_id,
+        const std::string& user_id,
+        const std::string& user_ip,
+        const std::string& dest_id,
+        const std::string& study_uid,
+        const std::string& patient_id = "",
+        atna_event_outcome outcome = atna_event_outcome::success);
+
+private:
+    // =========================================================================
+    // XML Helpers
+    // =========================================================================
+
+    [[nodiscard]] static std::string xml_escape(const std::string& str);
+
+    [[nodiscard]] static std::string format_datetime(
+        std::chrono::system_clock::time_point tp);
+
+    [[nodiscard]] static std::string format_coded_value_attrs(
+        const atna_coded_value& cv);
+};
+
+}  // namespace pacs::security
+
+#endif  // PACS_SECURITY_ATNA_AUDIT_LOGGER_HPP

--- a/src/security/atna_audit_logger.cpp
+++ b/src/security/atna_audit_logger.cpp
@@ -1,0 +1,555 @@
+/**
+ * @file atna_audit_logger.cpp
+ * @brief Implementation of the ATNA audit message generator
+ */
+
+#include "pacs/security/atna_audit_logger.hpp"
+
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
+namespace pacs::security {
+
+// =============================================================================
+// XML Generation
+// =============================================================================
+
+std::string atna_audit_logger::to_xml(const atna_audit_message& msg) {
+    std::ostringstream xml;
+
+    xml << "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n";
+    xml << "<AuditMessage>\n";
+
+    // -- EventIdentification --
+    xml << "  <EventIdentification"
+        << " EventActionCode=\""
+        << static_cast<char>(msg.event_action) << "\""
+        << " EventDateTime=\"" << format_datetime(msg.event_date_time) << "\""
+        << " EventOutcomeIndicator=\""
+        << static_cast<int>(msg.event_outcome) << "\">\n";
+
+    xml << "    <EventID " << format_coded_value_attrs(msg.event_id) << "/>\n";
+
+    for (const auto& etc : msg.event_type_codes) {
+        xml << "    <EventTypeCode " << format_coded_value_attrs(etc)
+            << "/>\n";
+    }
+
+    xml << "  </EventIdentification>\n";
+
+    // -- ActiveParticipant(s) --
+    for (const auto& ap : msg.active_participants) {
+        xml << "  <ActiveParticipant"
+            << " UserID=\"" << xml_escape(ap.user_id) << "\"";
+
+        if (!ap.alternative_user_id.empty()) {
+            xml << " AlternativeUserID=\""
+                << xml_escape(ap.alternative_user_id) << "\"";
+        }
+
+        if (!ap.user_name.empty()) {
+            xml << " UserName=\"" << xml_escape(ap.user_name) << "\"";
+        }
+
+        xml << " UserIsRequestor=\""
+            << (ap.user_is_requestor ? "true" : "false") << "\"";
+
+        if (!ap.network_access_point_id.empty()) {
+            xml << " NetworkAccessPointID=\""
+                << xml_escape(ap.network_access_point_id) << "\""
+                << " NetworkAccessPointTypeCode=\""
+                << static_cast<int>(ap.network_access_point_type) << "\"";
+        }
+
+        if (ap.role_id_codes.empty()) {
+            xml << "/>\n";
+        } else {
+            xml << ">\n";
+            for (const auto& role : ap.role_id_codes) {
+                xml << "    <RoleIDCode "
+                    << format_coded_value_attrs(role) << "/>\n";
+            }
+            xml << "  </ActiveParticipant>\n";
+        }
+    }
+
+    // -- AuditSourceIdentification --
+    xml << "  <AuditSourceIdentification"
+        << " AuditSourceID=\""
+        << xml_escape(msg.audit_source.audit_source_id) << "\"";
+
+    if (!msg.audit_source.audit_enterprise_site_id.empty()) {
+        xml << " AuditEnterpriseSiteID=\""
+            << xml_escape(msg.audit_source.audit_enterprise_site_id) << "\"";
+    }
+
+    if (msg.audit_source.audit_source_type_codes.empty()) {
+        xml << "/>\n";
+    } else {
+        xml << ">\n";
+        for (auto type_code : msg.audit_source.audit_source_type_codes) {
+            xml << "    <AuditSourceTypeCode code=\""
+                << static_cast<int>(type_code) << "\"/>\n";
+        }
+        xml << "  </AuditSourceIdentification>\n";
+    }
+
+    // -- ParticipantObjectIdentification(s) --
+    for (const auto& po : msg.participant_objects) {
+        xml << "  <ParticipantObjectIdentification"
+            << " ParticipantObjectTypeCode=\""
+            << static_cast<int>(po.object_type) << "\""
+            << " ParticipantObjectTypeCodeRole=\""
+            << static_cast<int>(po.object_role) << "\"";
+
+        if (!po.object_id.empty()) {
+            xml << " ParticipantObjectID=\""
+                << xml_escape(po.object_id) << "\"";
+        }
+
+        if (!po.object_name.empty()) {
+            xml << " ParticipantObjectName=\""
+                << xml_escape(po.object_name) << "\"";
+        }
+
+        bool has_children = !po.object_id_type_code.code.empty() ||
+                            !po.object_query.empty() ||
+                            !po.object_details.empty();
+
+        if (!has_children) {
+            xml << "/>\n";
+        } else {
+            xml << ">\n";
+
+            if (!po.object_id_type_code.code.empty()) {
+                xml << "    <ParticipantObjectIDTypeCode "
+                    << format_coded_value_attrs(po.object_id_type_code)
+                    << "/>\n";
+            }
+
+            if (!po.object_query.empty()) {
+                xml << "    <ParticipantObjectQuery>"
+                    << xml_escape(po.object_query)
+                    << "</ParticipantObjectQuery>\n";
+            }
+
+            for (const auto& detail : po.object_details) {
+                xml << "    <ParticipantObjectDetail"
+                    << " type=\"" << xml_escape(detail.type) << "\""
+                    << " value=\"" << xml_escape(detail.value) << "\"/>\n";
+            }
+
+            xml << "  </ParticipantObjectIdentification>\n";
+        }
+    }
+
+    xml << "</AuditMessage>\n";
+
+    return xml.str();
+}
+
+// =============================================================================
+// Event Factory Methods
+// =============================================================================
+
+atna_audit_message atna_audit_logger::build_application_activity(
+    const std::string& source_id,
+    const std::string& app_name,
+    bool is_start,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::application_activity;
+    msg.event_type_codes.push_back(
+        is_start ? atna_event_types::application_start
+                 : atna_event_types::application_stop);
+    msg.event_action = atna_event_action::execute;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    atna_active_participant ap;
+    ap.user_id = app_name;
+    ap.user_is_requestor = false;
+    ap.role_id_codes.push_back(atna_role_ids::application);
+    msg.active_participants.push_back(std::move(ap));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    return msg;
+}
+
+atna_audit_message atna_audit_logger::build_dicom_instances_accessed(
+    const std::string& source_id,
+    const std::string& user_id,
+    const std::string& user_ip,
+    const std::string& study_uid,
+    const std::string& patient_id,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::dicom_instances_accessed;
+    msg.event_action = atna_event_action::read;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    atna_active_participant ap;
+    ap.user_id = user_id;
+    ap.user_is_requestor = true;
+    ap.network_access_point_id = user_ip;
+    ap.network_access_point_type = atna_network_access_type::ip_address;
+    msg.active_participants.push_back(std::move(ap));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    // Study object
+    if (!study_uid.empty()) {
+        atna_participant_object obj;
+        obj.object_type = atna_object_type::system_object;
+        obj.object_role = atna_object_role::report;
+        obj.object_id_type_code = atna_object_id_types::study_instance_uid;
+        obj.object_id = study_uid;
+        msg.participant_objects.push_back(std::move(obj));
+    }
+
+    // Patient object
+    if (!patient_id.empty()) {
+        atna_participant_object patient_obj;
+        patient_obj.object_type = atna_object_type::person;
+        patient_obj.object_role = atna_object_role::patient;
+        patient_obj.object_id_type_code = atna_object_id_types::patient_number;
+        patient_obj.object_id = patient_id;
+        msg.participant_objects.push_back(std::move(patient_obj));
+    }
+
+    return msg;
+}
+
+atna_audit_message atna_audit_logger::build_dicom_instances_transferred(
+    const std::string& source_id,
+    const std::string& source_ae,
+    const std::string& source_ip,
+    const std::string& dest_ae,
+    const std::string& dest_ip,
+    const std::string& study_uid,
+    const std::string& patient_id,
+    bool is_import,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::dicom_instances_transferred;
+    msg.event_action = is_import ? atna_event_action::create
+                                 : atna_event_action::read;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    // Source participant
+    atna_active_participant src;
+    src.user_id = source_ae;
+    src.user_is_requestor = !is_import;
+    src.network_access_point_id = source_ip;
+    src.network_access_point_type = atna_network_access_type::ip_address;
+    src.role_id_codes.push_back(atna_role_ids::source);
+    msg.active_participants.push_back(std::move(src));
+
+    // Destination participant
+    atna_active_participant dst;
+    dst.user_id = dest_ae;
+    dst.user_is_requestor = is_import;
+    dst.network_access_point_id = dest_ip;
+    dst.network_access_point_type = atna_network_access_type::ip_address;
+    dst.role_id_codes.push_back(atna_role_ids::destination);
+    msg.active_participants.push_back(std::move(dst));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    // Study object
+    if (!study_uid.empty()) {
+        atna_participant_object obj;
+        obj.object_type = atna_object_type::system_object;
+        obj.object_role = atna_object_role::report;
+        obj.object_id_type_code = atna_object_id_types::study_instance_uid;
+        obj.object_id = study_uid;
+        msg.participant_objects.push_back(std::move(obj));
+    }
+
+    // Patient object
+    if (!patient_id.empty()) {
+        atna_participant_object patient_obj;
+        patient_obj.object_type = atna_object_type::person;
+        patient_obj.object_role = atna_object_role::patient;
+        patient_obj.object_id_type_code = atna_object_id_types::patient_number;
+        patient_obj.object_id = patient_id;
+        msg.participant_objects.push_back(std::move(patient_obj));
+    }
+
+    return msg;
+}
+
+atna_audit_message atna_audit_logger::build_study_deleted(
+    const std::string& source_id,
+    const std::string& user_id,
+    const std::string& user_ip,
+    const std::string& study_uid,
+    const std::string& patient_id,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::dicom_study_deleted;
+    msg.event_action = atna_event_action::delete_action;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    atna_active_participant ap;
+    ap.user_id = user_id;
+    ap.user_is_requestor = true;
+    ap.network_access_point_id = user_ip;
+    ap.network_access_point_type = atna_network_access_type::ip_address;
+    msg.active_participants.push_back(std::move(ap));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    // Study object
+    atna_participant_object obj;
+    obj.object_type = atna_object_type::system_object;
+    obj.object_role = atna_object_role::report;
+    obj.object_id_type_code = atna_object_id_types::study_instance_uid;
+    obj.object_id = study_uid;
+    msg.participant_objects.push_back(std::move(obj));
+
+    // Patient object
+    if (!patient_id.empty()) {
+        atna_participant_object patient_obj;
+        patient_obj.object_type = atna_object_type::person;
+        patient_obj.object_role = atna_object_role::patient;
+        patient_obj.object_id_type_code = atna_object_id_types::patient_number;
+        patient_obj.object_id = patient_id;
+        msg.participant_objects.push_back(std::move(patient_obj));
+    }
+
+    return msg;
+}
+
+atna_audit_message atna_audit_logger::build_security_alert(
+    const std::string& source_id,
+    const std::string& user_id,
+    const std::string& user_ip,
+    const std::string& alert_description,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::security_alert;
+    msg.event_action = atna_event_action::execute;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    atna_active_participant ap;
+    ap.user_id = user_id;
+    ap.user_is_requestor = true;
+    ap.network_access_point_id = user_ip;
+    ap.network_access_point_type = atna_network_access_type::ip_address;
+    msg.active_participants.push_back(std::move(ap));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    // Alert description as participant object
+    atna_participant_object obj;
+    obj.object_type = atna_object_type::system_object;
+    obj.object_role = atna_object_role::security_resource;
+    obj.object_id = source_id;
+    obj.object_name = alert_description;
+    msg.participant_objects.push_back(std::move(obj));
+
+    return msg;
+}
+
+atna_audit_message atna_audit_logger::build_user_authentication(
+    const std::string& source_id,
+    const std::string& user_id,
+    const std::string& user_ip,
+    bool is_login,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::user_authentication;
+    msg.event_type_codes.push_back(
+        is_login ? atna_event_types::login : atna_event_types::logout);
+    msg.event_action = atna_event_action::execute;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    atna_active_participant ap;
+    ap.user_id = user_id;
+    ap.user_is_requestor = true;
+    ap.network_access_point_id = user_ip;
+    ap.network_access_point_type = atna_network_access_type::ip_address;
+    msg.active_participants.push_back(std::move(ap));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    return msg;
+}
+
+atna_audit_message atna_audit_logger::build_query(
+    const std::string& source_id,
+    const std::string& user_id,
+    const std::string& user_ip,
+    const std::string& query_data,
+    const std::string& patient_id,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::query;
+    msg.event_action = atna_event_action::execute;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    atna_active_participant ap;
+    ap.user_id = user_id;
+    ap.user_is_requestor = true;
+    ap.network_access_point_id = user_ip;
+    ap.network_access_point_type = atna_network_access_type::ip_address;
+    ap.role_id_codes.push_back(atna_role_ids::source);
+    msg.active_participants.push_back(std::move(ap));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    // Query object
+    atna_participant_object query_obj;
+    query_obj.object_type = atna_object_type::system_object;
+    query_obj.object_role = atna_object_role::query;
+    query_obj.object_id_type_code = atna_object_id_types::sop_class_uid;
+    query_obj.object_query = query_data;
+    msg.participant_objects.push_back(std::move(query_obj));
+
+    // Patient object
+    if (!patient_id.empty()) {
+        atna_participant_object patient_obj;
+        patient_obj.object_type = atna_object_type::person;
+        patient_obj.object_role = atna_object_role::patient;
+        patient_obj.object_id_type_code = atna_object_id_types::patient_number;
+        patient_obj.object_id = patient_id;
+        msg.participant_objects.push_back(std::move(patient_obj));
+    }
+
+    return msg;
+}
+
+atna_audit_message atna_audit_logger::build_export(
+    const std::string& source_id,
+    const std::string& user_id,
+    const std::string& user_ip,
+    const std::string& dest_id,
+    const std::string& study_uid,
+    const std::string& patient_id,
+    atna_event_outcome outcome) {
+
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::data_export;
+    msg.event_action = atna_event_action::read;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = outcome;
+
+    // Exporter
+    atna_active_participant exporter;
+    exporter.user_id = user_id;
+    exporter.user_is_requestor = true;
+    exporter.network_access_point_id = user_ip;
+    exporter.network_access_point_type = atna_network_access_type::ip_address;
+    exporter.role_id_codes.push_back(atna_role_ids::source);
+    msg.active_participants.push_back(std::move(exporter));
+
+    // Destination
+    atna_active_participant dest;
+    dest.user_id = dest_id;
+    dest.user_is_requestor = false;
+    dest.role_id_codes.push_back(atna_role_ids::destination);
+    msg.active_participants.push_back(std::move(dest));
+
+    msg.audit_source.audit_source_id = source_id;
+
+    // Study object
+    if (!study_uid.empty()) {
+        atna_participant_object obj;
+        obj.object_type = atna_object_type::system_object;
+        obj.object_role = atna_object_role::report;
+        obj.object_id_type_code = atna_object_id_types::study_instance_uid;
+        obj.object_id = study_uid;
+        msg.participant_objects.push_back(std::move(obj));
+    }
+
+    // Patient object
+    if (!patient_id.empty()) {
+        atna_participant_object patient_obj;
+        patient_obj.object_type = atna_object_type::person;
+        patient_obj.object_role = atna_object_role::patient;
+        patient_obj.object_id_type_code = atna_object_id_types::patient_number;
+        patient_obj.object_id = patient_id;
+        msg.participant_objects.push_back(std::move(patient_obj));
+    }
+
+    return msg;
+}
+
+// =============================================================================
+// Private XML Helpers
+// =============================================================================
+
+std::string atna_audit_logger::xml_escape(const std::string& str) {
+    std::string result;
+    result.reserve(str.size());
+
+    for (char c : str) {
+        switch (c) {
+            case '&':  result += "&amp;";  break;
+            case '<':  result += "&lt;";   break;
+            case '>':  result += "&gt;";   break;
+            case '"':  result += "&quot;"; break;
+            case '\'': result += "&apos;"; break;
+            default:   result += c;        break;
+        }
+    }
+
+    return result;
+}
+
+std::string atna_audit_logger::format_datetime(
+    std::chrono::system_clock::time_point tp) {
+
+    auto time_t_val = std::chrono::system_clock::to_time_t(tp);
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+        tp.time_since_epoch()) % 1000;
+
+    std::tm tm_val{};
+#if defined(_WIN32)
+    gmtime_s(&tm_val, &time_t_val);
+#else
+    gmtime_r(&time_t_val, &tm_val);
+#endif
+
+    std::ostringstream oss;
+    oss << std::put_time(&tm_val, "%Y-%m-%dT%H:%M:%S")
+        << '.' << std::setfill('0') << std::setw(3) << ms.count()
+        << "Z";
+
+    return oss.str();
+}
+
+std::string atna_audit_logger::format_coded_value_attrs(
+    const atna_coded_value& cv) {
+
+    std::ostringstream oss;
+    oss << "csd-code=\"" << xml_escape(cv.code) << "\"";
+
+    if (!cv.code_system_name.empty()) {
+        oss << " codeSystemName=\"" << xml_escape(cv.code_system_name) << "\"";
+    }
+
+    if (!cv.display_name.empty()) {
+        oss << " originalText=\"" << xml_escape(cv.display_name) << "\"";
+    }
+
+    return oss.str();
+}
+
+}  // namespace pacs::security

--- a/tests/security/atna_audit_logger_test.cpp
+++ b/tests/security/atna_audit_logger_test.cpp
@@ -1,0 +1,662 @@
+/**
+ * @file atna_audit_logger_test.cpp
+ * @brief Unit tests for IHE ATNA-compliant audit message generator
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "pacs/security/atna_audit_logger.hpp"
+
+#include <string>
+
+using namespace pacs::security;
+using Catch::Matchers::ContainsSubstring;
+
+// =============================================================================
+// Data Structure Tests
+// =============================================================================
+
+TEST_CASE("atna_coded_value holds code, system, and display name",
+          "[security][atna]") {
+    atna_coded_value cv{"110100", "DCM", "Application Activity"};
+
+    CHECK(cv.code == "110100");
+    CHECK(cv.code_system_name == "DCM");
+    CHECK(cv.display_name == "Application Activity");
+}
+
+TEST_CASE("atna_event_action enum values match RFC 3881",
+          "[security][atna]") {
+    CHECK(static_cast<char>(atna_event_action::create) == 'C');
+    CHECK(static_cast<char>(atna_event_action::read) == 'R');
+    CHECK(static_cast<char>(atna_event_action::update) == 'U');
+    CHECK(static_cast<char>(atna_event_action::delete_action) == 'D');
+    CHECK(static_cast<char>(atna_event_action::execute) == 'E');
+}
+
+TEST_CASE("atna_event_outcome enum values match RFC 3881",
+          "[security][atna]") {
+    CHECK(static_cast<uint8_t>(atna_event_outcome::success) == 0);
+    CHECK(static_cast<uint8_t>(atna_event_outcome::minor_failure) == 4);
+    CHECK(static_cast<uint8_t>(atna_event_outcome::serious_failure) == 8);
+    CHECK(static_cast<uint8_t>(atna_event_outcome::major_failure) == 12);
+}
+
+TEST_CASE("atna_network_access_type enum values", "[security][atna]") {
+    CHECK(static_cast<uint8_t>(atna_network_access_type::machine_name) == 1);
+    CHECK(static_cast<uint8_t>(atna_network_access_type::ip_address) == 2);
+    CHECK(static_cast<uint8_t>(atna_network_access_type::phone_number) == 3);
+}
+
+TEST_CASE("atna_object_type and atna_object_role values", "[security][atna]") {
+    CHECK(static_cast<uint8_t>(atna_object_type::person) == 1);
+    CHECK(static_cast<uint8_t>(atna_object_type::system_object) == 2);
+    CHECK(static_cast<uint8_t>(atna_object_type::organization) == 3);
+    CHECK(static_cast<uint8_t>(atna_object_type::other) == 4);
+
+    CHECK(static_cast<uint8_t>(atna_object_role::patient) == 1);
+    CHECK(static_cast<uint8_t>(atna_object_role::report) == 3);
+    CHECK(static_cast<uint8_t>(atna_object_role::query) == 24);
+}
+
+TEST_CASE("atna_active_participant default values", "[security][atna]") {
+    atna_active_participant ap;
+    CHECK(ap.user_id.empty());
+    CHECK(ap.user_is_requestor == false);
+    CHECK(ap.network_access_point_type ==
+          atna_network_access_type::ip_address);
+    CHECK(ap.role_id_codes.empty());
+}
+
+TEST_CASE("atna_audit_message default values", "[security][atna]") {
+    atna_audit_message msg;
+    CHECK(msg.event_action == atna_event_action::execute);
+    CHECK(msg.event_outcome == atna_event_outcome::success);
+    CHECK(msg.active_participants.empty());
+    CHECK(msg.participant_objects.empty());
+    CHECK(msg.event_type_codes.empty());
+}
+
+// =============================================================================
+// Well-Known Constants Tests
+// =============================================================================
+
+TEST_CASE("ATNA event IDs have correct DCM codes", "[security][atna]") {
+    CHECK(atna_event_ids::application_activity.code == "110100");
+    CHECK(atna_event_ids::audit_log_used.code == "110101");
+    CHECK(atna_event_ids::begin_transferring.code == "110102");
+    CHECK(atna_event_ids::dicom_instances_accessed.code == "110103");
+    CHECK(atna_event_ids::dicom_instances_transferred.code == "110104");
+    CHECK(atna_event_ids::dicom_study_deleted.code == "110105");
+    CHECK(atna_event_ids::data_export.code == "110106");
+    CHECK(atna_event_ids::data_import.code == "110107");
+    CHECK(atna_event_ids::network_entry.code == "110108");
+    CHECK(atna_event_ids::order_record.code == "110109");
+    CHECK(atna_event_ids::patient_record.code == "110110");
+    CHECK(atna_event_ids::procedure_record.code == "110111");
+    CHECK(atna_event_ids::query.code == "110112");
+    CHECK(atna_event_ids::security_alert.code == "110113");
+    CHECK(atna_event_ids::user_authentication.code == "110114");
+
+    // All should use DCM code system
+    CHECK(atna_event_ids::application_activity.code_system_name == "DCM");
+    CHECK(atna_event_ids::user_authentication.code_system_name == "DCM");
+}
+
+TEST_CASE("ATNA event type codes for start/stop and login/logout",
+          "[security][atna]") {
+    CHECK(atna_event_types::application_start.code == "110120");
+    CHECK(atna_event_types::application_stop.code == "110121");
+    CHECK(atna_event_types::login.code == "110122");
+    CHECK(atna_event_types::logout.code == "110123");
+}
+
+TEST_CASE("ATNA role ID codes", "[security][atna]") {
+    CHECK(atna_role_ids::application.code == "110150");
+    CHECK(atna_role_ids::application_launcher.code == "110151");
+    CHECK(atna_role_ids::destination.code == "110152");
+    CHECK(atna_role_ids::source.code == "110153");
+    CHECK(atna_role_ids::destination_media.code == "110154");
+    CHECK(atna_role_ids::source_media.code == "110155");
+}
+
+TEST_CASE("ATNA object ID type codes", "[security][atna]") {
+    CHECK(atna_object_id_types::patient_number.code == "2");
+    CHECK(atna_object_id_types::patient_number.code_system_name == "RFC-3881");
+    CHECK(atna_object_id_types::study_instance_uid.code == "110180");
+    CHECK(atna_object_id_types::sop_class_uid.code == "110181");
+    CHECK(atna_object_id_types::node_id.code == "110182");
+}
+
+// =============================================================================
+// XML Generation Tests
+// =============================================================================
+
+TEST_CASE("to_xml produces valid XML structure", "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS_SERVER", "admin", "192.168.1.100", true);
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    CHECK_THAT(xml, ContainsSubstring("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+    CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    CHECK_THAT(xml, ContainsSubstring("</AuditMessage>"));
+    CHECK_THAT(xml, ContainsSubstring("<EventIdentification"));
+    CHECK_THAT(xml, ContainsSubstring("</EventIdentification>"));
+    CHECK_THAT(xml, ContainsSubstring("<ActiveParticipant"));
+    CHECK_THAT(xml, ContainsSubstring("<AuditSourceIdentification"));
+}
+
+TEST_CASE("to_xml includes correct event attributes", "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS_SERVER", "admin", "192.168.1.100", true);
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    // EventActionCode="E" for Execute
+    CHECK_THAT(xml, ContainsSubstring("EventActionCode=\"E\""));
+    // EventOutcomeIndicator="0" for Success
+    CHECK_THAT(xml, ContainsSubstring("EventOutcomeIndicator=\"0\""));
+    // EventID csd-code="110114" for UserAuthentication
+    CHECK_THAT(xml, ContainsSubstring("csd-code=\"110114\""));
+    // EventTypeCode for Login
+    CHECK_THAT(xml, ContainsSubstring("csd-code=\"110122\""));
+}
+
+TEST_CASE("to_xml includes ActiveParticipant details", "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS_SERVER", "admin", "192.168.1.100", true);
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    CHECK_THAT(xml, ContainsSubstring("UserID=\"admin\""));
+    CHECK_THAT(xml, ContainsSubstring("UserIsRequestor=\"true\""));
+    CHECK_THAT(xml, ContainsSubstring("NetworkAccessPointID=\"192.168.1.100\""));
+    CHECK_THAT(xml, ContainsSubstring("NetworkAccessPointTypeCode=\"2\""));
+}
+
+TEST_CASE("to_xml includes AuditSourceIdentification", "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS_SERVER", "admin", "192.168.1.100", true);
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    CHECK_THAT(xml, ContainsSubstring("AuditSourceID=\"PACS_SERVER\""));
+}
+
+TEST_CASE("to_xml includes ParticipantObjectIdentification",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_dicom_instances_accessed(
+        "PACS", "MODALITY_AE", "10.0.0.5",
+        "1.2.840.113619.2.55.3", "PAT001");
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    // Study object
+    CHECK_THAT(xml, ContainsSubstring(
+        "ParticipantObjectID=\"1.2.840.113619.2.55.3\""));
+    // Patient object
+    CHECK_THAT(xml, ContainsSubstring(
+        "ParticipantObjectID=\"PAT001\""));
+    // ParticipantObjectIDTypeCode for study
+    CHECK_THAT(xml, ContainsSubstring("csd-code=\"110180\""));
+    // ParticipantObjectIDTypeCode for patient
+    CHECK_THAT(xml, ContainsSubstring("csd-code=\"2\""));
+}
+
+TEST_CASE("to_xml escapes special XML characters", "[security][atna]") {
+    auto msg = atna_audit_logger::build_security_alert(
+        "PACS", "user<admin>", "10.0.0.1",
+        "Alert: A&B \"test\" 'msg'");
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    CHECK_THAT(xml, ContainsSubstring("user&lt;admin&gt;"));
+    CHECK_THAT(xml, ContainsSubstring("A&amp;B"));
+    CHECK_THAT(xml, ContainsSubstring("&quot;test&quot;"));
+    CHECK_THAT(xml, ContainsSubstring("&apos;msg&apos;"));
+}
+
+TEST_CASE("to_xml formats EventDateTime with milliseconds",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_application_activity(
+        "PACS", "MyApp", true);
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    // Should contain a datetime pattern like "2026-03-02T..."
+    CHECK_THAT(xml, ContainsSubstring("EventDateTime=\""));
+    CHECK_THAT(xml, ContainsSubstring("Z\""));
+}
+
+TEST_CASE("to_xml includes RoleIDCode as child element", "[security][atna]") {
+    auto msg = atna_audit_logger::build_application_activity(
+        "PACS", "MyApp", true);
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    // Application role should be present as child element
+    CHECK_THAT(xml, ContainsSubstring("<RoleIDCode"));
+    CHECK_THAT(xml, ContainsSubstring("csd-code=\"110150\""));
+    CHECK_THAT(xml, ContainsSubstring("</ActiveParticipant>"));
+}
+
+TEST_CASE("to_xml handles message with no participant objects",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS", "admin", "10.0.0.1", false);
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    // Should still produce valid XML without ParticipantObjectIdentification
+    CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    CHECK_THAT(xml, ContainsSubstring("</AuditMessage>"));
+    // Logout event type
+    CHECK_THAT(xml, ContainsSubstring("csd-code=\"110123\""));
+}
+
+TEST_CASE("to_xml handles query object with query data", "[security][atna]") {
+    auto msg = atna_audit_logger::build_query(
+        "PACS", "FINDER_AE", "10.0.0.2",
+        "PatientName=DOE*", "PAT002");
+
+    auto xml = atna_audit_logger::to_xml(msg);
+
+    CHECK_THAT(xml, ContainsSubstring("<ParticipantObjectQuery>"));
+    CHECK_THAT(xml, ContainsSubstring("PatientName=DOE*"));
+    CHECK_THAT(xml, ContainsSubstring("</ParticipantObjectQuery>"));
+}
+
+// =============================================================================
+// Factory Method Tests
+// =============================================================================
+
+TEST_CASE("build_application_activity produces correct start message",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_application_activity(
+        "PACS_01", "DicomServer", true);
+
+    CHECK(msg.event_id.code == "110100");
+    CHECK(msg.event_action == atna_event_action::execute);
+    CHECK(msg.event_outcome == atna_event_outcome::success);
+    REQUIRE(msg.event_type_codes.size() == 1);
+    CHECK(msg.event_type_codes[0].code == "110120"); // Application Start
+
+    REQUIRE(msg.active_participants.size() == 1);
+    CHECK(msg.active_participants[0].user_id == "DicomServer");
+    CHECK(msg.active_participants[0].user_is_requestor == false);
+    REQUIRE(msg.active_participants[0].role_id_codes.size() == 1);
+    CHECK(msg.active_participants[0].role_id_codes[0].code == "110150");
+
+    CHECK(msg.audit_source.audit_source_id == "PACS_01");
+}
+
+TEST_CASE("build_application_activity produces stop message",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_application_activity(
+        "PACS_01", "DicomServer", false,
+        atna_event_outcome::minor_failure);
+
+    REQUIRE(msg.event_type_codes.size() == 1);
+    CHECK(msg.event_type_codes[0].code == "110121"); // Application Stop
+    CHECK(msg.event_outcome == atna_event_outcome::minor_failure);
+}
+
+TEST_CASE("build_dicom_instances_accessed with study and patient",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_dicom_instances_accessed(
+        "PACS", "CT_AE", "192.168.1.50",
+        "1.2.840.12345", "PAT100");
+
+    CHECK(msg.event_id.code == "110103");
+    CHECK(msg.event_action == atna_event_action::read);
+
+    REQUIRE(msg.active_participants.size() == 1);
+    CHECK(msg.active_participants[0].user_id == "CT_AE");
+    CHECK(msg.active_participants[0].user_is_requestor == true);
+    CHECK(msg.active_participants[0].network_access_point_id == "192.168.1.50");
+
+    REQUIRE(msg.participant_objects.size() == 2);
+    // Study object
+    CHECK(msg.participant_objects[0].object_id == "1.2.840.12345");
+    CHECK(msg.participant_objects[0].object_role == atna_object_role::report);
+    CHECK(msg.participant_objects[0].object_id_type_code.code == "110180");
+    // Patient object
+    CHECK(msg.participant_objects[1].object_id == "PAT100");
+    CHECK(msg.participant_objects[1].object_role == atna_object_role::patient);
+    CHECK(msg.participant_objects[1].object_id_type_code.code == "2");
+}
+
+TEST_CASE("build_dicom_instances_accessed without patient",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_dicom_instances_accessed(
+        "PACS", "CT_AE", "10.0.0.1", "1.2.3.4");
+
+    REQUIRE(msg.participant_objects.size() == 1);
+    CHECK(msg.participant_objects[0].object_id == "1.2.3.4");
+}
+
+TEST_CASE("build_dicom_instances_transferred for import",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_dicom_instances_transferred(
+        "PACS", "MODALITY", "10.0.0.10",
+        "PACS_AE", "10.0.0.20",
+        "1.2.840.99999", "PAT200", true);
+
+    CHECK(msg.event_id.code == "110104");
+    CHECK(msg.event_action == atna_event_action::create); // Import = Create
+
+    REQUIRE(msg.active_participants.size() == 2);
+    // Source
+    CHECK(msg.active_participants[0].user_id == "MODALITY");
+    CHECK(msg.active_participants[0].user_is_requestor == false); // Not requestor for import
+    CHECK(msg.active_participants[0].role_id_codes[0].code == "110153"); // Source
+    // Destination
+    CHECK(msg.active_participants[1].user_id == "PACS_AE");
+    CHECK(msg.active_participants[1].user_is_requestor == true); // Requestor for import
+    CHECK(msg.active_participants[1].role_id_codes[0].code == "110152"); // Destination
+
+    REQUIRE(msg.participant_objects.size() == 2);
+}
+
+TEST_CASE("build_dicom_instances_transferred for export",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_dicom_instances_transferred(
+        "PACS", "PACS_AE", "10.0.0.20",
+        "WORKSTATION", "10.0.0.30",
+        "1.2.840.88888", "", false);
+
+    CHECK(msg.event_action == atna_event_action::read); // Export = Read
+
+    REQUIRE(msg.active_participants.size() == 2);
+    CHECK(msg.active_participants[0].user_is_requestor == true); // Requestor for export
+    CHECK(msg.active_participants[1].user_is_requestor == false);
+
+    // No patient object (empty patient_id)
+    REQUIRE(msg.participant_objects.size() == 1);
+}
+
+TEST_CASE("build_study_deleted includes study and patient objects",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_study_deleted(
+        "PACS", "admin_user", "10.0.0.1",
+        "1.2.840.55555", "PAT300");
+
+    CHECK(msg.event_id.code == "110105");
+    CHECK(msg.event_action == atna_event_action::delete_action);
+
+    REQUIRE(msg.active_participants.size() == 1);
+    CHECK(msg.active_participants[0].user_id == "admin_user");
+    CHECK(msg.active_participants[0].user_is_requestor == true);
+
+    REQUIRE(msg.participant_objects.size() == 2);
+    CHECK(msg.participant_objects[0].object_id == "1.2.840.55555");
+    CHECK(msg.participant_objects[1].object_id == "PAT300");
+}
+
+TEST_CASE("build_study_deleted without patient", "[security][atna]") {
+    auto msg = atna_audit_logger::build_study_deleted(
+        "PACS", "admin", "10.0.0.1", "1.2.3.4");
+
+    REQUIRE(msg.participant_objects.size() == 1);
+    CHECK(msg.participant_objects[0].object_id == "1.2.3.4");
+}
+
+TEST_CASE("build_security_alert default outcome is serious_failure",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_security_alert(
+        "PACS", "system", "10.0.0.1",
+        "TLS handshake failed");
+
+    CHECK(msg.event_id.code == "110113");
+    CHECK(msg.event_action == atna_event_action::execute);
+    CHECK(msg.event_outcome == atna_event_outcome::serious_failure);
+
+    REQUIRE(msg.participant_objects.size() == 1);
+    CHECK(msg.participant_objects[0].object_name == "TLS handshake failed");
+    CHECK(msg.participant_objects[0].object_role ==
+          atna_object_role::security_resource);
+}
+
+TEST_CASE("build_user_authentication login event", "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS", "dr.smith", "192.168.1.200", true);
+
+    CHECK(msg.event_id.code == "110114");
+    REQUIRE(msg.event_type_codes.size() == 1);
+    CHECK(msg.event_type_codes[0].code == "110122"); // Login
+
+    REQUIRE(msg.active_participants.size() == 1);
+    CHECK(msg.active_participants[0].user_id == "dr.smith");
+    CHECK(msg.participant_objects.empty());
+}
+
+TEST_CASE("build_user_authentication logout event", "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS", "dr.smith", "192.168.1.200", false);
+
+    REQUIRE(msg.event_type_codes.size() == 1);
+    CHECK(msg.event_type_codes[0].code == "110123"); // Logout
+}
+
+TEST_CASE("build_user_authentication failed login", "[security][atna]") {
+    auto msg = atna_audit_logger::build_user_authentication(
+        "PACS", "hacker", "10.0.0.99", true,
+        atna_event_outcome::serious_failure);
+
+    CHECK(msg.event_outcome == atna_event_outcome::serious_failure);
+}
+
+TEST_CASE("build_query includes query data and patient", "[security][atna]") {
+    auto msg = atna_audit_logger::build_query(
+        "PACS", "FINDER_AE", "10.0.0.5",
+        "PatientName=DOE*&StudyDate=20240101-", "PAT400");
+
+    CHECK(msg.event_id.code == "110112");
+    CHECK(msg.event_action == atna_event_action::execute);
+
+    REQUIRE(msg.active_participants.size() == 1);
+    CHECK(msg.active_participants[0].role_id_codes[0].code == "110153"); // Source
+
+    REQUIRE(msg.participant_objects.size() == 2);
+    // Query object
+    CHECK(msg.participant_objects[0].object_role == atna_object_role::query);
+    CHECK(msg.participant_objects[0].object_query ==
+          "PatientName=DOE*&StudyDate=20240101-");
+    // Patient object
+    CHECK(msg.participant_objects[1].object_id == "PAT400");
+}
+
+TEST_CASE("build_query without patient", "[security][atna]") {
+    auto msg = atna_audit_logger::build_query(
+        "PACS", "AE", "10.0.0.1", "Modality=CT");
+
+    REQUIRE(msg.participant_objects.size() == 1);
+    CHECK(msg.participant_objects[0].object_role == atna_object_role::query);
+}
+
+TEST_CASE("build_export includes source, destination, study, patient",
+          "[security][atna]") {
+    auto msg = atna_audit_logger::build_export(
+        "PACS", "EXPORTER_AE", "10.0.0.5",
+        "REMOTE_AE", "1.2.840.77777", "PAT500");
+
+    CHECK(msg.event_id.code == "110106");
+    CHECK(msg.event_action == atna_event_action::read);
+
+    REQUIRE(msg.active_participants.size() == 2);
+    // Exporter (source)
+    CHECK(msg.active_participants[0].user_id == "EXPORTER_AE");
+    CHECK(msg.active_participants[0].user_is_requestor == true);
+    CHECK(msg.active_participants[0].role_id_codes[0].code == "110153"); // Source
+    // Destination
+    CHECK(msg.active_participants[1].user_id == "REMOTE_AE");
+    CHECK(msg.active_participants[1].user_is_requestor == false);
+    CHECK(msg.active_participants[1].role_id_codes[0].code == "110152"); // Dest
+
+    REQUIRE(msg.participant_objects.size() == 2);
+    CHECK(msg.participant_objects[0].object_id == "1.2.840.77777");
+    CHECK(msg.participant_objects[1].object_id == "PAT500");
+}
+
+TEST_CASE("build_export without patient", "[security][atna]") {
+    auto msg = atna_audit_logger::build_export(
+        "PACS", "AE", "10.0.0.1", "DEST", "1.2.3");
+
+    REQUIRE(msg.participant_objects.size() == 1);
+    CHECK(msg.participant_objects[0].object_id == "1.2.3");
+}
+
+// =============================================================================
+// XML Round-Trip Validation
+// =============================================================================
+
+TEST_CASE("All factory methods produce parseable XML", "[security][atna]") {
+    // Ensure each factory method generates XML without errors
+    SECTION("application_activity") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_application_activity(
+                "SRC", "App", true));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+        CHECK_THAT(xml, ContainsSubstring("</AuditMessage>"));
+    }
+
+    SECTION("dicom_instances_accessed") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_dicom_instances_accessed(
+                "SRC", "AE", "1.2.3.4", "1.2.3"));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    }
+
+    SECTION("dicom_instances_transferred") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_dicom_instances_transferred(
+                "SRC", "SRC_AE", "1.2.3.4", "DST_AE", "5.6.7.8", "1.2.3"));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    }
+
+    SECTION("study_deleted") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_study_deleted(
+                "SRC", "user", "1.2.3.4", "1.2.3"));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    }
+
+    SECTION("security_alert") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_security_alert(
+                "SRC", "user", "1.2.3.4", "alert"));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    }
+
+    SECTION("user_authentication") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_user_authentication(
+                "SRC", "user", "1.2.3.4", true));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    }
+
+    SECTION("query") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_query(
+                "SRC", "AE", "1.2.3.4", "query=*"));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    }
+
+    SECTION("export") {
+        auto xml = atna_audit_logger::to_xml(
+            atna_audit_logger::build_export(
+                "SRC", "AE", "1.2.3.4", "DEST", "1.2.3"));
+        CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    }
+}
+
+// =============================================================================
+// Edge Cases
+// =============================================================================
+
+TEST_CASE("to_xml handles empty audit source", "[security][atna]") {
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::security_alert;
+    msg.event_date_time = std::chrono::system_clock::now();
+
+    auto xml = atna_audit_logger::to_xml(msg);
+    CHECK_THAT(xml, ContainsSubstring("<AuditMessage>"));
+    CHECK_THAT(xml, ContainsSubstring("AuditSourceID=\"\""));
+}
+
+TEST_CASE("to_xml handles ActiveParticipant without network info",
+          "[security][atna]") {
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::application_activity;
+    msg.event_date_time = std::chrono::system_clock::now();
+
+    atna_active_participant ap;
+    ap.user_id = "local_process";
+    ap.user_is_requestor = true;
+    // No network_access_point_id
+    msg.active_participants.push_back(std::move(ap));
+    msg.audit_source.audit_source_id = "PACS";
+
+    auto xml = atna_audit_logger::to_xml(msg);
+    CHECK_THAT(xml, ContainsSubstring("UserID=\"local_process\""));
+    // Should NOT contain NetworkAccessPointID when empty
+    // The participant should self-close since no role codes
+    CHECK_THAT(xml, ContainsSubstring("UserIsRequestor=\"true\"/>"));
+}
+
+TEST_CASE("to_xml handles ParticipantObject with details",
+          "[security][atna]") {
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::query;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.audit_source.audit_source_id = "PACS";
+
+    atna_participant_object obj;
+    obj.object_type = atna_object_type::system_object;
+    obj.object_role = atna_object_role::query;
+    obj.object_id_type_code = atna_object_id_types::sop_class_uid;
+    obj.object_details.push_back({"TransferSyntax", "1.2.840.10008.1.2"});
+    msg.participant_objects.push_back(std::move(obj));
+
+    auto xml = atna_audit_logger::to_xml(msg);
+    CHECK_THAT(xml, ContainsSubstring("<ParticipantObjectDetail"));
+    CHECK_THAT(xml, ContainsSubstring("type=\"TransferSyntax\""));
+    CHECK_THAT(xml, ContainsSubstring("value=\"1.2.840.10008.1.2\""));
+}
+
+TEST_CASE("to_xml handles AuditSource with type codes", "[security][atna]") {
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::application_activity;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.audit_source.audit_source_id = "PACS";
+    msg.audit_source.audit_enterprise_site_id = "Hospital_A";
+    msg.audit_source.audit_source_type_codes.push_back(4); // Application Server
+
+    auto xml = atna_audit_logger::to_xml(msg);
+    CHECK_THAT(xml, ContainsSubstring(
+        "AuditEnterpriseSiteID=\"Hospital_A\""));
+    CHECK_THAT(xml, ContainsSubstring(
+        "<AuditSourceTypeCode code=\"4\""));
+    CHECK_THAT(xml, ContainsSubstring("</AuditSourceIdentification>"));
+}
+
+TEST_CASE("to_xml handles ActiveParticipant with AlternativeUserID and UserName",
+          "[security][atna]") {
+    atna_audit_message msg;
+    msg.event_id = atna_event_ids::user_authentication;
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.audit_source.audit_source_id = "PACS";
+
+    atna_active_participant ap;
+    ap.user_id = "dr.smith";
+    ap.alternative_user_id = "pid:12345";
+    ap.user_name = "Dr. Jane Smith";
+    ap.user_is_requestor = true;
+    msg.active_participants.push_back(std::move(ap));
+
+    auto xml = atna_audit_logger::to_xml(msg);
+    CHECK_THAT(xml, ContainsSubstring("AlternativeUserID=\"pid:12345\""));
+    CHECK_THAT(xml, ContainsSubstring("UserName=\"Dr. Jane Smith\""));
+}


### PR DESCRIPTION
## Summary

Implements IHE ATNA-compliant audit message generator that produces RFC 3881 XML audit messages for security-relevant DICOM events. This is the first sub-issue of #796 (IHE ATNA Audit Trail Logging).

- RFC 3881 data structures: `atna_coded_value`, event actions/outcomes, active participants, audit sources, participant objects with details
- 15 DCM event ID constants (110100-110114), 4 event type codes, 6 role ID codes, 4 object ID type codes
- `atna_audit_logger::to_xml()` — XML serialization with proper escaping and ISO 8601 timestamps with milliseconds
- 8 event factory methods: `build_application_activity`, `build_dicom_instances_accessed`, `build_dicom_instances_transferred`, `build_study_deleted`, `build_security_alert`, `build_user_authentication`, `build_query`, `build_export`
- 43 unit tests with 212 assertions covering all data structures, constants, XML generation, edge cases, and factory methods

Closes #817

## Test Plan

- [x] All 43 ATNA audit logger tests pass (212 assertions)
- [x] All 99 security tests pass (1794 assertions)
- [x] Full project builds cleanly (40/40 steps)