### PR TITLE
feat(security): integrate ATNA audit logging into DICOM services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1138,6 +1138,7 @@ set(PACS_SECURITY_SOURCES
     src/security/anonymizer.cpp
     src/security/atna_audit_logger.cpp
     src/security/atna_syslog_transport.cpp
+    src/security/atna_service_auditor.cpp
 )
 
 # Digital signature sources (requires OpenSSL - Issue #191)
@@ -1921,6 +1922,7 @@ if(PACS_BUILD_TESTS)
         tests/security/anonymizer_test.cpp
         tests/security/atna_audit_logger_test.cpp
         tests/security/atna_syslog_transport_test.cpp
+        tests/security/atna_service_auditor_test.cpp
     )
 
     # Add digital signature tests if OpenSSL is available (Issue #191)

--- a/README.md
+++ b/README.md
@@ -414,15 +414,15 @@ cmake --build build --target run_full_benchmarks
 
 | Metric | Value |
 |--------|-------|
-| **Header Files** | 245 files |
-| **Source Files** | 169 files |
-| **Header LOC** | ~75,000 lines |
-| **Source LOC** | ~100,200 lines |
+| **Header Files** | 246 files |
+| **Source Files** | 170 files |
+| **Header LOC** | ~75,200 lines |
+| **Source LOC** | ~100,500 lines |
 | **Example LOC** | ~35,600 lines |
-| **Test LOC** | ~72,500 lines |
-| **Total LOC** | ~283,400 lines |
-| **Test Files** | 150 files |
-| **Test Cases** | 2217+ tests |
+| **Test LOC** | ~72,800 lines |
+| **Total LOC** | ~284,100 lines |
+| **Test Files** | 151 files |
+| **Test Cases** | 2232+ tests |
 | **Example Programs** | 32 apps |
 | **Documentation** | 59 markdown files |
 | **CI/CD Workflows** | 10 workflows |

--- a/include/pacs/security/atna_service_auditor.hpp
+++ b/include/pacs/security/atna_service_auditor.hpp
@@ -1,0 +1,214 @@
+/**
+ * @file atna_service_auditor.hpp
+ * @brief High-level facade for ATNA audit logging in DICOM services
+ *
+ * Wraps atna_audit_logger (message generation) and atna_syslog_transport
+ * (message delivery) into a simple API that DICOM services can call
+ * with minimal coupling.
+ *
+ * @see IHE ITI TF-1 Section 9 — Audit Trail and Node Authentication (ATNA)
+ * @see Issue #821 - Integrate ATNA audit logging into DICOM services
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SECURITY_ATNA_SERVICE_AUDITOR_HPP
+#define PACS_SECURITY_ATNA_SERVICE_AUDITOR_HPP
+
+#include "atna_audit_logger.hpp"
+#include "atna_syslog_transport.hpp"
+
+#include <atomic>
+#include <memory>
+#include <string>
+
+namespace pacs::security {
+
+/**
+ * @brief High-level facade for emitting ATNA audit events from DICOM services
+ *
+ * Combines the audit message generator (atna_audit_logger) with the syslog
+ * transport (atna_syslog_transport) to provide simple, one-call audit methods
+ * for common DICOM operations.
+ *
+ * ## Usage
+ * ```cpp
+ * syslog_transport_config config;
+ * config.host = "audit-server.hospital.local";
+ * config.port = 6514;
+ * config.protocol = syslog_transport_protocol::tls;
+ *
+ * atna_service_auditor auditor(config, "PACS_SYSTEM_01");
+ *
+ * // After a C-STORE operation:
+ * auditor.audit_instance_stored("MODALITY_01", "PACS_SCP",
+ *     "1.2.3.4.5", "PAT001", true);
+ *
+ * // After a C-FIND operation:
+ * auditor.audit_query("WORKSTATION_01", "PACS_SCP",
+ *     "STUDY", true);
+ * ```
+ */
+class atna_service_auditor {
+public:
+    // =========================================================================
+    // Construction
+    // =========================================================================
+
+    /**
+     * @brief Construct an auditor with syslog transport configuration
+     *
+     * @param config Syslog transport configuration
+     * @param audit_source_id Identifier for this audit source (e.g., "PACS_01")
+     */
+    atna_service_auditor(const syslog_transport_config& config,
+                         std::string audit_source_id);
+
+    ~atna_service_auditor() = default;
+
+    // Non-copyable, movable
+    atna_service_auditor(const atna_service_auditor&) = delete;
+    atna_service_auditor& operator=(const atna_service_auditor&) = delete;
+    atna_service_auditor(atna_service_auditor&&) noexcept;
+    atna_service_auditor& operator=(atna_service_auditor&&) noexcept;
+
+    // =========================================================================
+    // DICOM Service Audit Methods
+    // =========================================================================
+
+    /**
+     * @brief Audit a C-STORE (DICOM Instances Transferred) event
+     *
+     * @param source_ae Calling AE title (sender)
+     * @param dest_ae Called AE title (receiver)
+     * @param study_uid Study Instance UID
+     * @param patient_id Patient ID (optional, empty if unavailable)
+     * @param success Whether the operation succeeded
+     */
+    void audit_instance_stored(const std::string& source_ae,
+                               const std::string& dest_ae,
+                               const std::string& study_uid,
+                               const std::string& patient_id,
+                               bool success);
+
+    /**
+     * @brief Audit a C-FIND (Query) event
+     *
+     * @param calling_ae Calling AE title (query requester)
+     * @param called_ae Called AE title (query responder)
+     * @param query_level Query level string (PATIENT/STUDY/SERIES/IMAGE)
+     * @param success Whether the operation succeeded
+     */
+    void audit_query(const std::string& calling_ae,
+                     const std::string& called_ae,
+                     const std::string& query_level,
+                     bool success);
+
+    /**
+     * @brief Audit a User Authentication event
+     *
+     * @param user_id User identifier (AE title or username)
+     * @param is_login true for login, false for logout
+     * @param success Whether the authentication succeeded
+     */
+    void audit_authentication(const std::string& user_id,
+                              bool is_login,
+                              bool success);
+
+    /**
+     * @brief Audit a Security Alert event (e.g., access denied)
+     *
+     * @param user_id User identifier
+     * @param alert_description Description of the security alert
+     */
+    void audit_security_alert(const std::string& user_id,
+                              const std::string& alert_description);
+
+    // =========================================================================
+    // Enable / Disable
+    // =========================================================================
+
+    /**
+     * @brief Enable or disable audit event emission
+     *
+     * When disabled, audit methods return immediately without generating
+     * or sending any messages. Useful for testing or low-resource environments.
+     *
+     * @param enabled true to enable, false to disable
+     */
+    void set_enabled(bool enabled) noexcept;
+
+    /**
+     * @brief Check if audit event emission is enabled
+     * @return true if enabled
+     */
+    [[nodiscard]] bool is_enabled() const noexcept;
+
+    // =========================================================================
+    // Statistics
+    // =========================================================================
+
+    /**
+     * @brief Get the number of audit events successfully sent
+     */
+    [[nodiscard]] size_t events_sent() const noexcept;
+
+    /**
+     * @brief Get the number of audit event send failures
+     */
+    [[nodiscard]] size_t events_failed() const noexcept;
+
+    /**
+     * @brief Reset statistics counters
+     */
+    void reset_statistics() noexcept;
+
+    // =========================================================================
+    // Configuration Access
+    // =========================================================================
+
+    /**
+     * @brief Get the audit source identifier
+     */
+    [[nodiscard]] const std::string& audit_source_id() const noexcept;
+
+    /**
+     * @brief Get the underlying transport (for advanced use)
+     */
+    [[nodiscard]] const atna_syslog_transport& transport() const noexcept;
+
+private:
+    // =========================================================================
+    // Private Helpers
+    // =========================================================================
+
+    /**
+     * @brief Send an audit message via syslog transport
+     *
+     * Converts the message to XML and sends it. Updates statistics.
+     *
+     * @param message The audit message to send
+     */
+    void send_audit(const atna_audit_message& message);
+
+    // =========================================================================
+    // Private Members
+    // =========================================================================
+
+    /// Audit source identifier (e.g., "PACS_SYSTEM_01")
+    std::string audit_source_id_;
+
+    /// Syslog transport for sending audit messages
+    atna_syslog_transport transport_;
+
+    /// Whether audit is enabled
+    std::atomic<bool> enabled_{true};
+
+    /// Statistics
+    std::atomic<size_t> events_sent_{0};
+    std::atomic<size_t> events_failed_{0};
+};
+
+}  // namespace pacs::security
+
+#endif  // PACS_SECURITY_ATNA_SERVICE_AUDITOR_HPP

--- a/include/pacs/services/query_scp.hpp
+++ b/include/pacs/services/query_scp.hpp
@@ -48,7 +48,10 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <optional>
+
+namespace pacs::security { class atna_service_auditor; }
 
 namespace pacs::services {
 
@@ -261,6 +264,16 @@ public:
      */
     void set_cancel_check(cancel_check check);
 
+    /**
+     * @brief Set the ATNA audit handler for C-FIND operations
+     *
+     * When set, audit events are emitted for each completed C-FIND operation.
+     *
+     * @param auditor Shared pointer to an ATNA service auditor
+     */
+    void set_audit_handler(
+        std::shared_ptr<pacs::security::atna_service_auditor> auditor);
+
     // =========================================================================
     // scp_service Interface Implementation
     // =========================================================================
@@ -365,6 +378,7 @@ private:
 
     query_handler handler_;
     cancel_check cancel_check_;
+    std::shared_ptr<pacs::security::atna_service_auditor> auditor_;
     size_t max_results_{0};  // 0 = unlimited
     std::atomic<size_t> queries_processed_{0};
 };

--- a/include/pacs/services/storage_scp.hpp
+++ b/include/pacs/services/storage_scp.hpp
@@ -51,8 +51,11 @@
 
 #include <atomic>
 #include <functional>
+#include <memory>
 #include <string>
 #include <vector>
+
+namespace pacs::security { class atna_service_auditor; }
 
 namespace pacs::services {
 
@@ -257,6 +260,17 @@ public:
      */
     void set_post_store_handler(post_store_handler handler);
 
+    /**
+     * @brief Set the ATNA audit handler for C-STORE operations
+     *
+     * When set, audit events are emitted for each C-STORE operation
+     * (both success and failure).
+     *
+     * @param auditor Shared pointer to an ATNA service auditor
+     */
+    void set_audit_handler(
+        std::shared_ptr<pacs::security::atna_service_auditor> auditor);
+
     // =========================================================================
     // scp_service Interface Implementation
     // =========================================================================
@@ -334,6 +348,9 @@ private:
 
     /// Post-store notification handler
     post_store_handler post_store_handler_;
+
+    /// ATNA audit handler
+    std::shared_ptr<pacs::security::atna_service_auditor> auditor_;
 
     /// Statistics: number of images received
     std::atomic<size_t> images_received_{0};

--- a/src/security/atna_service_auditor.cpp
+++ b/src/security/atna_service_auditor.cpp
@@ -1,0 +1,196 @@
+/**
+ * @file atna_service_auditor.cpp
+ * @brief Implementation of the ATNA service auditor facade
+ */
+
+#include "pacs/security/atna_service_auditor.hpp"
+
+namespace pacs::security {
+
+// =============================================================================
+// Construction
+// =============================================================================
+
+atna_service_auditor::atna_service_auditor(
+    const syslog_transport_config& config,
+    std::string audit_source_id)
+    : audit_source_id_(std::move(audit_source_id)),
+      transport_(config) {}
+
+atna_service_auditor::atna_service_auditor(
+    atna_service_auditor&& other) noexcept
+    : audit_source_id_(std::move(other.audit_source_id_)),
+      transport_(std::move(other.transport_)),
+      enabled_(other.enabled_.load(std::memory_order_relaxed)),
+      events_sent_(other.events_sent_.load(std::memory_order_relaxed)),
+      events_failed_(other.events_failed_.load(std::memory_order_relaxed)) {}
+
+atna_service_auditor& atna_service_auditor::operator=(
+    atna_service_auditor&& other) noexcept {
+    if (this != &other) {
+        audit_source_id_ = std::move(other.audit_source_id_);
+        transport_ = std::move(other.transport_);
+        enabled_.store(other.enabled_.load(std::memory_order_relaxed),
+                       std::memory_order_relaxed);
+        events_sent_.store(other.events_sent_.load(std::memory_order_relaxed),
+                           std::memory_order_relaxed);
+        events_failed_.store(
+            other.events_failed_.load(std::memory_order_relaxed),
+            std::memory_order_relaxed);
+    }
+    return *this;
+}
+
+// =============================================================================
+// DICOM Service Audit Methods
+// =============================================================================
+
+void atna_service_auditor::audit_instance_stored(
+    const std::string& source_ae,
+    const std::string& dest_ae,
+    const std::string& study_uid,
+    const std::string& patient_id,
+    bool success) {
+
+    if (!enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    auto outcome = success ? atna_event_outcome::success
+                           : atna_event_outcome::serious_failure;
+
+    auto msg = atna_audit_logger::build_dicom_instances_transferred(
+        audit_source_id_,
+        source_ae,    // source AE
+        "",           // source IP (not available at service level)
+        dest_ae,      // destination AE
+        "",           // destination IP (not available at service level)
+        study_uid,
+        patient_id,
+        true,         // is_import (SCP receiving)
+        outcome);
+
+    send_audit(msg);
+}
+
+void atna_service_auditor::audit_query(
+    const std::string& calling_ae,
+    const std::string& called_ae,
+    const std::string& query_level,
+    bool success) {
+
+    if (!enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    auto outcome = success ? atna_event_outcome::success
+                           : atna_event_outcome::serious_failure;
+
+    // Use query level as query_data for the audit trail
+    auto msg = atna_audit_logger::build_query(
+        audit_source_id_,
+        calling_ae,
+        "",           // user IP (not available at service level)
+        "QueryLevel=" + query_level + " CalledAE=" + called_ae,
+        "",           // patient_id (not available from query keys here)
+        outcome);
+
+    send_audit(msg);
+}
+
+void atna_service_auditor::audit_authentication(
+    const std::string& user_id,
+    bool is_login,
+    bool success) {
+
+    if (!enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    auto outcome = success ? atna_event_outcome::success
+                           : atna_event_outcome::serious_failure;
+
+    auto msg = atna_audit_logger::build_user_authentication(
+        audit_source_id_,
+        user_id,
+        "",           // user IP (not available at this level)
+        is_login,
+        outcome);
+
+    send_audit(msg);
+}
+
+void atna_service_auditor::audit_security_alert(
+    const std::string& user_id,
+    const std::string& alert_description) {
+
+    if (!enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    auto msg = atna_audit_logger::build_security_alert(
+        audit_source_id_,
+        user_id,
+        "",           // user IP (not available at this level)
+        alert_description);
+
+    send_audit(msg);
+}
+
+// =============================================================================
+// Enable / Disable
+// =============================================================================
+
+void atna_service_auditor::set_enabled(bool enabled) noexcept {
+    enabled_.store(enabled, std::memory_order_relaxed);
+}
+
+bool atna_service_auditor::is_enabled() const noexcept {
+    return enabled_.load(std::memory_order_relaxed);
+}
+
+// =============================================================================
+// Statistics
+// =============================================================================
+
+size_t atna_service_auditor::events_sent() const noexcept {
+    return events_sent_.load(std::memory_order_relaxed);
+}
+
+size_t atna_service_auditor::events_failed() const noexcept {
+    return events_failed_.load(std::memory_order_relaxed);
+}
+
+void atna_service_auditor::reset_statistics() noexcept {
+    events_sent_.store(0, std::memory_order_relaxed);
+    events_failed_.store(0, std::memory_order_relaxed);
+}
+
+// =============================================================================
+// Configuration Access
+// =============================================================================
+
+const std::string& atna_service_auditor::audit_source_id() const noexcept {
+    return audit_source_id_;
+}
+
+const atna_syslog_transport& atna_service_auditor::transport() const noexcept {
+    return transport_;
+}
+
+// =============================================================================
+// Private Helpers
+// =============================================================================
+
+void atna_service_auditor::send_audit(const atna_audit_message& message) {
+    auto xml = atna_audit_logger::to_xml(message);
+    auto result = transport_.send(xml);
+
+    if (result.is_ok()) {
+        events_sent_.fetch_add(1, std::memory_order_relaxed);
+    } else {
+        events_failed_.fetch_add(1, std::memory_order_relaxed);
+    }
+}
+
+}  // namespace pacs::security

--- a/src/services/query_scp.cpp
+++ b/src/services/query_scp.cpp
@@ -39,6 +39,7 @@
 #include "pacs/core/result.hpp"
 #include "pacs/network/dimse/command_field.hpp"
 #include "pacs/network/dimse/status_codes.hpp"
+#include "pacs/security/atna_service_auditor.hpp"
 
 #include <kcenon/common/patterns/event_bus.h>
 
@@ -82,6 +83,11 @@ size_t query_scp::max_results() const noexcept {
 
 void query_scp::set_cancel_check(cancel_check check) {
     cancel_check_ = std::move(check);
+}
+
+void query_scp::set_audit_handler(
+    std::shared_ptr<pacs::security::atna_service_auditor> auditor) {
+    auditor_ = std::move(auditor);
 }
 
 // =============================================================================
@@ -195,6 +201,15 @@ network::Result<std::monostate> query_scp::handle_message(
             static_cast<uint64_t>(execution_time_ms)
         }
     );
+
+    // Emit ATNA audit event
+    if (auditor_) {
+        auditor_->audit_query(
+            calling_ae,
+            std::string(assoc.called_ae()),
+            std::string(to_string(level.value())),
+            true);
+    }
 
     // Send final success response (no dataset)
     return send_final_response(

--- a/src/services/storage_scp.cpp
+++ b/src/services/storage_scp.cpp
@@ -38,6 +38,7 @@
 #include "pacs/core/result.hpp"
 #include "pacs/network/dimse/command_field.hpp"
 #include "pacs/network/dimse/status_codes.hpp"
+#include "pacs/security/atna_service_auditor.hpp"
 
 #include <kcenon/common/patterns/event_bus.h>
 
@@ -68,6 +69,11 @@ void storage_scp::set_pre_store_handler(pre_store_handler handler) {
 
 void storage_scp::set_post_store_handler(post_store_handler handler) {
     post_store_handler_ = std::move(handler);
+}
+
+void storage_scp::set_audit_handler(
+    std::shared_ptr<pacs::security::atna_service_auditor> auditor) {
+    auditor_ = std::move(auditor);
 }
 
 // =============================================================================
@@ -188,6 +194,18 @@ network::Result<std::monostate> storage_scp::handle_message(
                 "C-STORE operation failed"
             }
         );
+    }
+
+    // Emit ATNA audit event
+    if (auditor_) {
+        auto audit_study_uid = dataset.get_string(core::tags::study_instance_uid);
+        auto audit_patient_id = dataset.get_string(core::tags::patient_id);
+        auditor_->audit_instance_stored(
+            std::string(assoc.calling_ae()),
+            std::string(assoc.called_ae()),
+            audit_study_uid,
+            audit_patient_id,
+            !is_failure(status));
     }
 
     // Build and send the response

--- a/tests/security/atna_service_auditor_test.cpp
+++ b/tests/security/atna_service_auditor_test.cpp
@@ -1,0 +1,238 @@
+/**
+ * @file atna_service_auditor_test.cpp
+ * @brief Unit tests for ATNA service auditor facade
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "pacs/security/atna_service_auditor.hpp"
+
+#include <string>
+
+using namespace pacs::security;
+using Catch::Matchers::ContainsSubstring;
+
+// =============================================================================
+// Helper: Create auditor pointing to unresolvable host (no real network needed)
+// =============================================================================
+
+namespace {
+
+syslog_transport_config make_test_config() {
+    syslog_transport_config config;
+    config.host = "localhost";
+    config.port = 15140;  // Unlikely to be in use
+    config.protocol = syslog_transport_protocol::udp;
+    return config;
+}
+
+}  // namespace
+
+// =============================================================================
+// Construction Tests
+// =============================================================================
+
+TEST_CASE("atna_service_auditor constructs with config and source ID",
+          "[security][auditor]") {
+    atna_service_auditor auditor(make_test_config(), "PACS_TEST_01");
+
+    CHECK(auditor.audit_source_id() == "PACS_TEST_01");
+    CHECK(auditor.is_enabled() == true);
+    CHECK(auditor.events_sent() == 0);
+    CHECK(auditor.events_failed() == 0);
+}
+
+TEST_CASE("atna_service_auditor is movable", "[security][auditor]") {
+    atna_service_auditor auditor1(make_test_config(), "PACS_MOVE");
+
+    atna_service_auditor auditor2(std::move(auditor1));
+    CHECK(auditor2.audit_source_id() == "PACS_MOVE");
+    CHECK(auditor2.is_enabled() == true);
+}
+
+TEST_CASE("atna_service_auditor move assignment", "[security][auditor]") {
+    atna_service_auditor auditor1(make_test_config(), "SOURCE_A");
+    atna_service_auditor auditor2(make_test_config(), "SOURCE_B");
+
+    auditor2 = std::move(auditor1);
+    CHECK(auditor2.audit_source_id() == "SOURCE_A");
+}
+
+// =============================================================================
+// Enable / Disable Tests
+// =============================================================================
+
+TEST_CASE("atna_service_auditor enable/disable", "[security][auditor]") {
+    atna_service_auditor auditor(make_test_config(), "PACS_TEST");
+
+    CHECK(auditor.is_enabled() == true);
+
+    auditor.set_enabled(false);
+    CHECK(auditor.is_enabled() == false);
+
+    auditor.set_enabled(true);
+    CHECK(auditor.is_enabled() == true);
+}
+
+TEST_CASE("disabled auditor does not send events", "[security][auditor]") {
+    syslog_transport_config config;
+    config.host = "this-host-does-not-exist.invalid";
+    config.port = 514;
+
+    atna_service_auditor auditor(config, "PACS_TEST");
+    auditor.set_enabled(false);
+
+    // These should return immediately without attempting to send
+    auditor.audit_instance_stored("SCU", "SCP", "1.2.3", "PAT01", true);
+    auditor.audit_query("SCU", "SCP", "STUDY", true);
+    auditor.audit_authentication("user1", true, true);
+    auditor.audit_security_alert("user1", "test alert");
+
+    CHECK(auditor.events_sent() == 0);
+    CHECK(auditor.events_failed() == 0);
+}
+
+// =============================================================================
+// Statistics Tests
+// =============================================================================
+
+TEST_CASE("atna_service_auditor statistics start at zero",
+          "[security][auditor]") {
+    atna_service_auditor auditor(make_test_config(), "PACS_TEST");
+
+    CHECK(auditor.events_sent() == 0);
+    CHECK(auditor.events_failed() == 0);
+}
+
+TEST_CASE("atna_service_auditor reset_statistics", "[security][auditor]") {
+    atna_service_auditor auditor(make_test_config(), "PACS_TEST");
+
+    auditor.reset_statistics();
+
+    CHECK(auditor.events_sent() == 0);
+    CHECK(auditor.events_failed() == 0);
+}
+
+// =============================================================================
+// Audit Event Emission Tests (with unresolvable host to verify error counting)
+// =============================================================================
+
+TEST_CASE("audit_instance_stored with unresolvable host counts as failure",
+          "[security][auditor]") {
+    syslog_transport_config config;
+    config.host = "this-host-does-not-exist.invalid";
+    config.port = 514;
+
+    atna_service_auditor auditor(config, "PACS_TEST");
+
+    auditor.audit_instance_stored(
+        "MODALITY_01", "PACS_SCP", "1.2.3.4.5.6", "PAT001", true);
+
+    CHECK(auditor.events_failed() == 1);
+    CHECK(auditor.events_sent() == 0);
+}
+
+TEST_CASE("audit_query with unresolvable host counts as failure",
+          "[security][auditor]") {
+    syslog_transport_config config;
+    config.host = "this-host-does-not-exist.invalid";
+    config.port = 514;
+
+    atna_service_auditor auditor(config, "PACS_TEST");
+
+    auditor.audit_query("WORKSTATION", "PACS_SCP", "STUDY", true);
+
+    CHECK(auditor.events_failed() == 1);
+    CHECK(auditor.events_sent() == 0);
+}
+
+TEST_CASE("audit_authentication with unresolvable host counts as failure",
+          "[security][auditor]") {
+    syslog_transport_config config;
+    config.host = "this-host-does-not-exist.invalid";
+    config.port = 514;
+
+    atna_service_auditor auditor(config, "PACS_TEST");
+
+    auditor.audit_authentication("dr.smith", true, true);
+
+    CHECK(auditor.events_failed() == 1);
+}
+
+TEST_CASE("audit_security_alert with unresolvable host counts as failure",
+          "[security][auditor]") {
+    syslog_transport_config config;
+    config.host = "this-host-does-not-exist.invalid";
+    config.port = 514;
+
+    atna_service_auditor auditor(config, "PACS_TEST");
+
+    auditor.audit_security_alert("intruder", "Unauthorized access attempt");
+
+    CHECK(auditor.events_failed() == 1);
+}
+
+// =============================================================================
+// Multiple Events Test
+// =============================================================================
+
+TEST_CASE("multiple audit events accumulate statistics",
+          "[security][auditor]") {
+    syslog_transport_config config;
+    config.host = "this-host-does-not-exist.invalid";
+    config.port = 514;
+
+    atna_service_auditor auditor(config, "PACS_TEST");
+
+    auditor.audit_instance_stored("SCU", "SCP", "1.2.3", "P1", true);
+    auditor.audit_instance_stored("SCU", "SCP", "1.2.4", "P2", false);
+    auditor.audit_query("SCU", "SCP", "PATIENT", true);
+    auditor.audit_authentication("user1", true, false);
+    auditor.audit_security_alert("user2", "alert");
+
+    CHECK(auditor.events_failed() == 5);
+    CHECK(auditor.events_sent() == 0);
+
+    auditor.reset_statistics();
+    CHECK(auditor.events_failed() == 0);
+    CHECK(auditor.events_sent() == 0);
+}
+
+// =============================================================================
+// Configuration Access Tests
+// =============================================================================
+
+TEST_CASE("transport() returns reference to internal transport",
+          "[security][auditor]") {
+    syslog_transport_config config;
+    config.host = "audit-server.local";
+    config.port = 6514;
+
+    atna_service_auditor auditor(config, "PACS_01");
+
+    CHECK(auditor.transport().config().host == "audit-server.local");
+    CHECK(auditor.transport().config().port == 6514);
+}
+
+TEST_CASE("audit_source_id returns configured source ID",
+          "[security][auditor]") {
+    atna_service_auditor auditor(make_test_config(), "MY_PACS_SYSTEM");
+
+    CHECK(auditor.audit_source_id() == "MY_PACS_SYSTEM");
+}
+
+// =============================================================================
+// Success Path Test (localhost UDP — may succeed if socket is available)
+// =============================================================================
+
+TEST_CASE("audit event to localhost may succeed or fail gracefully",
+          "[security][auditor]") {
+    atna_service_auditor auditor(make_test_config(), "PACS_LOCAL");
+
+    auditor.audit_instance_stored(
+        "MODALITY", "PACS", "1.2.3.4.5", "PAT001", true);
+
+    // Should have attempted to send — either sent or failed, but no crash
+    CHECK((auditor.events_sent() + auditor.events_failed()) == 1);
+}


### PR DESCRIPTION
Closes #821
Part of #796

## Summary

- Add `atna_service_auditor` facade class that provides a high-level API for ATNA audit logging in DICOM services
- Integrate audit event emission into `storage_scp` (C-STORE operations) via `set_audit_handler()`
- Integrate audit event emission into `query_scp` (C-FIND operations) via `set_audit_handler()`
- Support enable/disable control and atomic statistics tracking (events_sent, events_failed)
- Add 15 unit tests with 30 assertions covering construction, move semantics, enable/disable, event emission with unresolvable hosts, and statistics

## Architecture

The `atna_service_auditor` acts as a facade that wraps:
- `atna_audit_logger` (RFC 3881 XML message generation from #818)
- `atna_syslog_transport` (RFC 5424/5425/5426 transport from #820)

Services call high-level methods like `audit_instance_stored()` or `audit_query()`, and the facade handles message construction, XML serialization, and transport.

## Test Plan

- [x] 15 unit tests for `atna_service_auditor` (construction, move, enable/disable, statistics, event emission)
- [x] Full security test suite: 138 tests, 1908 assertions passing
- [x] Full services test suite: 649 tests, 8583 assertions passing (no regressions)
- [x] Build: 87/87 targets with zero compilation errors