### PR TITLE
feat(validation): add VL Whole Slide Microscopy Image IOD validator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1078,6 +1078,7 @@ add_library(pacs_services
     src/services/validation/sr_iod_validator.cpp
     src/services/validation/ct_iod_validator.cpp
     src/services/validation/mr_iod_validator.cpp
+    src/services/validation/wsi_iod_validator.cpp
     src/services/cache/query_cache.cpp
     src/services/cache/database_cursor.cpp
     src/services/cache/query_result_stream.cpp
@@ -1890,6 +1891,7 @@ if(PACS_BUILD_TESTS)
         tests/services/wsi_storage_test.cpp
         tests/services/ct_iod_validator_test.cpp
         tests/services/mr_iod_validator_test.cpp
+        tests/services/wsi_iod_validator_test.cpp
         tests/services/cache/simple_lru_cache_test.cpp
         tests/services/cache/query_cache_test.cpp
         tests/services/cache/streaming_query_test.cpp

--- a/include/pacs/services/validation/wsi_iod_validator.hpp
+++ b/include/pacs/services/validation/wsi_iod_validator.hpp
@@ -1,0 +1,293 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file wsi_iod_validator.hpp
+ * @brief VL Whole Slide Microscopy Image IOD Validator
+ *
+ * Provides validation for VL Whole Slide Microscopy Image Information
+ * Object Definitions as specified in DICOM PS3.3 Section A.32.8.
+ *
+ * WSI images are gigapixel-scale, tiled multi-frame images used in
+ * digital pathology. They have unique structural requirements including
+ * tile dimensions, optical paths, and specimen identification.
+ *
+ * @see DICOM PS3.3 Section A.32.8 - VL Whole Slide Microscopy Image IOD
+ * @see DICOM PS3.3 Section C.8.12.4 - Whole Slide Microscopy Image Module
+ * @see Issue #826 - Add WSI IOD validator
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_VALIDATION_WSI_IOD_VALIDATOR_HPP
+#define PACS_SERVICES_VALIDATION_WSI_IOD_VALIDATOR_HPP
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/core/dicom_tag.hpp"
+#include "pacs/services/validation/us_iod_validator.hpp"  // Reuse validation types
+
+#include <string>
+#include <vector>
+
+namespace pacs::services::validation {
+
+// =============================================================================
+// WSI-Specific DICOM Tags for Validation
+// =============================================================================
+
+namespace wsi_iod_tags {
+
+/// Total Pixel Matrix Columns (0048,0006)
+inline constexpr core::dicom_tag total_pixel_matrix_columns{0x0048, 0x0006};
+
+/// Total Pixel Matrix Rows (0048,0007)
+inline constexpr core::dicom_tag total_pixel_matrix_rows{0x0048, 0x0007};
+
+/// Total Pixel Matrix Focal Planes (0048,0008)
+inline constexpr core::dicom_tag total_pixel_matrix_focal_planes{0x0048, 0x0008};
+
+/// Image Orientation (Slide) (0048,0102)
+inline constexpr core::dicom_tag image_orientation_slide{0x0048, 0x0102};
+
+/// Dimension Organization Type (0020,9311)
+inline constexpr core::dicom_tag dimension_organization_type{0x0020, 0x9311};
+
+/// Number of Frames (0028,0008)
+inline constexpr core::dicom_tag number_of_frames{0x0028, 0x0008};
+
+/// Imaged Volume Width (0048,0001) — physical width in mm
+inline constexpr core::dicom_tag imaged_volume_width{0x0048, 0x0001};
+
+/// Imaged Volume Height (0048,0002) — physical height in mm
+inline constexpr core::dicom_tag imaged_volume_height{0x0048, 0x0002};
+
+/// Optical Path Identifier (0048,0105)
+inline constexpr core::dicom_tag optical_path_identifier{0x0048, 0x0105};
+
+/// Optical Path Description (0048,0106)
+inline constexpr core::dicom_tag optical_path_description{0x0048, 0x0106};
+
+/// Specimen Identifier (0040,0551)
+inline constexpr core::dicom_tag specimen_identifier{0x0040, 0x0551};
+
+/// Container Identifier (0040,0512)
+inline constexpr core::dicom_tag container_identifier{0x0040, 0x0512};
+
+}  // namespace wsi_iod_tags
+
+// =============================================================================
+// WSI Validation Options
+// =============================================================================
+
+/**
+ * @brief Options for WSI IOD validation
+ */
+struct wsi_validation_options {
+    /// Check Type 1 (required) attributes
+    bool check_type1 = true;
+
+    /// Check Type 2 (required, can be empty) attributes
+    bool check_type2 = true;
+
+    /// Check Type 1C/2C (conditionally required) attributes
+    bool check_conditional = true;
+
+    /// Validate pixel data consistency (rows, columns, bits)
+    bool validate_pixel_data = true;
+
+    /// Validate WSI-specific image parameters
+    bool validate_wsi_params = true;
+
+    /// Validate optical path information
+    bool validate_optical_path = true;
+
+    /// Strict mode - treat warnings as errors
+    bool strict_mode = false;
+};
+
+// =============================================================================
+// WSI IOD Validator
+// =============================================================================
+
+/**
+ * @brief Validator for VL Whole Slide Microscopy Image IODs
+ *
+ * Validates DICOM datasets against the VL Whole Slide Microscopy Image
+ * IOD specification (PS3.3 Section A.32.8).
+ *
+ * ## Validated Modules (PS3.3 Table A.32.8-1)
+ *
+ * ### Mandatory Modules
+ * - Patient Module (M)
+ * - General Study Module (M)
+ * - General Series Module (M) — Modality = "SM"
+ * - Whole Slide Microscopy Image Module (M)
+ * - Optical Path Module (M)
+ * - Multi-frame Dimension Module (M)
+ * - Image Pixel Module (M)
+ * - SOP Common Module (M)
+ *
+ * ### User Optional Modules
+ * - Specimen Module (U) — checked at info level
+ *
+ * @example
+ * @code
+ * wsi_iod_validator validator;
+ * auto result = validator.validate(dataset);
+ *
+ * if (!result.is_valid) {
+ *     for (const auto& finding : result.findings) {
+ *         std::cerr << finding.message << "\n";
+ *     }
+ * }
+ * @endcode
+ */
+class wsi_iod_validator {
+public:
+    /**
+     * @brief Construct validator with default options
+     */
+    wsi_iod_validator() = default;
+
+    /**
+     * @brief Construct validator with custom options
+     * @param options Validation options
+     */
+    explicit wsi_iod_validator(const wsi_validation_options& options);
+
+    /**
+     * @brief Validate a DICOM dataset against WSI IOD
+     * @param dataset The dataset to validate
+     * @return Validation result with all findings
+     */
+    [[nodiscard]] validation_result validate(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Quick check if dataset has minimum required WSI attributes
+     * @param dataset The dataset to check
+     * @return true if all Type 1 attributes are present
+     */
+    [[nodiscard]] bool quick_check(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Get the validation options
+     */
+    [[nodiscard]] const wsi_validation_options& options() const noexcept;
+
+    /**
+     * @brief Set validation options
+     */
+    void set_options(const wsi_validation_options& options);
+
+private:
+    // Module validation methods
+    void validate_patient_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_study_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_series_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_wsi_image_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_optical_path_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_multiframe_dimension_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_image_pixel_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_specimen_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_sop_common_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    // Attribute validation helpers
+    void check_type1_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_type2_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_modality(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void check_pixel_data_consistency(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    wsi_validation_options options_;
+};
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+/**
+ * @brief Validate a WSI dataset with default options
+ * @param dataset The dataset to validate
+ * @return Validation result
+ */
+[[nodiscard]] validation_result validate_wsi_iod(
+    const core::dicom_dataset& dataset);
+
+/**
+ * @brief Quick check if a dataset is a valid WSI image
+ * @param dataset The dataset to check
+ * @return true if the dataset passes basic WSI IOD validation
+ */
+[[nodiscard]] bool is_valid_wsi_dataset(const core::dicom_dataset& dataset);
+
+}  // namespace pacs::services::validation
+
+#endif  // PACS_SERVICES_VALIDATION_WSI_IOD_VALIDATOR_HPP

--- a/src/services/validation/wsi_iod_validator.cpp
+++ b/src/services/validation/wsi_iod_validator.cpp
@@ -1,0 +1,528 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file wsi_iod_validator.cpp
+ * @brief Implementation of VL Whole Slide Microscopy Image IOD Validator
+ *
+ * @see DICOM PS3.3 Section A.32.8 - VL Whole Slide Microscopy Image IOD
+ * @see Issue #826 - Add WSI IOD validator
+ */
+
+#include "pacs/services/validation/wsi_iod_validator.hpp"
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/services/sop_classes/wsi_storage.hpp"
+
+namespace pacs::services::validation {
+
+using namespace pacs::core;
+
+// =============================================================================
+// wsi_iod_validator Implementation
+// =============================================================================
+
+wsi_iod_validator::wsi_iod_validator(const wsi_validation_options& options)
+    : options_(options) {}
+
+validation_result wsi_iod_validator::validate(
+    const dicom_dataset& dataset) const {
+    validation_result result;
+    result.is_valid = true;
+
+    // Validate mandatory modules (PS3.3 Table A.32.8-1)
+    if (options_.check_type1 || options_.check_type2) {
+        validate_patient_module(dataset, result.findings);
+        validate_general_study_module(dataset, result.findings);
+        validate_general_series_module(dataset, result.findings);
+        validate_sop_common_module(dataset, result.findings);
+    }
+
+    if (options_.validate_wsi_params) {
+        validate_wsi_image_module(dataset, result.findings);
+        validate_multiframe_dimension_module(dataset, result.findings);
+    }
+
+    if (options_.validate_optical_path) {
+        validate_optical_path_module(dataset, result.findings);
+    }
+
+    if (options_.validate_pixel_data) {
+        validate_image_pixel_module(dataset, result.findings);
+    }
+
+    // Specimen Module is User Optional — info-level checks
+    if (options_.check_conditional) {
+        validate_specimen_module(dataset, result.findings);
+    }
+
+    // Determine overall validity
+    for (const auto& finding : result.findings) {
+        if (finding.severity == validation_severity::error) {
+            result.is_valid = false;
+            break;
+        }
+        if (options_.strict_mode &&
+            finding.severity == validation_severity::warning) {
+            result.is_valid = false;
+            break;
+        }
+    }
+
+    return result;
+}
+
+bool wsi_iod_validator::quick_check(const dicom_dataset& dataset) const {
+    // General Study Module Type 1
+    if (!dataset.contains(tags::study_instance_uid)) return false;
+
+    // General Series Module Type 1
+    if (!dataset.contains(tags::modality)) return false;
+    if (!dataset.contains(tags::series_instance_uid)) return false;
+
+    // Check modality is SM
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "SM") return false;
+
+    // WSI Image Module Type 1
+    if (!dataset.contains(tags::image_type)) return false;
+    if (!dataset.contains(wsi_iod_tags::total_pixel_matrix_columns))
+        return false;
+    if (!dataset.contains(wsi_iod_tags::total_pixel_matrix_rows)) return false;
+
+    // Image Pixel Module Type 1
+    if (!dataset.contains(tags::samples_per_pixel)) return false;
+    if (!dataset.contains(tags::photometric_interpretation)) return false;
+    if (!dataset.contains(tags::rows)) return false;
+    if (!dataset.contains(tags::columns)) return false;
+    if (!dataset.contains(tags::bits_allocated)) return false;
+    if (!dataset.contains(tags::bits_stored)) return false;
+    if (!dataset.contains(tags::high_bit)) return false;
+    if (!dataset.contains(tags::pixel_representation)) return false;
+
+    // SOP Common Module Type 1
+    if (!dataset.contains(tags::sop_class_uid)) return false;
+    if (!dataset.contains(tags::sop_instance_uid)) return false;
+
+    return true;
+}
+
+const wsi_validation_options& wsi_iod_validator::options() const noexcept {
+    return options_;
+}
+
+void wsi_iod_validator::set_options(const wsi_validation_options& options) {
+    options_ = options;
+}
+
+// =============================================================================
+// Module Validation Methods
+// =============================================================================
+
+void wsi_iod_validator::validate_patient_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Patient Module - All attributes are Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::patient_name, "PatientName",
+                              findings);
+        check_type2_attribute(dataset, tags::patient_id, "PatientID",
+                              findings);
+        check_type2_attribute(dataset, tags::patient_birth_date,
+                              "PatientBirthDate", findings);
+        check_type2_attribute(dataset, tags::patient_sex, "PatientSex",
+                              findings);
+    }
+}
+
+void wsi_iod_validator::validate_general_study_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::study_instance_uid,
+                              "StudyInstanceUID", findings);
+    }
+
+    // Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::study_date, "StudyDate",
+                              findings);
+        check_type2_attribute(dataset, tags::study_time, "StudyTime",
+                              findings);
+        check_type2_attribute(dataset, tags::referring_physician_name,
+                              "ReferringPhysicianName", findings);
+        check_type2_attribute(dataset, tags::study_id, "StudyID", findings);
+        check_type2_attribute(dataset, tags::accession_number,
+                              "AccessionNumber", findings);
+    }
+}
+
+void wsi_iod_validator::validate_general_series_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::modality, "Modality", findings);
+        check_type1_attribute(dataset, tags::series_instance_uid,
+                              "SeriesInstanceUID", findings);
+
+        // Modality must be "SM"
+        check_modality(dataset, findings);
+    }
+
+    // Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::series_number, "SeriesNumber",
+                              findings);
+    }
+}
+
+void wsi_iod_validator::validate_wsi_image_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // WSI Image Module (PS3.3 Section C.8.12.4)
+
+    // ImageType is Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::image_type, "ImageType",
+                              findings);
+    }
+
+    // Total Pixel Matrix Columns/Rows are Type 1
+    check_type1_attribute(dataset, wsi_iod_tags::total_pixel_matrix_columns,
+                          "TotalPixelMatrixColumns", findings);
+    check_type1_attribute(dataset, wsi_iod_tags::total_pixel_matrix_rows,
+                          "TotalPixelMatrixRows", findings);
+
+    // Number of Frames is Type 1 for multi-frame WSI
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, wsi_iod_tags::number_of_frames,
+                              "NumberOfFrames", findings);
+    }
+
+    // Informational checks for WSI-specific attributes
+    if (options_.check_conditional) {
+        // Imaged Volume Width/Height — important for physical measurements
+        if (!dataset.contains(wsi_iod_tags::imaged_volume_width)) {
+            findings.push_back(
+                {validation_severity::info, wsi_iod_tags::imaged_volume_width,
+                 "ImagedVolumeWidth (0048,0001) not present - physical "
+                 "dimensions unavailable",
+                 "WSI-INFO-001"});
+        }
+
+        if (!dataset.contains(wsi_iod_tags::imaged_volume_height)) {
+            findings.push_back(
+                {validation_severity::info, wsi_iod_tags::imaged_volume_height,
+                 "ImagedVolumeHeight (0048,0002) not present - physical "
+                 "dimensions unavailable",
+                 "WSI-INFO-002"});
+        }
+
+        // Image Orientation (Slide) is Type 1C
+        if (dataset.contains(wsi_iod_tags::total_pixel_matrix_columns) &&
+            !dataset.contains(wsi_iod_tags::image_orientation_slide)) {
+            findings.push_back(
+                {validation_severity::warning,
+                 wsi_iod_tags::image_orientation_slide,
+                 "ImageOrientationSlide (0048,0102) missing - slide "
+                 "orientation unknown",
+                 "WSI-WARN-001"});
+        }
+    }
+}
+
+void wsi_iod_validator::validate_optical_path_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Optical Path Module — Optical Path Identifier is Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, wsi_iod_tags::optical_path_identifier,
+                              "OpticalPathIdentifier", findings);
+    }
+
+    // Optical Path Description is Type 3 (optional), info if missing
+    if (options_.check_conditional) {
+        if (!dataset.contains(wsi_iod_tags::optical_path_description)) {
+            findings.push_back(
+                {validation_severity::info,
+                 wsi_iod_tags::optical_path_description,
+                 "OpticalPathDescription (0048,0106) not present - optical "
+                 "path details unavailable",
+                 "WSI-INFO-003"});
+        }
+    }
+}
+
+void wsi_iod_validator::validate_multiframe_dimension_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Dimension Organization Type is Type 1
+    check_type1_attribute(dataset, wsi_iod_tags::dimension_organization_type,
+                          "DimensionOrganizationType", findings);
+
+    // Validate the Dimension Organization Type value
+    if (dataset.contains(wsi_iod_tags::dimension_organization_type)) {
+        auto org_type =
+            dataset.get_string(wsi_iod_tags::dimension_organization_type);
+        if (org_type != "TILED_FULL" && org_type != "TILED_SPARSE") {
+            findings.push_back(
+                {validation_severity::error,
+                 wsi_iod_tags::dimension_organization_type,
+                 "DimensionOrganizationType must be 'TILED_FULL' or "
+                 "'TILED_SPARSE' for WSI, found: " + org_type,
+                 "WSI-ERR-001"});
+        }
+    }
+}
+
+void wsi_iod_validator::validate_image_pixel_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1 attributes
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::samples_per_pixel,
+                              "SamplesPerPixel", findings);
+        check_type1_attribute(dataset, tags::photometric_interpretation,
+                              "PhotometricInterpretation", findings);
+        check_type1_attribute(dataset, tags::rows, "Rows", findings);
+        check_type1_attribute(dataset, tags::columns, "Columns", findings);
+        check_type1_attribute(dataset, tags::bits_allocated, "BitsAllocated",
+                              findings);
+        check_type1_attribute(dataset, tags::bits_stored, "BitsStored",
+                              findings);
+        check_type1_attribute(dataset, tags::high_bit, "HighBit", findings);
+        check_type1_attribute(dataset, tags::pixel_representation,
+                              "PixelRepresentation", findings);
+    }
+
+    // Validate pixel data consistency
+    if (options_.validate_pixel_data) {
+        check_pixel_data_consistency(dataset, findings);
+    }
+}
+
+void wsi_iod_validator::validate_specimen_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Specimen Module is User Optional (U) for WSI
+    // Provide info-level findings when specimen data is absent
+
+    if (!dataset.contains(wsi_iod_tags::specimen_identifier)) {
+        findings.push_back(
+            {validation_severity::info, wsi_iod_tags::specimen_identifier,
+             "SpecimenIdentifier (0040,0551) not present - specimen "
+             "tracking unavailable",
+             "WSI-INFO-004"});
+    }
+
+    if (!dataset.contains(wsi_iod_tags::container_identifier)) {
+        findings.push_back(
+            {validation_severity::info, wsi_iod_tags::container_identifier,
+             "ContainerIdentifier (0040,0512) not present - container "
+             "tracking unavailable",
+             "WSI-INFO-005"});
+    }
+}
+
+void wsi_iod_validator::validate_sop_common_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::sop_class_uid, "SOPClassUID",
+                              findings);
+        check_type1_attribute(dataset, tags::sop_instance_uid,
+                              "SOPInstanceUID", findings);
+    }
+
+    // Validate SOP Class UID is a WSI storage class
+    if (dataset.contains(tags::sop_class_uid)) {
+        auto sop_class = dataset.get_string(tags::sop_class_uid);
+        if (!sop_classes::is_wsi_storage_sop_class(sop_class)) {
+            findings.push_back(
+                {validation_severity::error, tags::sop_class_uid,
+                 "SOPClassUID is not a recognized WSI Storage SOP Class: " +
+                     sop_class,
+                 "WSI-ERR-002"});
+        }
+    }
+}
+
+// =============================================================================
+// Attribute Validation Helpers
+// =============================================================================
+
+void wsi_iod_validator::check_type1_attribute(
+    const dicom_dataset& dataset, dicom_tag tag, std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tag)) {
+        findings.push_back(
+            {validation_severity::error, tag,
+             std::string("Type 1 attribute missing: ") + std::string(name) +
+                 " (" + tag.to_string() + ")",
+             "WSI-TYPE1-MISSING"});
+    } else {
+        // Type 1 must have a value (cannot be empty)
+        auto value = dataset.get_string(tag);
+        if (value.empty()) {
+            findings.push_back(
+                {validation_severity::error, tag,
+                 std::string("Type 1 attribute has empty value: ") +
+                     std::string(name) + " (" + tag.to_string() + ")",
+                 "WSI-TYPE1-EMPTY"});
+        }
+    }
+}
+
+void wsi_iod_validator::check_type2_attribute(
+    const dicom_dataset& dataset, dicom_tag tag, std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 2 must be present but can be empty
+    if (!dataset.contains(tag)) {
+        findings.push_back(
+            {validation_severity::warning, tag,
+             std::string("Type 2 attribute missing: ") + std::string(name) +
+                 " (" + tag.to_string() + ")",
+             "WSI-TYPE2-MISSING"});
+    }
+}
+
+void wsi_iod_validator::check_modality(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tags::modality)) {
+        return;  // Already reported as Type 1 missing
+    }
+
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "SM") {
+        findings.push_back(
+            {validation_severity::error, tags::modality,
+             "Modality must be 'SM' for WSI images, found: " + modality,
+             "WSI-ERR-003"});
+    }
+}
+
+void wsi_iod_validator::check_pixel_data_consistency(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Check BitsStored <= BitsAllocated
+    auto bits_allocated =
+        dataset.get_numeric<uint16_t>(tags::bits_allocated);
+    auto bits_stored = dataset.get_numeric<uint16_t>(tags::bits_stored);
+    auto high_bit = dataset.get_numeric<uint16_t>(tags::high_bit);
+
+    if (bits_allocated && bits_stored) {
+        if (*bits_stored > *bits_allocated) {
+            findings.push_back(
+                {validation_severity::error, tags::bits_stored,
+                 "BitsStored (" + std::to_string(*bits_stored) +
+                     ") exceeds BitsAllocated (" +
+                     std::to_string(*bits_allocated) + ")",
+                 "WSI-ERR-004"});
+        }
+    }
+
+    // Check HighBit == BitsStored - 1
+    if (bits_stored && high_bit) {
+        if (*high_bit != *bits_stored - 1) {
+            findings.push_back(
+                {validation_severity::warning, tags::high_bit,
+                 "HighBit (" + std::to_string(*high_bit) +
+                     ") should typically be BitsStored - 1 (" +
+                     std::to_string(*bits_stored - 1) + ")",
+                 "WSI-WARN-002"});
+        }
+    }
+
+    // Validate PhotometricInterpretation for WSI
+    if (dataset.contains(tags::photometric_interpretation)) {
+        auto photometric =
+            dataset.get_string(tags::photometric_interpretation);
+        if (!sop_classes::is_valid_wsi_photometric(photometric)) {
+            findings.push_back(
+                {validation_severity::error,
+                 tags::photometric_interpretation,
+                 "WSI images must use RGB, YBR_FULL_422, YBR_ICT, YBR_RCT, "
+                 "or MONOCHROME2, found: " + photometric,
+                 "WSI-ERR-005"});
+        }
+    }
+
+    // WSI SamplesPerPixel must be 1 (grayscale/fluorescence) or 3 (color)
+    auto samples = dataset.get_numeric<uint16_t>(tags::samples_per_pixel);
+    if (samples && *samples != 1 && *samples != 3) {
+        findings.push_back(
+            {validation_severity::error, tags::samples_per_pixel,
+             "WSI images require SamplesPerPixel of 1 or 3, found: " +
+                 std::to_string(*samples),
+             "WSI-ERR-006"});
+    }
+
+    // WSI images must use unsigned pixel representation
+    auto pixel_rep =
+        dataset.get_numeric<uint16_t>(tags::pixel_representation);
+    if (pixel_rep && *pixel_rep != 0) {
+        findings.push_back(
+            {validation_severity::warning, tags::pixel_representation,
+             "WSI images typically use unsigned pixel representation "
+             "(PixelRepresentation = 0)",
+             "WSI-WARN-003"});
+    }
+}
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+validation_result validate_wsi_iod(const dicom_dataset& dataset) {
+    wsi_iod_validator validator;
+    return validator.validate(dataset);
+}
+
+bool is_valid_wsi_dataset(const dicom_dataset& dataset) {
+    wsi_iod_validator validator;
+    return validator.quick_check(dataset);
+}
+
+}  // namespace pacs::services::validation

--- a/tests/services/wsi_iod_validator_test.cpp
+++ b/tests/services/wsi_iod_validator_test.cpp
@@ -1,0 +1,721 @@
+/**
+ * @file wsi_iod_validator_test.cpp
+ * @brief Unit tests for VL Whole Slide Microscopy Image IOD Validator
+ *
+ * @see DICOM PS3.3 Section A.32.8 - VL Whole Slide Microscopy Image IOD
+ * @see Issue #826 - Add WSI IOD validator
+ */
+
+#include <pacs/services/validation/wsi_iod_validator.hpp>
+#include <pacs/services/sop_classes/wsi_storage.hpp>
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_element.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services::validation;
+using namespace pacs::services::sop_classes;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+// ============================================================================
+// Test Fixtures - Helper Functions
+// ============================================================================
+
+namespace {
+
+/// Helper to create a minimal valid WSI dataset
+dicom_dataset create_minimal_wsi_dataset() {
+    dicom_dataset ds;
+
+    // Patient Module (Type 2)
+    ds.set_string(tags::patient_name, vr_type::PN, "Test^Patient");
+    ds.set_string(tags::patient_id, vr_type::LO, "WSI12345");
+    ds.set_string(tags::patient_birth_date, vr_type::DA, "19700101");
+    ds.set_string(tags::patient_sex, vr_type::CS, "F");
+
+    // General Study Module
+    ds.set_string(tags::study_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9");
+    ds.set_string(tags::study_date, vr_type::DA, "20240101");
+    ds.set_string(tags::study_time, vr_type::TM, "120000");
+    ds.set_string(tags::referring_physician_name, vr_type::PN,
+                  "Dr^Pathologist");
+    ds.set_string(tags::study_id, vr_type::SH, "STUDY001");
+    ds.set_string(tags::accession_number, vr_type::SH, "ACC001");
+
+    // General Series Module — Modality = "SM" (Slide Microscopy)
+    ds.set_string(tags::modality, vr_type::CS, "SM");
+    ds.set_string(tags::series_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.1");
+    ds.set_string(tags::series_number, vr_type::IS, "1");
+
+    // Image Pixel Module — RGB for brightfield WSI
+    ds.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 3);
+    ds.set_string(tags::photometric_interpretation, vr_type::CS, "RGB");
+    ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 256);
+    ds.set_numeric<uint16_t>(tags::columns, vr_type::US, 256);
+    ds.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 8);
+    ds.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 8);
+    ds.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 7);
+    ds.set_numeric<uint16_t>(tags::pixel_representation, vr_type::US, 0);
+
+    // WSI Image Module — Type 1 attributes
+    ds.set_string(tags::image_type, vr_type::CS,
+                  "ORIGINAL\\PRIMARY\\VOLUME\\NONE");
+    ds.set_numeric<uint32_t>(wsi_iod_tags::total_pixel_matrix_columns,
+                              vr_type::UL, 98304);
+    ds.set_numeric<uint32_t>(wsi_iod_tags::total_pixel_matrix_rows,
+                              vr_type::UL, 65536);
+    ds.set_string(wsi_iod_tags::number_of_frames, vr_type::IS, "1536");
+
+    // Image Orientation (Slide) — Type 1C
+    ds.set_string(wsi_iod_tags::image_orientation_slide, vr_type::DS,
+                  "0.0\\-1.0\\0.0\\-1.0\\0.0\\0.0");
+
+    // Imaged Volume Width/Height
+    ds.set_string(wsi_iod_tags::imaged_volume_width, vr_type::DS, "25.0");
+    ds.set_string(wsi_iod_tags::imaged_volume_height, vr_type::DS, "15.0");
+
+    // Optical Path Module — Type 1
+    ds.set_string(wsi_iod_tags::optical_path_identifier, vr_type::SH, "1");
+    ds.set_string(wsi_iod_tags::optical_path_description, vr_type::ST,
+                  "Brightfield");
+
+    // Multi-frame Dimension Module — Type 1
+    ds.set_string(wsi_iod_tags::dimension_organization_type, vr_type::CS,
+                  "TILED_FULL");
+
+    // Specimen Module (User Optional)
+    ds.set_string(wsi_iod_tags::specimen_identifier, vr_type::LO,
+                  "SPEC-001");
+    ds.set_string(wsi_iod_tags::container_identifier, vr_type::LO,
+                  "SLIDE-001");
+
+    // SOP Common Module
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  std::string(wsi_image_storage_uid));
+    ds.set_string(tags::sop_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.2");
+
+    return ds;
+}
+
+}  // namespace
+
+// ============================================================================
+// WSI IOD Validator Basic Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator validates minimal valid dataset",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+    auto dataset = create_minimal_wsi_dataset();
+
+    auto result = validator.validate(dataset);
+
+    CHECK(result.is_valid);
+    CHECK_FALSE(result.has_errors());
+}
+
+TEST_CASE("wsi_iod_validator detects missing Type 1 attributes",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+    auto dataset = create_minimal_wsi_dataset();
+
+    SECTION("missing StudyInstanceUID") {
+        dataset.remove(tags::study_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+        CHECK(result.has_errors());
+    }
+
+    SECTION("missing Modality") {
+        dataset.remove(tags::modality);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SeriesInstanceUID") {
+        dataset.remove(tags::series_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPClassUID") {
+        dataset.remove(tags::sop_class_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPInstanceUID") {
+        dataset.remove(tags::sop_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing Rows") {
+        dataset.remove(tags::rows);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing ImageType") {
+        dataset.remove(tags::image_type);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing TotalPixelMatrixColumns") {
+        dataset.remove(wsi_iod_tags::total_pixel_matrix_columns);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing TotalPixelMatrixRows") {
+        dataset.remove(wsi_iod_tags::total_pixel_matrix_rows);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing NumberOfFrames") {
+        dataset.remove(wsi_iod_tags::number_of_frames);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing OpticalPathIdentifier") {
+        dataset.remove(wsi_iod_tags::optical_path_identifier);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing DimensionOrganizationType") {
+        dataset.remove(wsi_iod_tags::dimension_organization_type);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// Type 2 Attribute Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator detects missing Type 2 attributes",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+    auto dataset = create_minimal_wsi_dataset();
+
+    SECTION("missing PatientName generates warning") {
+        dataset.remove(tags::patient_name);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing StudyDate generates warning") {
+        dataset.remove(tags::study_date);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing SeriesNumber generates warning") {
+        dataset.remove(tags::series_number);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing AccessionNumber generates warning") {
+        dataset.remove(tags::accession_number);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+}
+
+// ============================================================================
+// Modality Validation Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator checks modality value",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+    auto dataset = create_minimal_wsi_dataset();
+
+    SECTION("wrong modality - CT") {
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-003") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK(found_modality_error);
+    }
+
+    SECTION("wrong modality - MR") {
+        dataset.set_string(tags::modality, vr_type::CS, "MR");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// SOP Class UID Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator checks SOP Class UID",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+    auto dataset = create_minimal_wsi_dataset();
+
+    SECTION("WSI Image Storage is valid") {
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(wsi_image_storage_uid));
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+    }
+
+    SECTION("non-WSI SOP Class is invalid") {
+        // CT SOP Class
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          "1.2.840.10008.5.1.4.1.1.2");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-002") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK(found_sop_error);
+    }
+}
+
+// ============================================================================
+// Pixel Data Consistency Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator checks pixel data consistency",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+    auto dataset = create_minimal_wsi_dataset();
+
+    SECTION("BitsStored exceeds BitsAllocated") {
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 16);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-004") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK(found_bits_error);
+    }
+
+    SECTION("wrong HighBit generates warning") {
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 5);
+        auto result = validator.validate(dataset);
+        CHECK(result.has_warnings());
+
+        bool found_highbit_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-WARN-002") {
+                found_highbit_warning = true;
+                break;
+            }
+        }
+        CHECK(found_highbit_warning);
+    }
+
+    SECTION("invalid PhotometricInterpretation") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "PALETTE COLOR");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-005") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK(found_photometric_error);
+    }
+
+    SECTION("valid YBR_FULL_422 photometric") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "YBR_FULL_422");
+        auto result = validator.validate(dataset);
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-005") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_photometric_error);
+    }
+
+    SECTION("valid MONOCHROME2 with SamplesPerPixel=1") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "MONOCHROME2");
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 1);
+        auto result = validator.validate(dataset);
+        bool found_photometric_error = false;
+        bool found_samples_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-005") found_photometric_error = true;
+            if (f.code == "WSI-ERR-006") found_samples_error = true;
+        }
+        CHECK_FALSE(found_photometric_error);
+        CHECK_FALSE(found_samples_error);
+    }
+
+    SECTION("invalid SamplesPerPixel (not 1 or 3)") {
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 4);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_samples_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-006") {
+                found_samples_error = true;
+                break;
+            }
+        }
+        CHECK(found_samples_error);
+    }
+
+    SECTION("signed pixel representation generates warning") {
+        dataset.set_numeric<uint16_t>(tags::pixel_representation, vr_type::US,
+                                      1);
+        auto result = validator.validate(dataset);
+        CHECK(result.has_warnings());
+
+        bool found_repr_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-WARN-003") {
+                found_repr_warning = true;
+                break;
+            }
+        }
+        CHECK(found_repr_warning);
+    }
+}
+
+// ============================================================================
+// WSI-Specific Attribute Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator checks WSI-specific attributes",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+    auto dataset = create_minimal_wsi_dataset();
+
+    SECTION("invalid DimensionOrganizationType") {
+        dataset.set_string(wsi_iod_tags::dimension_organization_type,
+                          vr_type::CS, "3D");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_dim_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-001") {
+                found_dim_error = true;
+                break;
+            }
+        }
+        CHECK(found_dim_error);
+    }
+
+    SECTION("TILED_SPARSE is valid") {
+        dataset.set_string(wsi_iod_tags::dimension_organization_type,
+                          vr_type::CS, "TILED_SPARSE");
+        auto result = validator.validate(dataset);
+        bool found_dim_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-001") {
+                found_dim_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_dim_error);
+    }
+
+    SECTION("missing ImageOrientationSlide generates warning") {
+        dataset.remove(wsi_iod_tags::image_orientation_slide);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+
+        bool found_orientation_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-WARN-001") {
+                found_orientation_warning = true;
+                break;
+            }
+        }
+        CHECK(found_orientation_warning);
+    }
+
+    SECTION("missing ImagedVolumeWidth generates info") {
+        dataset.remove(wsi_iod_tags::imaged_volume_width);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_volume_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-INFO-001") {
+                found_volume_info = true;
+                break;
+            }
+        }
+        CHECK(found_volume_info);
+    }
+
+    SECTION("missing ImagedVolumeHeight generates info") {
+        dataset.remove(wsi_iod_tags::imaged_volume_height);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_volume_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-INFO-002") {
+                found_volume_info = true;
+                break;
+            }
+        }
+        CHECK(found_volume_info);
+    }
+
+    SECTION("missing OpticalPathDescription generates info") {
+        dataset.remove(wsi_iod_tags::optical_path_description);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_path_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-INFO-003") {
+                found_path_info = true;
+                break;
+            }
+        }
+        CHECK(found_path_info);
+    }
+
+    SECTION("missing SpecimenIdentifier generates info") {
+        dataset.remove(wsi_iod_tags::specimen_identifier);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_specimen_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-INFO-004") {
+                found_specimen_info = true;
+                break;
+            }
+        }
+        CHECK(found_specimen_info);
+    }
+
+    SECTION("missing ContainerIdentifier generates info") {
+        dataset.remove(wsi_iod_tags::container_identifier);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_container_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-INFO-005") {
+                found_container_info = true;
+                break;
+            }
+        }
+        CHECK(found_container_info);
+    }
+}
+
+// ============================================================================
+// Quick Check Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator quick_check works correctly",
+          "[services][wsi][validator]") {
+    wsi_iod_validator validator;
+
+    SECTION("valid dataset passes quick check") {
+        auto dataset = create_minimal_wsi_dataset();
+        CHECK(validator.quick_check(dataset));
+    }
+
+    SECTION("invalid modality fails quick check") {
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing required attribute fails quick check") {
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.remove(tags::rows);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing TotalPixelMatrixColumns fails quick check") {
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.remove(wsi_iod_tags::total_pixel_matrix_columns);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing TotalPixelMatrixRows fails quick check") {
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.remove(wsi_iod_tags::total_pixel_matrix_rows);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing SOPClassUID fails quick check") {
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.remove(tags::sop_class_uid);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+}
+
+// ============================================================================
+// Custom Options Tests
+// ============================================================================
+
+TEST_CASE("wsi_iod_validator with custom options",
+          "[services][wsi][validator]") {
+
+    SECTION("strict mode treats warnings as errors") {
+        wsi_validation_options options;
+        options.strict_mode = true;
+
+        wsi_iod_validator validator(options);
+        auto dataset = create_minimal_wsi_dataset();
+
+        // Remove a Type 2 attribute to get a warning
+        dataset.remove(tags::patient_name);
+
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("can disable WSI parameter validation") {
+        wsi_validation_options options;
+        options.validate_wsi_params = false;
+
+        wsi_iod_validator validator(options);
+        auto dataset = create_minimal_wsi_dataset();
+
+        // Verify the option doesn't crash
+        auto result = validator.validate(dataset);
+        CHECK(result.findings.size() >= 0);
+    }
+
+    SECTION("can disable pixel data validation") {
+        wsi_validation_options options;
+        options.validate_pixel_data = false;
+
+        wsi_iod_validator validator(options);
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 16);
+
+        auto result = validator.validate(dataset);
+        // Should not have pixel data errors when validation is disabled
+        bool found_pixel_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "WSI-ERR-004") {
+                found_pixel_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_pixel_error);
+    }
+
+    SECTION("can disable optical path validation") {
+        wsi_validation_options options;
+        options.validate_optical_path = false;
+
+        wsi_iod_validator validator(options);
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.remove(wsi_iod_tags::optical_path_identifier);
+
+        auto result = validator.validate(dataset);
+        // Should not have optical path errors when validation is disabled
+        bool found_optical_error = false;
+        for (const auto& f : result.findings) {
+            if (f.tag == wsi_iod_tags::optical_path_identifier &&
+                f.severity == validation_severity::error) {
+                found_optical_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_optical_error);
+    }
+
+    SECTION("options getter returns current options") {
+        wsi_validation_options options;
+        options.strict_mode = true;
+        options.validate_wsi_params = false;
+
+        wsi_iod_validator validator(options);
+        CHECK(validator.options().strict_mode);
+        CHECK_FALSE(validator.options().validate_wsi_params);
+    }
+
+    SECTION("set_options updates options") {
+        wsi_iod_validator validator;
+        CHECK_FALSE(validator.options().strict_mode);
+
+        wsi_validation_options new_options;
+        new_options.strict_mode = true;
+        validator.set_options(new_options);
+
+        CHECK(validator.options().strict_mode);
+    }
+}
+
+// ============================================================================
+// Convenience Function Tests
+// ============================================================================
+
+TEST_CASE("validate_wsi_iod convenience function",
+          "[services][wsi][validator]") {
+    auto dataset = create_minimal_wsi_dataset();
+    auto result = validate_wsi_iod(dataset);
+    CHECK(result.is_valid);
+}
+
+TEST_CASE("is_valid_wsi_dataset convenience function",
+          "[services][wsi][validator]") {
+    SECTION("valid dataset") {
+        auto dataset = create_minimal_wsi_dataset();
+        CHECK(is_valid_wsi_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - wrong modality") {
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(is_valid_wsi_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - missing TotalPixelMatrixColumns") {
+        auto dataset = create_minimal_wsi_dataset();
+        dataset.remove(wsi_iod_tags::total_pixel_matrix_columns);
+        CHECK_FALSE(is_valid_wsi_dataset(dataset));
+    }
+}


### PR DESCRIPTION
Closes #826

## Summary

- Implement WSI IOD validator following the established `ct_iod_validator` pattern
- Validate 9 DICOM modules per PS3.3 Section A.32.8 (VL Whole Slide Microscopy Image IOD)
- WSI-specific validations: DimensionOrganizationType (TILED_FULL/TILED_SPARSE), Modality=SM, RGB/YBR/MONOCHROME2 photometric, SamplesPerPixel 1 or 3, optical path, specimen tracking
- 6 error codes (WSI-ERR-001 to WSI-ERR-006), 3 warning codes (WSI-WARN-001 to WSI-WARN-003), 5 info codes (WSI-INFO-001 to WSI-INFO-005)
- 11 test cases with 76 assertions, all services tests passing (668 cases, 8698 assertions)

## Files

| File | Description |
|------|-------------|
| `include/pacs/services/validation/wsi_iod_validator.hpp` | Header with WSI tags, options, and validator class |
| `src/services/validation/wsi_iod_validator.cpp` | Implementation of 9 module validators and helpers |
| `tests/services/wsi_iod_validator_test.cpp` | Comprehensive test suite |
| `CMakeLists.txt` | Build system registration |

## Test Plan

- [x] All WSI IOD validator tests pass (11 cases, 76 assertions)
- [x] Full services test suite passes with no regressions (668 cases, 8698 assertions)
- [x] Local build succeeds (Release config)
- [x] CI workflows pass