### PR TITLE
feat(services): add Ophthalmic Photography/Tomography SOP Class support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1068,6 +1068,7 @@ add_library(pacs_services
     src/services/sop_classes/ct_storage.cpp
     src/services/sop_classes/mr_storage.cpp
     src/services/sop_classes/wsi_storage.cpp
+    src/services/sop_classes/ophthalmic_storage.cpp
     src/services/validation/us_iod_validator.cpp
     src/services/validation/dx_iod_validator.cpp
     src/services/validation/mg_iod_validator.cpp
@@ -1889,6 +1890,7 @@ if(PACS_BUILD_TESTS)
         tests/services/sr_storage_test.cpp
         tests/services/ct_storage_test.cpp
         tests/services/wsi_storage_test.cpp
+        tests/services/ophthalmic_storage_test.cpp
         tests/services/ct_iod_validator_test.cpp
         tests/services/mr_iod_validator_test.cpp
         tests/services/wsi_iod_validator_test.cpp

--- a/include/pacs/services/sop_class_registry.hpp
+++ b/include/pacs/services/sop_class_registry.hpp
@@ -91,6 +91,7 @@ enum class modality_type {
     sr,         ///< Structured Report
     seg,        ///< Segmentation
     sm,         ///< Slide Microscopy (Whole Slide Imaging)
+    op,         ///< Ophthalmic Photography / Tomography
     other       ///< Other modalities
 };
 
@@ -237,6 +238,7 @@ private:
     void register_print_sop_classes();
     void register_ups_sop_classes();
     void register_wsi_sop_classes();
+    void register_ophthalmic_sop_classes();
     void register_other_sop_classes();
 
     std::unordered_map<std::string, sop_class_info> registry_;

--- a/include/pacs/services/sop_classes/ophthalmic_storage.hpp
+++ b/include/pacs/services/sop_classes/ophthalmic_storage.hpp
@@ -1,0 +1,147 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file ophthalmic_storage.hpp
+ * @brief Ophthalmic Photography and Tomography Storage SOP Classes
+ *
+ * Provides SOP Class definitions and utilities for Ophthalmic Photography
+ * (fundus cameras) and Optical Coherence Tomography (OCT) image storage.
+ *
+ * @see DICOM PS3.3 Section A.39 - Ophthalmic Photography IODs
+ * @see DICOM PS3.3 Section A.40 - Ophthalmic Tomography Image IOD
+ * @see Issue #829 - Add Ophthalmic SOP Class registration and storage definition
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_SOP_CLASSES_OPHTHALMIC_STORAGE_HPP
+#define PACS_SERVICES_SOP_CLASSES_OPHTHALMIC_STORAGE_HPP
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::services::sop_classes {
+
+// =============================================================================
+// Ophthalmic Storage SOP Class UIDs
+// =============================================================================
+
+/// Ophthalmic Photography 8 Bit Image Storage
+inline constexpr std::string_view ophthalmic_photo_8bit_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.77.1.5.1";
+
+/// Ophthalmic Photography 16 Bit Image Storage
+inline constexpr std::string_view ophthalmic_photo_16bit_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.77.1.5.2";
+
+/// Ophthalmic Tomography Image Storage (OCT)
+inline constexpr std::string_view ophthalmic_tomography_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.77.1.5.4";
+
+/// Wide Field Ophthalmic Photography SOP Class Storage
+inline constexpr std::string_view wide_field_ophthalmic_photo_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.77.1.5.7";
+
+/// Ophthalmic Optical Coherence Tomography B-scan Volume Analysis Storage
+inline constexpr std::string_view ophthalmic_oct_bscan_analysis_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.77.1.5.8";
+
+// =============================================================================
+// Ophthalmic DICOM Tags
+// =============================================================================
+
+namespace ophthalmic_tags {
+
+/// Image Laterality (0020,0062) — R, L, or B
+inline constexpr uint32_t image_laterality = 0x00200062;
+
+/// Anatomic Region Sequence (0008,2218)
+inline constexpr uint32_t anatomic_region_sequence = 0x00082218;
+
+/// Acquisition Device Type Code Sequence (0022,0015)
+inline constexpr uint32_t acquisition_device_type_code_sequence = 0x00220015;
+
+/// Detector Type (0018,7004)
+inline constexpr uint32_t detector_type = 0x00187004;
+
+/// Pupil Dilated (0022,000D)
+inline constexpr uint32_t pupil_dilated = 0x0022000D;
+
+/// Depth of Field (0022,0035)
+inline constexpr uint32_t depth_of_field = 0x00220035;
+
+/// Axial Length of the Eye (0022,0030)
+inline constexpr uint32_t axial_length_of_eye = 0x00220030;
+
+/// Emmetropic Magnification (0022,000A)
+inline constexpr uint32_t emmetropic_magnification = 0x0022000A;
+
+/// Intra Ocular Pressure (0022,000B)
+inline constexpr uint32_t intra_ocular_pressure = 0x0022000B;
+
+/// Horizontal Field of View (0022,000C)
+inline constexpr uint32_t horizontal_field_of_view = 0x0022000C;
+
+}  // namespace ophthalmic_tags
+
+// =============================================================================
+// Ophthalmic SOP Class Utilities
+// =============================================================================
+
+/**
+ * @brief Get all Ophthalmic Storage SOP Class UIDs
+ * @return Vector of Ophthalmic Storage SOP Class UIDs
+ */
+[[nodiscard]] std::vector<std::string> get_ophthalmic_storage_sop_classes();
+
+/**
+ * @brief Check if a SOP Class UID is an Ophthalmic Storage SOP Class
+ * @param uid The SOP Class UID to check
+ * @return true if this is an ophthalmic storage SOP class
+ */
+[[nodiscard]] bool is_ophthalmic_storage_sop_class(std::string_view uid) noexcept;
+
+/**
+ * @brief Check if photometric interpretation is valid for ophthalmic imaging
+ *
+ * Ophthalmic Photography supports RGB (color fundus) and MONOCHROME2
+ * (fluorescein angiography, ICG). OCT supports MONOCHROME2.
+ * MONOCHROME1 is also valid for certain ophthalmic applications.
+ *
+ * @param value The photometric interpretation string
+ * @return true if valid for ophthalmic images
+ */
+[[nodiscard]] bool is_valid_ophthalmic_photometric(std::string_view value) noexcept;
+
+}  // namespace pacs::services::sop_classes
+
+#endif  // PACS_SERVICES_SOP_CLASSES_OPHTHALMIC_STORAGE_HPP

--- a/src/services/sop_class_registry.cpp
+++ b/src/services/sop_class_registry.cpp
@@ -43,6 +43,7 @@
 #include "pacs/services/sop_classes/us_storage.hpp"
 #include "pacs/services/sop_classes/wsi_storage.hpp"
 #include "pacs/services/sop_classes/xa_storage.hpp"
+#include "pacs/services/sop_classes/ophthalmic_storage.hpp"
 
 #include <algorithm>
 
@@ -151,6 +152,7 @@ std::string_view sop_class_registry::modality_to_string(modality_type modality) 
         case modality_type::sr: return "SR";
         case modality_type::seg: return "SEG";
         case modality_type::sm: return "SM";
+        case modality_type::op: return "OP";
         case modality_type::other: return "OT";
     }
     return "OT";
@@ -176,6 +178,7 @@ modality_type sop_class_registry::parse_modality(std::string_view modality) noex
     if (modality == "SR") return modality_type::sr;
     if (modality == "SEG") return modality_type::seg;
     if (modality == "SM") return modality_type::sm;
+    if (modality == "OP" || modality == "OPT") return modality_type::op;
     return modality_type::other;
 }
 
@@ -197,6 +200,7 @@ void sop_class_registry::register_standard_sop_classes() {
     register_print_sop_classes();
     register_ups_sop_classes();
     register_wsi_sop_classes();
+    register_ophthalmic_sop_classes();
     register_other_sop_classes();
 }
 
@@ -976,6 +980,73 @@ void sop_class_registry::register_wsi_sop_classes() {
             modality_type::sm,
             false,
             true  // supports multiframe (tiled images)
+        }
+    );
+}
+
+void sop_class_registry::register_ophthalmic_sop_classes() {
+    // Ophthalmic Photography 8 Bit Image Storage
+    registry_.emplace(
+        std::string(sop_classes::ophthalmic_photo_8bit_storage_uid),
+        sop_class_info{
+            sop_classes::ophthalmic_photo_8bit_storage_uid,
+            "Ophthalmic Photography 8 Bit Image Storage",
+            sop_class_category::storage,
+            modality_type::op,
+            false,
+            false
+        }
+    );
+
+    // Ophthalmic Photography 16 Bit Image Storage
+    registry_.emplace(
+        std::string(sop_classes::ophthalmic_photo_16bit_storage_uid),
+        sop_class_info{
+            sop_classes::ophthalmic_photo_16bit_storage_uid,
+            "Ophthalmic Photography 16 Bit Image Storage",
+            sop_class_category::storage,
+            modality_type::op,
+            false,
+            false
+        }
+    );
+
+    // Ophthalmic Tomography Image Storage (OCT)
+    registry_.emplace(
+        std::string(sop_classes::ophthalmic_tomography_storage_uid),
+        sop_class_info{
+            sop_classes::ophthalmic_tomography_storage_uid,
+            "Ophthalmic Tomography Image Storage",
+            sop_class_category::storage,
+            modality_type::op,
+            false,
+            true  // OCT produces multi-frame B-scan volumes
+        }
+    );
+
+    // Wide Field Ophthalmic Photography SOP Class Storage
+    registry_.emplace(
+        std::string(sop_classes::wide_field_ophthalmic_photo_storage_uid),
+        sop_class_info{
+            sop_classes::wide_field_ophthalmic_photo_storage_uid,
+            "Wide Field Ophthalmic Photography Storage",
+            sop_class_category::storage,
+            modality_type::op,
+            false,
+            false
+        }
+    );
+
+    // Ophthalmic OCT B-scan Volume Analysis Storage
+    registry_.emplace(
+        std::string(sop_classes::ophthalmic_oct_bscan_analysis_storage_uid),
+        sop_class_info{
+            sop_classes::ophthalmic_oct_bscan_analysis_storage_uid,
+            "Ophthalmic OCT B-scan Volume Analysis Storage",
+            sop_class_category::storage,
+            modality_type::op,
+            false,
+            true  // B-scan volume analysis is multi-frame
         }
     );
 }

--- a/src/services/sop_classes/ophthalmic_storage.cpp
+++ b/src/services/sop_classes/ophthalmic_storage.cpp
@@ -1,0 +1,65 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file ophthalmic_storage.cpp
+ * @brief Implementation of Ophthalmic Storage SOP Class utilities
+ *
+ * @see Issue #829 - Add Ophthalmic SOP Class registration and storage definition
+ */
+
+#include "pacs/services/sop_classes/ophthalmic_storage.hpp"
+
+namespace pacs::services::sop_classes {
+
+std::vector<std::string> get_ophthalmic_storage_sop_classes() {
+    return {
+        std::string(ophthalmic_photo_8bit_storage_uid),
+        std::string(ophthalmic_photo_16bit_storage_uid),
+        std::string(ophthalmic_tomography_storage_uid),
+        std::string(wide_field_ophthalmic_photo_storage_uid),
+        std::string(ophthalmic_oct_bscan_analysis_storage_uid),
+    };
+}
+
+bool is_ophthalmic_storage_sop_class(std::string_view uid) noexcept {
+    return uid == ophthalmic_photo_8bit_storage_uid ||
+           uid == ophthalmic_photo_16bit_storage_uid ||
+           uid == ophthalmic_tomography_storage_uid ||
+           uid == wide_field_ophthalmic_photo_storage_uid ||
+           uid == ophthalmic_oct_bscan_analysis_storage_uid;
+}
+
+bool is_valid_ophthalmic_photometric(std::string_view value) noexcept {
+    return value == "MONOCHROME1" || value == "MONOCHROME2" ||
+           value == "RGB" || value == "YBR_FULL_422" ||
+           value == "PALETTE COLOR";
+}
+
+}  // namespace pacs::services::sop_classes

--- a/tests/services/ophthalmic_storage_test.cpp
+++ b/tests/services/ophthalmic_storage_test.cpp
@@ -1,0 +1,260 @@
+/**
+ * @file ophthalmic_storage_test.cpp
+ * @brief Unit tests for Ophthalmic Photography/Tomography Storage SOP Classes
+ *
+ * @see Issue #829 - Add Ophthalmic SOP Class registration and storage definition
+ */
+
+#include <pacs/services/sop_classes/ophthalmic_storage.hpp>
+#include <pacs/services/sop_class_registry.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+
+using namespace pacs::services;
+using namespace pacs::services::sop_classes;
+
+// ============================================================================
+// SOP Class UID Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic SOP Class UIDs are correct",
+          "[services][ophthalmic][storage]") {
+    CHECK(ophthalmic_photo_8bit_storage_uid
+          == "1.2.840.10008.5.1.4.1.1.77.1.5.1");
+    CHECK(ophthalmic_photo_16bit_storage_uid
+          == "1.2.840.10008.5.1.4.1.1.77.1.5.2");
+    CHECK(ophthalmic_tomography_storage_uid
+          == "1.2.840.10008.5.1.4.1.1.77.1.5.4");
+    CHECK(wide_field_ophthalmic_photo_storage_uid
+          == "1.2.840.10008.5.1.4.1.1.77.1.5.7");
+    CHECK(ophthalmic_oct_bscan_analysis_storage_uid
+          == "1.2.840.10008.5.1.4.1.1.77.1.5.8");
+}
+
+// ============================================================================
+// is_ophthalmic_storage_sop_class Tests
+// ============================================================================
+
+TEST_CASE("is_ophthalmic_storage_sop_class identifies ophthalmic SOP Classes",
+          "[services][ophthalmic][storage]") {
+    SECTION("Ophthalmic Photography 8 Bit") {
+        CHECK(is_ophthalmic_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.77.1.5.1"));
+    }
+
+    SECTION("Ophthalmic Photography 16 Bit") {
+        CHECK(is_ophthalmic_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.77.1.5.2"));
+    }
+
+    SECTION("Ophthalmic Tomography (OCT)") {
+        CHECK(is_ophthalmic_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.77.1.5.4"));
+    }
+
+    SECTION("Wide Field Ophthalmic Photography") {
+        CHECK(is_ophthalmic_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.77.1.5.7"));
+    }
+
+    SECTION("Ophthalmic OCT B-scan Volume Analysis") {
+        CHECK(is_ophthalmic_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.77.1.5.8"));
+    }
+
+    SECTION("non-ophthalmic SOP Class - CT") {
+        CHECK_FALSE(is_ophthalmic_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.2"));
+    }
+
+    SECTION("non-ophthalmic SOP Class - WSI") {
+        CHECK_FALSE(is_ophthalmic_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.77.1.6"));
+    }
+
+    SECTION("empty string") {
+        CHECK_FALSE(is_ophthalmic_storage_sop_class(""));
+    }
+}
+
+// ============================================================================
+// get_ophthalmic_storage_sop_classes Tests
+// ============================================================================
+
+TEST_CASE("get_ophthalmic_storage_sop_classes returns all UIDs",
+          "[services][ophthalmic][storage]") {
+    auto uids = get_ophthalmic_storage_sop_classes();
+    CHECK(uids.size() == 5);
+
+    CHECK(std::find(uids.begin(), uids.end(),
+                    "1.2.840.10008.5.1.4.1.1.77.1.5.1") != uids.end());
+    CHECK(std::find(uids.begin(), uids.end(),
+                    "1.2.840.10008.5.1.4.1.1.77.1.5.2") != uids.end());
+    CHECK(std::find(uids.begin(), uids.end(),
+                    "1.2.840.10008.5.1.4.1.1.77.1.5.4") != uids.end());
+    CHECK(std::find(uids.begin(), uids.end(),
+                    "1.2.840.10008.5.1.4.1.1.77.1.5.7") != uids.end());
+    CHECK(std::find(uids.begin(), uids.end(),
+                    "1.2.840.10008.5.1.4.1.1.77.1.5.8") != uids.end());
+}
+
+// ============================================================================
+// is_valid_ophthalmic_photometric Tests
+// ============================================================================
+
+TEST_CASE("is_valid_ophthalmic_photometric checks supported color models",
+          "[services][ophthalmic][storage]") {
+    SECTION("MONOCHROME1 is valid (inverse grayscale)") {
+        CHECK(is_valid_ophthalmic_photometric("MONOCHROME1"));
+    }
+
+    SECTION("MONOCHROME2 is valid (OCT, fluorescein angiography)") {
+        CHECK(is_valid_ophthalmic_photometric("MONOCHROME2"));
+    }
+
+    SECTION("RGB is valid (color fundus photography)") {
+        CHECK(is_valid_ophthalmic_photometric("RGB"));
+    }
+
+    SECTION("YBR_FULL_422 is valid (JPEG compressed)") {
+        CHECK(is_valid_ophthalmic_photometric("YBR_FULL_422"));
+    }
+
+    SECTION("PALETTE COLOR is valid (pseudo-color mapping)") {
+        CHECK(is_valid_ophthalmic_photometric("PALETTE COLOR"));
+    }
+
+    SECTION("YBR_ICT is invalid for ophthalmic") {
+        CHECK_FALSE(is_valid_ophthalmic_photometric("YBR_ICT"));
+    }
+
+    SECTION("YBR_RCT is invalid for ophthalmic") {
+        CHECK_FALSE(is_valid_ophthalmic_photometric("YBR_RCT"));
+    }
+
+    SECTION("empty string is invalid") {
+        CHECK_FALSE(is_valid_ophthalmic_photometric(""));
+    }
+}
+
+// ============================================================================
+// Ophthalmic DICOM Tag Constant Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic DICOM tag constants are correct",
+          "[services][ophthalmic][storage]") {
+    CHECK(ophthalmic_tags::image_laterality == 0x00200062);
+    CHECK(ophthalmic_tags::anatomic_region_sequence == 0x00082218);
+    CHECK(ophthalmic_tags::acquisition_device_type_code_sequence == 0x00220015);
+    CHECK(ophthalmic_tags::detector_type == 0x00187004);
+    CHECK(ophthalmic_tags::pupil_dilated == 0x0022000D);
+    CHECK(ophthalmic_tags::axial_length_of_eye == 0x00220030);
+    CHECK(ophthalmic_tags::horizontal_field_of_view == 0x0022000C);
+}
+
+// ============================================================================
+// SOP Class Registry Integration Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic SOP Classes are registered in sop_class_registry",
+          "[services][ophthalmic][storage][registry]") {
+    auto& registry = sop_class_registry::instance();
+
+    SECTION("all ophthalmic UIDs are supported") {
+        CHECK(registry.is_supported(ophthalmic_photo_8bit_storage_uid));
+        CHECK(registry.is_supported(ophthalmic_photo_16bit_storage_uid));
+        CHECK(registry.is_supported(ophthalmic_tomography_storage_uid));
+        CHECK(registry.is_supported(wide_field_ophthalmic_photo_storage_uid));
+        CHECK(registry.is_supported(ophthalmic_oct_bscan_analysis_storage_uid));
+    }
+
+    SECTION("8-bit photography info is correct") {
+        const auto* info = registry.get_info(ophthalmic_photo_8bit_storage_uid);
+        REQUIRE(info != nullptr);
+        CHECK(info->uid == ophthalmic_photo_8bit_storage_uid);
+        CHECK(info->name == "Ophthalmic Photography 8 Bit Image Storage");
+        CHECK(info->category == sop_class_category::storage);
+        CHECK(info->modality == modality_type::op);
+        CHECK(info->is_retired == false);
+        CHECK(info->supports_multiframe == false);
+    }
+
+    SECTION("OCT info supports multiframe") {
+        const auto* info = registry.get_info(ophthalmic_tomography_storage_uid);
+        REQUIRE(info != nullptr);
+        CHECK(info->name == "Ophthalmic Tomography Image Storage");
+        CHECK(info->modality == modality_type::op);
+        CHECK(info->supports_multiframe == true);
+    }
+
+    SECTION("B-scan volume analysis info supports multiframe") {
+        const auto* info = registry.get_info(
+            ophthalmic_oct_bscan_analysis_storage_uid);
+        REQUIRE(info != nullptr);
+        CHECK(info->name == "Ophthalmic OCT B-scan Volume Analysis Storage");
+        CHECK(info->supports_multiframe == true);
+    }
+
+    SECTION("ophthalmic classes appear in storage class list") {
+        auto storage_classes = registry.get_all_storage_classes();
+        auto it = std::find(storage_classes.begin(), storage_classes.end(),
+                            std::string(ophthalmic_photo_8bit_storage_uid));
+        CHECK(it != storage_classes.end());
+    }
+
+    SECTION("ophthalmic classes appear in OP modality query") {
+        auto op_classes = registry.get_by_modality(modality_type::op);
+        CHECK(op_classes.size() >= 5);
+        auto it = std::find(op_classes.begin(), op_classes.end(),
+                            std::string(ophthalmic_tomography_storage_uid));
+        CHECK(it != op_classes.end());
+    }
+}
+
+// ============================================================================
+// Modality Conversion Tests
+// ============================================================================
+
+TEST_CASE("OP modality string conversion",
+          "[services][ophthalmic][storage][registry]") {
+    SECTION("modality_to_string returns OP") {
+        CHECK(sop_class_registry::modality_to_string(modality_type::op)
+              == "OP");
+    }
+
+    SECTION("parse_modality recognizes OP") {
+        CHECK(sop_class_registry::parse_modality("OP") == modality_type::op);
+    }
+
+    SECTION("parse_modality recognizes OPT as OP") {
+        CHECK(sop_class_registry::parse_modality("OPT") == modality_type::op);
+    }
+}
+
+// ============================================================================
+// Convenience Function Tests
+// ============================================================================
+
+TEST_CASE("convenience functions work for ophthalmic",
+          "[services][ophthalmic][storage][registry]") {
+    SECTION("is_storage_sop_class") {
+        CHECK(is_storage_sop_class(ophthalmic_photo_8bit_storage_uid));
+        CHECK(is_storage_sop_class(ophthalmic_tomography_storage_uid));
+    }
+
+    SECTION("get_storage_modality") {
+        CHECK(get_storage_modality(ophthalmic_photo_8bit_storage_uid)
+              == modality_type::op);
+        CHECK(get_storage_modality(ophthalmic_tomography_storage_uid)
+              == modality_type::op);
+    }
+
+    SECTION("get_sop_class_name") {
+        CHECK(get_sop_class_name(ophthalmic_photo_8bit_storage_uid)
+              == "Ophthalmic Photography 8 Bit Image Storage");
+        CHECK(get_sop_class_name(ophthalmic_tomography_storage_uid)
+              == "Ophthalmic Tomography Image Storage");
+    }
+}


### PR DESCRIPTION
Closes #829

## Summary

- Register 5 Ophthalmic Storage SOP Classes (Photography 8/16-bit, Tomography/OCT, Wide Field, OCT B-scan Volume Analysis)
- Add `ophthalmic_storage.hpp/.cpp` with SOP Class UIDs, DICOM tag constants, and utility functions
- Add `op` modality type to `modality_type` enum with OP/OPT string conversion
- Register all 5 SOP Classes in `sop_class_registry` with correct multiframe flags
- Add comprehensive unit tests (7 test cases covering UIDs, identification, photometric validation, tag constants, registry integration, modality conversion, convenience functions)

Part of #793

## Test Plan

- [x] All 7 ophthalmic storage tests pass
- [x] All 58 related regression tests pass (WSI, registry, modality conversion)
- [x] Build passes with `-Werror` and no warnings