### PR TITLE
feat(validation): add Ophthalmic Photography/Tomography IOD validator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1080,6 +1080,7 @@ add_library(pacs_services
     src/services/validation/ct_iod_validator.cpp
     src/services/validation/mr_iod_validator.cpp
     src/services/validation/wsi_iod_validator.cpp
+    src/services/validation/ophthalmic_iod_validator.cpp
     src/services/cache/query_cache.cpp
     src/services/cache/database_cursor.cpp
     src/services/cache/query_result_stream.cpp
@@ -1894,6 +1895,7 @@ if(PACS_BUILD_TESTS)
         tests/services/ct_iod_validator_test.cpp
         tests/services/mr_iod_validator_test.cpp
         tests/services/wsi_iod_validator_test.cpp
+        tests/services/ophthalmic_iod_validator_test.cpp
         tests/services/cache/simple_lru_cache_test.cpp
         tests/services/cache/query_cache_test.cpp
         tests/services/cache/streaming_query_test.cpp

--- a/include/pacs/services/validation/ophthalmic_iod_validator.hpp
+++ b/include/pacs/services/validation/ophthalmic_iod_validator.hpp
@@ -1,0 +1,287 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file ophthalmic_iod_validator.hpp
+ * @brief Ophthalmic Photography and Tomography Image IOD Validator
+ *
+ * Provides validation for Ophthalmic Photography (8-bit, 16-bit, wide-field)
+ * and Optical Coherence Tomography Image Information Object Definitions
+ * as specified in DICOM PS3.3 Sections A.39 and A.40.
+ *
+ * Ophthalmic images include fundus photography, fluorescein angiography,
+ * ICG angiography, and OCT B-scans. They require laterality tracking and
+ * support modality-specific photometric interpretations.
+ *
+ * @see DICOM PS3.3 Section A.39 - Ophthalmic Photography IODs
+ * @see DICOM PS3.3 Section A.40 - Ophthalmic Tomography Image IOD
+ * @see Issue #830 - Add Ophthalmic IOD validator
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_VALIDATION_OPHTHALMIC_IOD_VALIDATOR_HPP
+#define PACS_SERVICES_VALIDATION_OPHTHALMIC_IOD_VALIDATOR_HPP
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/core/dicom_tag.hpp"
+#include "pacs/services/validation/us_iod_validator.hpp"  // Reuse validation types
+
+#include <string>
+#include <vector>
+
+namespace pacs::services::validation {
+
+// =============================================================================
+// Ophthalmic-Specific DICOM Tags for Validation
+// =============================================================================
+
+namespace ophthalmic_iod_tags {
+
+/// Image Laterality (0020,0062) — R, L, or B
+inline constexpr core::dicom_tag image_laterality{0x0020, 0x0062};
+
+/// Anatomic Region Sequence (0008,2218)
+inline constexpr core::dicom_tag anatomic_region_sequence{0x0008, 0x2218};
+
+/// Acquisition Device Type Code Sequence (0022,0015)
+inline constexpr core::dicom_tag acquisition_device_type_code_sequence{0x0022,
+                                                                       0x0015};
+
+/// Pupil Dilated (0022,000D)
+inline constexpr core::dicom_tag pupil_dilated{0x0022, 0x000D};
+
+/// Axial Length of the Eye (0022,0030)
+inline constexpr core::dicom_tag axial_length_of_eye{0x0022, 0x0030};
+
+/// Horizontal Field of View (0022,000C)
+inline constexpr core::dicom_tag horizontal_field_of_view{0x0022, 0x000C};
+
+/// Detector Type (0018,7004)
+inline constexpr core::dicom_tag detector_type{0x0018, 0x7004};
+
+/// Number of Frames (0028,0008)
+inline constexpr core::dicom_tag number_of_frames{0x0028, 0x0008};
+
+/// Acquisition Context Sequence (0040,0555)
+inline constexpr core::dicom_tag acquisition_context_sequence{0x0040, 0x0555};
+
+}  // namespace ophthalmic_iod_tags
+
+// =============================================================================
+// Ophthalmic Validation Options
+// =============================================================================
+
+/**
+ * @brief Options for Ophthalmic IOD validation
+ */
+struct ophthalmic_validation_options {
+    /// Check Type 1 (required) attributes
+    bool check_type1 = true;
+
+    /// Check Type 2 (required, can be empty) attributes
+    bool check_type2 = true;
+
+    /// Check Type 1C/2C (conditionally required) attributes
+    bool check_conditional = true;
+
+    /// Validate pixel data consistency (rows, columns, bits)
+    bool validate_pixel_data = true;
+
+    /// Validate ophthalmic-specific image parameters
+    bool validate_ophthalmic_params = true;
+
+    /// Validate laterality (R/L/B)
+    bool validate_laterality = true;
+
+    /// Strict mode - treat warnings as errors
+    bool strict_mode = false;
+};
+
+// =============================================================================
+// Ophthalmic IOD Validator
+// =============================================================================
+
+/**
+ * @brief Validator for Ophthalmic Photography and Tomography Image IODs
+ *
+ * Validates DICOM datasets against the Ophthalmic Photography and
+ * Tomography Image IOD specifications (PS3.3 Sections A.39/A.40).
+ *
+ * ## Validated Modules
+ *
+ * ### Mandatory Modules
+ * - Patient Module (M)
+ * - General Study Module (M)
+ * - General Series Module (M) — Modality = "OP" or "OPT"
+ * - Ophthalmic Photography Image Module (M)
+ * - Image Pixel Module (M)
+ * - SOP Common Module (M)
+ * - Acquisition Context Module (M)
+ *
+ * ### Conditional Modules
+ * - Multi-frame Module (C) — for OCT images
+ *
+ * @example
+ * @code
+ * ophthalmic_iod_validator validator;
+ * auto result = validator.validate(dataset);
+ *
+ * if (!result.is_valid) {
+ *     for (const auto& finding : result.findings) {
+ *         std::cerr << finding.message << "\n";
+ *     }
+ * }
+ * @endcode
+ */
+class ophthalmic_iod_validator {
+public:
+    /**
+     * @brief Construct validator with default options
+     */
+    ophthalmic_iod_validator() = default;
+
+    /**
+     * @brief Construct validator with custom options
+     * @param options Validation options
+     */
+    explicit ophthalmic_iod_validator(
+        const ophthalmic_validation_options& options);
+
+    /**
+     * @brief Validate a DICOM dataset against Ophthalmic IOD
+     * @param dataset The dataset to validate
+     * @return Validation result with all findings
+     */
+    [[nodiscard]] validation_result validate(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Quick check if dataset has minimum required ophthalmic attributes
+     * @param dataset The dataset to check
+     * @return true if all Type 1 attributes are present
+     */
+    [[nodiscard]] bool quick_check(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Get the validation options
+     */
+    [[nodiscard]] const ophthalmic_validation_options& options() const noexcept;
+
+    /**
+     * @brief Set validation options
+     */
+    void set_options(const ophthalmic_validation_options& options);
+
+private:
+    // Module validation methods
+    void validate_patient_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_study_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_series_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_ophthalmic_image_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_image_pixel_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_multiframe_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_acquisition_context_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_sop_common_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    // Attribute validation helpers
+    void check_type1_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_type2_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_modality(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void check_laterality(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void check_pixel_data_consistency(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    ophthalmic_validation_options options_;
+};
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+/**
+ * @brief Validate an ophthalmic dataset with default options
+ * @param dataset The dataset to validate
+ * @return Validation result
+ */
+[[nodiscard]] validation_result validate_ophthalmic_iod(
+    const core::dicom_dataset& dataset);
+
+/**
+ * @brief Quick check if a dataset is a valid ophthalmic image
+ * @param dataset The dataset to check
+ * @return true if the dataset passes basic ophthalmic IOD validation
+ */
+[[nodiscard]] bool is_valid_ophthalmic_dataset(
+    const core::dicom_dataset& dataset);
+
+}  // namespace pacs::services::validation
+
+#endif  // PACS_SERVICES_VALIDATION_OPHTHALMIC_IOD_VALIDATOR_HPP

--- a/src/services/validation/ophthalmic_iod_validator.cpp
+++ b/src/services/validation/ophthalmic_iod_validator.cpp
@@ -1,0 +1,525 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file ophthalmic_iod_validator.cpp
+ * @brief Implementation of Ophthalmic Photography/Tomography Image IOD Validator
+ *
+ * @see DICOM PS3.3 Section A.39 - Ophthalmic Photography IODs
+ * @see DICOM PS3.3 Section A.40 - Ophthalmic Tomography Image IOD
+ * @see Issue #830 - Add Ophthalmic IOD validator
+ */
+
+#include "pacs/services/validation/ophthalmic_iod_validator.hpp"
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/services/sop_classes/ophthalmic_storage.hpp"
+
+namespace pacs::services::validation {
+
+using namespace pacs::core;
+
+// =============================================================================
+// ophthalmic_iod_validator Implementation
+// =============================================================================
+
+ophthalmic_iod_validator::ophthalmic_iod_validator(
+    const ophthalmic_validation_options& options)
+    : options_(options) {}
+
+validation_result ophthalmic_iod_validator::validate(
+    const dicom_dataset& dataset) const {
+    validation_result result;
+    result.is_valid = true;
+
+    // Validate mandatory modules (PS3.3 Tables A.39-1 / A.40-1)
+    if (options_.check_type1 || options_.check_type2) {
+        validate_patient_module(dataset, result.findings);
+        validate_general_study_module(dataset, result.findings);
+        validate_general_series_module(dataset, result.findings);
+        validate_sop_common_module(dataset, result.findings);
+    }
+
+    if (options_.validate_ophthalmic_params) {
+        validate_ophthalmic_image_module(dataset, result.findings);
+    }
+
+    if (options_.validate_pixel_data) {
+        validate_image_pixel_module(dataset, result.findings);
+    }
+
+    // Multi-frame Module is conditional — applies to OCT images
+    if (options_.check_conditional) {
+        validate_multiframe_module(dataset, result.findings);
+        validate_acquisition_context_module(dataset, result.findings);
+    }
+
+    // Determine overall validity
+    for (const auto& finding : result.findings) {
+        if (finding.severity == validation_severity::error) {
+            result.is_valid = false;
+            break;
+        }
+        if (options_.strict_mode &&
+            finding.severity == validation_severity::warning) {
+            result.is_valid = false;
+            break;
+        }
+    }
+
+    return result;
+}
+
+bool ophthalmic_iod_validator::quick_check(const dicom_dataset& dataset) const {
+    // General Study Module Type 1
+    if (!dataset.contains(tags::study_instance_uid)) return false;
+
+    // General Series Module Type 1
+    if (!dataset.contains(tags::modality)) return false;
+    if (!dataset.contains(tags::series_instance_uid)) return false;
+
+    // Check modality is OP or OPT
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "OP" && modality != "OPT") return false;
+
+    // Ophthalmic Image Module Type 1
+    if (!dataset.contains(tags::image_type)) return false;
+    if (!dataset.contains(ophthalmic_iod_tags::image_laterality)) return false;
+
+    // Image Pixel Module Type 1
+    if (!dataset.contains(tags::samples_per_pixel)) return false;
+    if (!dataset.contains(tags::photometric_interpretation)) return false;
+    if (!dataset.contains(tags::rows)) return false;
+    if (!dataset.contains(tags::columns)) return false;
+    if (!dataset.contains(tags::bits_allocated)) return false;
+    if (!dataset.contains(tags::bits_stored)) return false;
+    if (!dataset.contains(tags::high_bit)) return false;
+    if (!dataset.contains(tags::pixel_representation)) return false;
+
+    // SOP Common Module Type 1
+    if (!dataset.contains(tags::sop_class_uid)) return false;
+    if (!dataset.contains(tags::sop_instance_uid)) return false;
+
+    return true;
+}
+
+const ophthalmic_validation_options&
+ophthalmic_iod_validator::options() const noexcept {
+    return options_;
+}
+
+void ophthalmic_iod_validator::set_options(
+    const ophthalmic_validation_options& options) {
+    options_ = options;
+}
+
+// =============================================================================
+// Module Validation Methods
+// =============================================================================
+
+void ophthalmic_iod_validator::validate_patient_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Patient Module - All attributes are Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::patient_name, "PatientName",
+                              findings);
+        check_type2_attribute(dataset, tags::patient_id, "PatientID",
+                              findings);
+        check_type2_attribute(dataset, tags::patient_birth_date,
+                              "PatientBirthDate", findings);
+        check_type2_attribute(dataset, tags::patient_sex, "PatientSex",
+                              findings);
+    }
+}
+
+void ophthalmic_iod_validator::validate_general_study_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::study_instance_uid,
+                              "StudyInstanceUID", findings);
+    }
+
+    // Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::study_date, "StudyDate",
+                              findings);
+        check_type2_attribute(dataset, tags::study_time, "StudyTime",
+                              findings);
+        check_type2_attribute(dataset, tags::referring_physician_name,
+                              "ReferringPhysicianName", findings);
+        check_type2_attribute(dataset, tags::study_id, "StudyID", findings);
+        check_type2_attribute(dataset, tags::accession_number,
+                              "AccessionNumber", findings);
+    }
+}
+
+void ophthalmic_iod_validator::validate_general_series_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::modality, "Modality", findings);
+        check_type1_attribute(dataset, tags::series_instance_uid,
+                              "SeriesInstanceUID", findings);
+
+        // Modality must be "OP" or "OPT"
+        check_modality(dataset, findings);
+    }
+
+    // Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::series_number, "SeriesNumber",
+                              findings);
+    }
+}
+
+void ophthalmic_iod_validator::validate_ophthalmic_image_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // ImageType is Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::image_type, "ImageType",
+                              findings);
+    }
+
+    // Image Laterality is Type 1 — must be R, L, or B
+    if (options_.validate_laterality) {
+        check_type1_attribute(dataset, ophthalmic_iod_tags::image_laterality,
+                              "ImageLaterality", findings);
+        check_laterality(dataset, findings);
+    }
+
+    // Informational checks for ophthalmic-specific attributes
+    if (options_.check_conditional) {
+        // Anatomic Region Sequence — Type 1 for ophthalmic
+        if (!dataset.contains(
+                ophthalmic_iod_tags::anatomic_region_sequence)) {
+            findings.push_back(
+                {validation_severity::warning,
+                 ophthalmic_iod_tags::anatomic_region_sequence,
+                 "AnatomicRegionSequence (0008,2218) missing - anatomic "
+                 "region unspecified",
+                 "OPHTH-WARN-001"});
+        }
+
+        // Acquisition Device Type Code Sequence — Type 2
+        if (!dataset.contains(
+                ophthalmic_iod_tags::acquisition_device_type_code_sequence)) {
+            findings.push_back(
+                {validation_severity::info,
+                 ophthalmic_iod_tags::acquisition_device_type_code_sequence,
+                 "AcquisitionDeviceTypeCodeSequence (0022,0015) not present "
+                 "- device type unavailable",
+                 "OPHTH-INFO-001"});
+        }
+
+        // Horizontal Field of View — Type 2C
+        if (!dataset.contains(
+                ophthalmic_iod_tags::horizontal_field_of_view)) {
+            findings.push_back(
+                {validation_severity::info,
+                 ophthalmic_iod_tags::horizontal_field_of_view,
+                 "HorizontalFieldOfView (0022,000C) not present - field of "
+                 "view unavailable",
+                 "OPHTH-INFO-002"});
+        }
+
+        // Pupil Dilated — Type 2C
+        if (!dataset.contains(ophthalmic_iod_tags::pupil_dilated)) {
+            findings.push_back(
+                {validation_severity::info,
+                 ophthalmic_iod_tags::pupil_dilated,
+                 "PupilDilated (0022,000D) not present - pupil dilation "
+                 "status unknown",
+                 "OPHTH-INFO-003"});
+        }
+    }
+}
+
+void ophthalmic_iod_validator::validate_image_pixel_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1 attributes
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::samples_per_pixel,
+                              "SamplesPerPixel", findings);
+        check_type1_attribute(dataset, tags::photometric_interpretation,
+                              "PhotometricInterpretation", findings);
+        check_type1_attribute(dataset, tags::rows, "Rows", findings);
+        check_type1_attribute(dataset, tags::columns, "Columns", findings);
+        check_type1_attribute(dataset, tags::bits_allocated, "BitsAllocated",
+                              findings);
+        check_type1_attribute(dataset, tags::bits_stored, "BitsStored",
+                              findings);
+        check_type1_attribute(dataset, tags::high_bit, "HighBit", findings);
+        check_type1_attribute(dataset, tags::pixel_representation,
+                              "PixelRepresentation", findings);
+    }
+
+    // Validate pixel data consistency
+    if (options_.validate_pixel_data) {
+        check_pixel_data_consistency(dataset, findings);
+    }
+}
+
+void ophthalmic_iod_validator::validate_multiframe_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Multi-frame Module is conditional — required for OCT images
+    if (!dataset.contains(tags::sop_class_uid)) return;
+
+    auto sop_class = dataset.get_string(tags::sop_class_uid);
+    bool is_oct =
+        (sop_class == sop_classes::ophthalmic_tomography_storage_uid ||
+         sop_class == sop_classes::ophthalmic_oct_bscan_analysis_storage_uid);
+
+    if (is_oct) {
+        // NumberOfFrames is Type 1 for OCT multi-frame
+        if (!dataset.contains(ophthalmic_iod_tags::number_of_frames)) {
+            findings.push_back(
+                {validation_severity::error,
+                 ophthalmic_iod_tags::number_of_frames,
+                 "NumberOfFrames (0028,0008) required for OCT multi-frame "
+                 "images",
+                 "OPHTH-ERR-001"});
+        }
+    }
+}
+
+void ophthalmic_iod_validator::validate_acquisition_context_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Acquisition Context Module is mandatory
+    if (!dataset.contains(ophthalmic_iod_tags::acquisition_context_sequence)) {
+        findings.push_back(
+            {validation_severity::info,
+             ophthalmic_iod_tags::acquisition_context_sequence,
+             "AcquisitionContextSequence (0040,0555) not present - "
+             "acquisition context unavailable",
+             "OPHTH-INFO-004"});
+    }
+}
+
+void ophthalmic_iod_validator::validate_sop_common_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::sop_class_uid, "SOPClassUID",
+                              findings);
+        check_type1_attribute(dataset, tags::sop_instance_uid,
+                              "SOPInstanceUID", findings);
+    }
+
+    // Validate SOP Class UID is an ophthalmic storage class
+    if (dataset.contains(tags::sop_class_uid)) {
+        auto sop_class = dataset.get_string(tags::sop_class_uid);
+        if (!sop_classes::is_ophthalmic_storage_sop_class(sop_class)) {
+            findings.push_back(
+                {validation_severity::error, tags::sop_class_uid,
+                 "SOPClassUID is not a recognized Ophthalmic Storage SOP "
+                 "Class: " + sop_class,
+                 "OPHTH-ERR-002"});
+        }
+    }
+}
+
+// =============================================================================
+// Attribute Validation Helpers
+// =============================================================================
+
+void ophthalmic_iod_validator::check_type1_attribute(
+    const dicom_dataset& dataset, dicom_tag tag, std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tag)) {
+        findings.push_back(
+            {validation_severity::error, tag,
+             std::string("Type 1 attribute missing: ") + std::string(name) +
+                 " (" + tag.to_string() + ")",
+             "OPHTH-TYPE1-MISSING"});
+    } else {
+        // Type 1 must have a value (cannot be empty)
+        auto value = dataset.get_string(tag);
+        if (value.empty()) {
+            findings.push_back(
+                {validation_severity::error, tag,
+                 std::string("Type 1 attribute has empty value: ") +
+                     std::string(name) + " (" + tag.to_string() + ")",
+                 "OPHTH-TYPE1-EMPTY"});
+        }
+    }
+}
+
+void ophthalmic_iod_validator::check_type2_attribute(
+    const dicom_dataset& dataset, dicom_tag tag, std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    // Type 2 must be present but can be empty
+    if (!dataset.contains(tag)) {
+        findings.push_back(
+            {validation_severity::warning, tag,
+             std::string("Type 2 attribute missing: ") + std::string(name) +
+                 " (" + tag.to_string() + ")",
+             "OPHTH-TYPE2-MISSING"});
+    }
+}
+
+void ophthalmic_iod_validator::check_modality(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tags::modality)) {
+        return;  // Already reported as Type 1 missing
+    }
+
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "OP" && modality != "OPT") {
+        findings.push_back(
+            {validation_severity::error, tags::modality,
+             "Modality must be 'OP' or 'OPT' for ophthalmic images, "
+             "found: " + modality,
+             "OPHTH-ERR-003"});
+    }
+}
+
+void ophthalmic_iod_validator::check_laterality(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(ophthalmic_iod_tags::image_laterality)) {
+        return;  // Already reported as Type 1 missing
+    }
+
+    auto laterality =
+        dataset.get_string(ophthalmic_iod_tags::image_laterality);
+    if (laterality != "R" && laterality != "L" && laterality != "B") {
+        findings.push_back(
+            {validation_severity::error,
+             ophthalmic_iod_tags::image_laterality,
+             "ImageLaterality must be 'R' (Right), 'L' (Left), or "
+             "'B' (Both), found: " + laterality,
+             "OPHTH-ERR-004"});
+    }
+}
+
+void ophthalmic_iod_validator::check_pixel_data_consistency(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Check BitsStored <= BitsAllocated
+    auto bits_allocated =
+        dataset.get_numeric<uint16_t>(tags::bits_allocated);
+    auto bits_stored = dataset.get_numeric<uint16_t>(tags::bits_stored);
+    auto high_bit = dataset.get_numeric<uint16_t>(tags::high_bit);
+
+    if (bits_allocated && bits_stored) {
+        if (*bits_stored > *bits_allocated) {
+            findings.push_back(
+                {validation_severity::error, tags::bits_stored,
+                 "BitsStored (" + std::to_string(*bits_stored) +
+                     ") exceeds BitsAllocated (" +
+                     std::to_string(*bits_allocated) + ")",
+                 "OPHTH-ERR-005"});
+        }
+    }
+
+    // Check HighBit == BitsStored - 1
+    if (bits_stored && high_bit) {
+        if (*high_bit != *bits_stored - 1) {
+            findings.push_back(
+                {validation_severity::warning, tags::high_bit,
+                 "HighBit (" + std::to_string(*high_bit) +
+                     ") should typically be BitsStored - 1 (" +
+                     std::to_string(*bits_stored - 1) + ")",
+                 "OPHTH-WARN-002"});
+        }
+    }
+
+    // Validate PhotometricInterpretation for ophthalmic
+    if (dataset.contains(tags::photometric_interpretation)) {
+        auto photometric =
+            dataset.get_string(tags::photometric_interpretation);
+        if (!sop_classes::is_valid_ophthalmic_photometric(photometric)) {
+            findings.push_back(
+                {validation_severity::error,
+                 tags::photometric_interpretation,
+                 "Ophthalmic images must use MONOCHROME1, MONOCHROME2, "
+                 "RGB, YBR_FULL_422, or PALETTE COLOR, found: " + photometric,
+                 "OPHTH-ERR-006"});
+        }
+    }
+
+    // Ophthalmic SamplesPerPixel must be 1 (grayscale) or 3 (color)
+    auto samples = dataset.get_numeric<uint16_t>(tags::samples_per_pixel);
+    if (samples && *samples != 1 && *samples != 3) {
+        findings.push_back(
+            {validation_severity::error, tags::samples_per_pixel,
+             "Ophthalmic images require SamplesPerPixel of 1 or 3, "
+             "found: " + std::to_string(*samples),
+             "OPHTH-ERR-007"});
+    }
+
+    // Ophthalmic images use unsigned pixel representation
+    auto pixel_rep =
+        dataset.get_numeric<uint16_t>(tags::pixel_representation);
+    if (pixel_rep && *pixel_rep != 0) {
+        findings.push_back(
+            {validation_severity::warning, tags::pixel_representation,
+             "Ophthalmic images typically use unsigned pixel representation "
+             "(PixelRepresentation = 0)",
+             "OPHTH-WARN-003"});
+    }
+}
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+validation_result validate_ophthalmic_iod(const dicom_dataset& dataset) {
+    ophthalmic_iod_validator validator;
+    return validator.validate(dataset);
+}
+
+bool is_valid_ophthalmic_dataset(const dicom_dataset& dataset) {
+    ophthalmic_iod_validator validator;
+    return validator.quick_check(dataset);
+}
+
+}  // namespace pacs::services::validation

--- a/tests/services/ophthalmic_iod_validator_test.cpp
+++ b/tests/services/ophthalmic_iod_validator_test.cpp
@@ -1,0 +1,902 @@
+/**
+ * @file ophthalmic_iod_validator_test.cpp
+ * @brief Unit tests for Ophthalmic Photography/Tomography Image IOD Validator
+ *
+ * @see DICOM PS3.3 Section A.39 - Ophthalmic Photography IODs
+ * @see DICOM PS3.3 Section A.40 - Ophthalmic Tomography Image IOD
+ * @see Issue #830 - Add Ophthalmic IOD validator
+ */
+
+#include <pacs/services/validation/ophthalmic_iod_validator.hpp>
+#include <pacs/services/sop_classes/ophthalmic_storage.hpp>
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_element.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services::validation;
+using namespace pacs::services::sop_classes;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+// ============================================================================
+// Test Fixtures - Helper Functions
+// ============================================================================
+
+namespace {
+
+/// Helper to create a minimal valid ophthalmic photography dataset
+dicom_dataset create_minimal_ophthalmic_dataset() {
+    dicom_dataset ds;
+
+    // Patient Module (Type 2)
+    ds.set_string(tags::patient_name, vr_type::PN, "Test^Patient");
+    ds.set_string(tags::patient_id, vr_type::LO, "OPHTH12345");
+    ds.set_string(tags::patient_birth_date, vr_type::DA, "19700101");
+    ds.set_string(tags::patient_sex, vr_type::CS, "F");
+
+    // General Study Module
+    ds.set_string(tags::study_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9");
+    ds.set_string(tags::study_date, vr_type::DA, "20240101");
+    ds.set_string(tags::study_time, vr_type::TM, "120000");
+    ds.set_string(tags::referring_physician_name, vr_type::PN,
+                  "Dr^Ophthalmologist");
+    ds.set_string(tags::study_id, vr_type::SH, "STUDY001");
+    ds.set_string(tags::accession_number, vr_type::SH, "ACC001");
+
+    // General Series Module — Modality = "OP"
+    ds.set_string(tags::modality, vr_type::CS, "OP");
+    ds.set_string(tags::series_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.1");
+    ds.set_string(tags::series_number, vr_type::IS, "1");
+
+    // Image Pixel Module — RGB for color fundus
+    ds.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 3);
+    ds.set_string(tags::photometric_interpretation, vr_type::CS, "RGB");
+    ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 2048);
+    ds.set_numeric<uint16_t>(tags::columns, vr_type::US, 2048);
+    ds.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 8);
+    ds.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 8);
+    ds.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 7);
+    ds.set_numeric<uint16_t>(tags::pixel_representation, vr_type::US, 0);
+
+    // Ophthalmic Image Module — Type 1 attributes
+    ds.set_string(tags::image_type, vr_type::CS,
+                  "ORIGINAL\\PRIMARY");
+    ds.set_string(ophthalmic_iod_tags::image_laterality, vr_type::CS, "R");
+
+    // Ophthalmic-specific optional attributes
+    ds.set_string(ophthalmic_iod_tags::anatomic_region_sequence,
+                  vr_type::SQ, "");
+    ds.set_string(ophthalmic_iod_tags::acquisition_device_type_code_sequence,
+                  vr_type::SQ, "");
+    ds.set_string(ophthalmic_iod_tags::horizontal_field_of_view,
+                  vr_type::DS, "45.0");
+    ds.set_string(ophthalmic_iod_tags::pupil_dilated, vr_type::CS, "YES");
+
+    // Acquisition Context Module
+    ds.set_string(ophthalmic_iod_tags::acquisition_context_sequence,
+                  vr_type::SQ, "");
+
+    // SOP Common Module
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  std::string(ophthalmic_photo_8bit_storage_uid));
+    ds.set_string(tags::sop_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.2");
+
+    return ds;
+}
+
+/// Helper to create a minimal valid OCT dataset
+dicom_dataset create_minimal_oct_dataset() {
+    auto ds = create_minimal_ophthalmic_dataset();
+
+    // Override for OCT
+    ds.set_string(tags::modality, vr_type::CS, "OPT");
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  std::string(ophthalmic_tomography_storage_uid));
+
+    // OCT uses MONOCHROME2 grayscale
+    ds.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 1);
+    ds.set_string(tags::photometric_interpretation, vr_type::CS,
+                  "MONOCHROME2");
+
+    // Multi-frame for OCT
+    ds.set_string(ophthalmic_iod_tags::number_of_frames, vr_type::IS, "128");
+
+    return ds;
+}
+
+}  // namespace
+
+// ============================================================================
+// Ophthalmic IOD Validator Basic Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator validates minimal valid dataset",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    auto result = validator.validate(dataset);
+
+    CHECK(result.is_valid);
+    CHECK_FALSE(result.has_errors());
+}
+
+TEST_CASE("ophthalmic_iod_validator validates minimal valid OCT dataset",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_oct_dataset();
+
+    auto result = validator.validate(dataset);
+
+    CHECK(result.is_valid);
+    CHECK_FALSE(result.has_errors());
+}
+
+// ============================================================================
+// Type 1 Attribute Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator detects missing Type 1 attributes",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    SECTION("missing StudyInstanceUID") {
+        dataset.remove(tags::study_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+        CHECK(result.has_errors());
+    }
+
+    SECTION("missing Modality") {
+        dataset.remove(tags::modality);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SeriesInstanceUID") {
+        dataset.remove(tags::series_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPClassUID") {
+        dataset.remove(tags::sop_class_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPInstanceUID") {
+        dataset.remove(tags::sop_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing Rows") {
+        dataset.remove(tags::rows);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing ImageType") {
+        dataset.remove(tags::image_type);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing ImageLaterality") {
+        dataset.remove(ophthalmic_iod_tags::image_laterality);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// Type 2 Attribute Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator detects missing Type 2 attributes",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    SECTION("missing PatientName generates warning") {
+        dataset.remove(tags::patient_name);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing StudyDate generates warning") {
+        dataset.remove(tags::study_date);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing SeriesNumber generates warning") {
+        dataset.remove(tags::series_number);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing AccessionNumber generates warning") {
+        dataset.remove(tags::accession_number);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+}
+
+// ============================================================================
+// Modality Validation Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator checks modality value",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    SECTION("OP modality is valid") {
+        dataset.set_string(tags::modality, vr_type::CS, "OP");
+        auto result = validator.validate(dataset);
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-003") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_modality_error);
+    }
+
+    SECTION("OPT modality is valid") {
+        dataset.set_string(tags::modality, vr_type::CS, "OPT");
+        auto result = validator.validate(dataset);
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-003") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_modality_error);
+    }
+
+    SECTION("wrong modality - CT") {
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-003") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK(found_modality_error);
+    }
+
+    SECTION("wrong modality - SM") {
+        dataset.set_string(tags::modality, vr_type::CS, "SM");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// Laterality Validation Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator checks image laterality",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    SECTION("R (Right) is valid") {
+        dataset.set_string(ophthalmic_iod_tags::image_laterality,
+                          vr_type::CS, "R");
+        auto result = validator.validate(dataset);
+        bool found_lat_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-004") {
+                found_lat_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_lat_error);
+    }
+
+    SECTION("L (Left) is valid") {
+        dataset.set_string(ophthalmic_iod_tags::image_laterality,
+                          vr_type::CS, "L");
+        auto result = validator.validate(dataset);
+        bool found_lat_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-004") {
+                found_lat_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_lat_error);
+    }
+
+    SECTION("B (Both) is valid") {
+        dataset.set_string(ophthalmic_iod_tags::image_laterality,
+                          vr_type::CS, "B");
+        auto result = validator.validate(dataset);
+        bool found_lat_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-004") {
+                found_lat_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_lat_error);
+    }
+
+    SECTION("invalid laterality value") {
+        dataset.set_string(ophthalmic_iod_tags::image_laterality,
+                          vr_type::CS, "X");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_lat_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-004") {
+                found_lat_error = true;
+                break;
+            }
+        }
+        CHECK(found_lat_error);
+    }
+
+    SECTION("missing laterality generates error") {
+        dataset.remove(ophthalmic_iod_tags::image_laterality);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// SOP Class UID Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator checks SOP Class UID",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    SECTION("8-bit Photography Storage is valid") {
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(ophthalmic_photo_8bit_storage_uid));
+        auto result = validator.validate(dataset);
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-002") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_sop_error);
+    }
+
+    SECTION("16-bit Photography Storage is valid") {
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(ophthalmic_photo_16bit_storage_uid));
+        auto result = validator.validate(dataset);
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-002") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_sop_error);
+    }
+
+    SECTION("OCT Storage is valid") {
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(ophthalmic_tomography_storage_uid));
+        auto result = validator.validate(dataset);
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-002") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_sop_error);
+    }
+
+    SECTION("non-ophthalmic SOP Class is invalid") {
+        // CT SOP Class
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          "1.2.840.10008.5.1.4.1.1.2");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-002") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK(found_sop_error);
+    }
+}
+
+// ============================================================================
+// Pixel Data Consistency Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator checks pixel data consistency",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    SECTION("BitsStored exceeds BitsAllocated") {
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 16);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-005") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK(found_bits_error);
+    }
+
+    SECTION("wrong HighBit generates warning") {
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 5);
+        auto result = validator.validate(dataset);
+        CHECK(result.has_warnings());
+
+        bool found_highbit_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-WARN-002") {
+                found_highbit_warning = true;
+                break;
+            }
+        }
+        CHECK(found_highbit_warning);
+    }
+
+    SECTION("invalid PhotometricInterpretation") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "YBR_ICT");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-006") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK(found_photometric_error);
+    }
+
+    SECTION("valid MONOCHROME2 with SamplesPerPixel=1") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "MONOCHROME2");
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 1);
+        auto result = validator.validate(dataset);
+        bool found_photometric_error = false;
+        bool found_samples_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-006") found_photometric_error = true;
+            if (f.code == "OPHTH-ERR-007") found_samples_error = true;
+        }
+        CHECK_FALSE(found_photometric_error);
+        CHECK_FALSE(found_samples_error);
+    }
+
+    SECTION("valid MONOCHROME1") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "MONOCHROME1");
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 1);
+        auto result = validator.validate(dataset);
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-006") found_photometric_error = true;
+        }
+        CHECK_FALSE(found_photometric_error);
+    }
+
+    SECTION("valid YBR_FULL_422 photometric") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "YBR_FULL_422");
+        auto result = validator.validate(dataset);
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-006") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_photometric_error);
+    }
+
+    SECTION("valid PALETTE COLOR photometric") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "PALETTE COLOR");
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 1);
+        auto result = validator.validate(dataset);
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-006") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_photometric_error);
+    }
+
+    SECTION("invalid SamplesPerPixel (not 1 or 3)") {
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 4);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_samples_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-007") {
+                found_samples_error = true;
+                break;
+            }
+        }
+        CHECK(found_samples_error);
+    }
+
+    SECTION("signed pixel representation generates warning") {
+        dataset.set_numeric<uint16_t>(tags::pixel_representation, vr_type::US,
+                                      1);
+        auto result = validator.validate(dataset);
+        CHECK(result.has_warnings());
+
+        bool found_repr_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-WARN-003") {
+                found_repr_warning = true;
+                break;
+            }
+        }
+        CHECK(found_repr_warning);
+    }
+}
+
+// ============================================================================
+// OCT Multi-frame Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator checks OCT multi-frame requirements",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+
+    SECTION("OCT without NumberOfFrames generates error") {
+        auto dataset = create_minimal_oct_dataset();
+        dataset.remove(ophthalmic_iod_tags::number_of_frames);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_frames_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-001") {
+                found_frames_error = true;
+                break;
+            }
+        }
+        CHECK(found_frames_error);
+    }
+
+    SECTION("OCT with NumberOfFrames is valid") {
+        auto dataset = create_minimal_oct_dataset();
+        auto result = validator.validate(dataset);
+
+        bool found_frames_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-001") {
+                found_frames_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_frames_error);
+    }
+
+    SECTION("B-scan analysis without NumberOfFrames generates error") {
+        auto dataset = create_minimal_oct_dataset();
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(ophthalmic_oct_bscan_analysis_storage_uid));
+        dataset.remove(ophthalmic_iod_tags::number_of_frames);
+        auto result = validator.validate(dataset);
+
+        bool found_frames_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-001") {
+                found_frames_error = true;
+                break;
+            }
+        }
+        CHECK(found_frames_error);
+    }
+
+    SECTION("photography does not require NumberOfFrames") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        // Photography (8-bit) should not require NumberOfFrames
+        auto result = validator.validate(dataset);
+        bool found_frames_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-001") {
+                found_frames_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_frames_error);
+    }
+}
+
+// ============================================================================
+// Ophthalmic-Specific Attribute Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator checks ophthalmic-specific attributes",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+    auto dataset = create_minimal_ophthalmic_dataset();
+
+    SECTION("missing AnatomicRegionSequence generates warning") {
+        dataset.remove(ophthalmic_iod_tags::anatomic_region_sequence);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-WARN-001") {
+                found_warning = true;
+                break;
+            }
+        }
+        CHECK(found_warning);
+    }
+
+    SECTION("missing AcquisitionDeviceTypeCodeSequence generates info") {
+        dataset.remove(
+            ophthalmic_iod_tags::acquisition_device_type_code_sequence);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-INFO-001") {
+                found_info = true;
+                break;
+            }
+        }
+        CHECK(found_info);
+    }
+
+    SECTION("missing HorizontalFieldOfView generates info") {
+        dataset.remove(ophthalmic_iod_tags::horizontal_field_of_view);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-INFO-002") {
+                found_info = true;
+                break;
+            }
+        }
+        CHECK(found_info);
+    }
+
+    SECTION("missing PupilDilated generates info") {
+        dataset.remove(ophthalmic_iod_tags::pupil_dilated);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-INFO-003") {
+                found_info = true;
+                break;
+            }
+        }
+        CHECK(found_info);
+    }
+
+    SECTION("missing AcquisitionContextSequence generates info") {
+        dataset.remove(ophthalmic_iod_tags::acquisition_context_sequence);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+
+        bool found_info = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-INFO-004") {
+                found_info = true;
+                break;
+            }
+        }
+        CHECK(found_info);
+    }
+}
+
+// ============================================================================
+// Quick Check Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator quick_check works correctly",
+          "[services][ophthalmic][validator]") {
+    ophthalmic_iod_validator validator;
+
+    SECTION("valid dataset passes quick check") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        CHECK(validator.quick_check(dataset));
+    }
+
+    SECTION("valid OCT dataset passes quick check") {
+        auto dataset = create_minimal_oct_dataset();
+        CHECK(validator.quick_check(dataset));
+    }
+
+    SECTION("invalid modality fails quick check") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing required attribute fails quick check") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.remove(tags::rows);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing ImageLaterality fails quick check") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.remove(ophthalmic_iod_tags::image_laterality);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing SOPClassUID fails quick check") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.remove(tags::sop_class_uid);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+}
+
+// ============================================================================
+// Custom Options Tests
+// ============================================================================
+
+TEST_CASE("ophthalmic_iod_validator with custom options",
+          "[services][ophthalmic][validator]") {
+
+    SECTION("strict mode treats warnings as errors") {
+        ophthalmic_validation_options options;
+        options.strict_mode = true;
+
+        ophthalmic_iod_validator validator(options);
+        auto dataset = create_minimal_ophthalmic_dataset();
+
+        // Remove a Type 2 attribute to get a warning
+        dataset.remove(tags::patient_name);
+
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("can disable ophthalmic parameter validation") {
+        ophthalmic_validation_options options;
+        options.validate_ophthalmic_params = false;
+
+        ophthalmic_iod_validator validator(options);
+        auto dataset = create_minimal_ophthalmic_dataset();
+
+        auto result = validator.validate(dataset);
+        CHECK(result.findings.size() >= 0);
+    }
+
+    SECTION("can disable pixel data validation") {
+        ophthalmic_validation_options options;
+        options.validate_pixel_data = false;
+
+        ophthalmic_iod_validator validator(options);
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 16);
+
+        auto result = validator.validate(dataset);
+        bool found_pixel_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "OPHTH-ERR-005") {
+                found_pixel_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_pixel_error);
+    }
+
+    SECTION("can disable laterality validation") {
+        ophthalmic_validation_options options;
+        options.validate_laterality = false;
+
+        ophthalmic_iod_validator validator(options);
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.remove(ophthalmic_iod_tags::image_laterality);
+
+        auto result = validator.validate(dataset);
+        bool found_lat_error = false;
+        for (const auto& f : result.findings) {
+            if (f.tag == ophthalmic_iod_tags::image_laterality &&
+                f.severity == validation_severity::error) {
+                found_lat_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_lat_error);
+    }
+
+    SECTION("options getter returns current options") {
+        ophthalmic_validation_options options;
+        options.strict_mode = true;
+        options.validate_ophthalmic_params = false;
+
+        ophthalmic_iod_validator validator(options);
+        CHECK(validator.options().strict_mode);
+        CHECK_FALSE(validator.options().validate_ophthalmic_params);
+    }
+
+    SECTION("set_options updates options") {
+        ophthalmic_iod_validator validator;
+        CHECK_FALSE(validator.options().strict_mode);
+
+        ophthalmic_validation_options new_options;
+        new_options.strict_mode = true;
+        validator.set_options(new_options);
+
+        CHECK(validator.options().strict_mode);
+    }
+}
+
+// ============================================================================
+// Convenience Function Tests
+// ============================================================================
+
+TEST_CASE("validate_ophthalmic_iod convenience function",
+          "[services][ophthalmic][validator]") {
+    auto dataset = create_minimal_ophthalmic_dataset();
+    auto result = validate_ophthalmic_iod(dataset);
+    CHECK(result.is_valid);
+}
+
+TEST_CASE("is_valid_ophthalmic_dataset convenience function",
+          "[services][ophthalmic][validator]") {
+    SECTION("valid dataset") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        CHECK(is_valid_ophthalmic_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - wrong modality") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(is_valid_ophthalmic_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - missing ImageLaterality") {
+        auto dataset = create_minimal_ophthalmic_dataset();
+        dataset.remove(ophthalmic_iod_tags::image_laterality);
+        CHECK_FALSE(is_valid_ophthalmic_dataset(dataset));
+    }
+}


### PR DESCRIPTION
Closes #830

## Summary
- Add `ophthalmic_iod_validator` class validating DICOM datasets against Ophthalmic Photography (PS3.3 A.39) and Optical Coherence Tomography (PS3.3 A.40) IOD specifications
- Validate mandatory modules: Patient, General Study, General Series (OP/OPT modality), Ophthalmic Photography Image, Image Pixel, SOP Common, Acquisition Context
- Validate conditional Multi-frame Module for OCT images (NumberOfFrames required)
- Validate Image Laterality (R/L/B) as Type 1 attribute
- Validate pixel data consistency (BitsStored/BitsAllocated, PhotometricInterpretation, SamplesPerPixel)
- Provide convenience functions `validate_ophthalmic_iod()` and `is_valid_ophthalmic_dataset()`
- 21 unit tests covering all error codes and validation paths

## Test Plan
- [x] All 21 ophthalmic IOD validator tests pass
- [x] All 170 regression tests pass (registry, WSI, US, CT, MR validators)
- [x] Build passes with `-Werror` and no warnings