### PR TITLE
feat(services): add Parametric Map Storage SOP Class registration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1069,6 +1069,7 @@ add_library(pacs_services
     src/services/sop_classes/mr_storage.cpp
     src/services/sop_classes/wsi_storage.cpp
     src/services/sop_classes/ophthalmic_storage.cpp
+    src/services/sop_classes/parametric_map_storage.cpp
     src/services/validation/us_iod_validator.cpp
     src/services/validation/dx_iod_validator.cpp
     src/services/validation/mg_iod_validator.cpp
@@ -1892,6 +1893,7 @@ if(PACS_BUILD_TESTS)
         tests/services/ct_storage_test.cpp
         tests/services/wsi_storage_test.cpp
         tests/services/ophthalmic_storage_test.cpp
+        tests/services/parametric_map_storage_test.cpp
         tests/services/ct_iod_validator_test.cpp
         tests/services/mr_iod_validator_test.cpp
         tests/services/wsi_iod_validator_test.cpp

--- a/include/pacs/services/sop_class_registry.hpp
+++ b/include/pacs/services/sop_class_registry.hpp
@@ -92,6 +92,7 @@ enum class modality_type {
     seg,        ///< Segmentation
     sm,         ///< Slide Microscopy (Whole Slide Imaging)
     op,         ///< Ophthalmic Photography / Tomography
+    pmap,       ///< Parametric Map
     other       ///< Other modalities
 };
 
@@ -239,6 +240,7 @@ private:
     void register_ups_sop_classes();
     void register_wsi_sop_classes();
     void register_ophthalmic_sop_classes();
+    void register_parametric_map_sop_classes();
     void register_other_sop_classes();
 
     std::unordered_map<std::string, sop_class_info> registry_;

--- a/include/pacs/services/sop_classes/parametric_map_storage.hpp
+++ b/include/pacs/services/sop_classes/parametric_map_storage.hpp
@@ -1,0 +1,201 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file parametric_map_storage.hpp
+ * @brief Parametric Map Storage SOP Class
+ *
+ * Provides SOP Class definition and utilities for Parametric Map storage.
+ * Parametric Maps encode voxel-level quantitative data (ADC maps, perfusion
+ * maps, T1/T2 relaxometry maps) using float or double pixel values.
+ *
+ * @see DICOM PS3.3 Section A.75 - Parametric Map IOD
+ * @see DICOM Supplement 172 - Parametric Map Storage
+ * @see Issue #833 - Add Parametric Map Storage SOP Class registration
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_SOP_CLASSES_PARAMETRIC_MAP_STORAGE_HPP
+#define PACS_SERVICES_SOP_CLASSES_PARAMETRIC_MAP_STORAGE_HPP
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::services::sop_classes {
+
+// =============================================================================
+// Parametric Map Storage SOP Class UIDs
+// =============================================================================
+
+/// Parametric Map Storage SOP Class UID
+inline constexpr std::string_view parametric_map_storage_uid =
+    "1.2.840.10008.5.1.4.1.1.30";
+
+// =============================================================================
+// Parametric Map Transfer Syntaxes
+// =============================================================================
+
+/**
+ * @brief Get recommended transfer syntaxes for Parametric Map objects
+ *
+ * Returns a prioritized list of transfer syntaxes suitable for parametric
+ * map storage. Float pixel data requires uncompressed or lossless transfer
+ * syntaxes to preserve quantitative accuracy.
+ *
+ * @return Vector of transfer syntax UIDs in priority order
+ */
+[[nodiscard]] std::vector<std::string> get_parametric_map_transfer_syntaxes();
+
+// =============================================================================
+// Pixel Value Representation
+// =============================================================================
+
+/**
+ * @brief Pixel value representation for parametric map data
+ *
+ * Defines how the pixel data is encoded in the Parametric Map.
+ * Per DICOM PS3.3 C.7.6.16.2.17, parametric maps use float or double.
+ */
+enum class pixel_value_representation {
+    float32,    ///< 32-bit IEEE 754 floating point (BitsAllocated=32)
+    float64     ///< 64-bit IEEE 754 floating point (BitsAllocated=64)
+};
+
+/**
+ * @brief Get bits allocated for a pixel value representation
+ * @param repr The pixel value representation
+ * @return BitsAllocated value (32 or 64)
+ */
+[[nodiscard]] uint16_t get_bits_allocated(pixel_value_representation repr) noexcept;
+
+/**
+ * @brief Parse pixel value representation from BitsAllocated value
+ * @param bits_allocated The BitsAllocated value
+ * @return The pixel value representation, defaults to float32 for unknown values
+ */
+[[nodiscard]] pixel_value_representation
+parse_pixel_value_representation(uint16_t bits_allocated) noexcept;
+
+/**
+ * @brief Check if a BitsAllocated value is valid for parametric maps
+ * @param bits_allocated The BitsAllocated value to check
+ * @return true if 32 or 64
+ */
+[[nodiscard]] bool is_valid_parametric_map_bits_allocated(uint16_t bits_allocated) noexcept;
+
+// =============================================================================
+// Parametric Map SOP Class Information
+// =============================================================================
+
+/**
+ * @brief Information about the Parametric Map Storage SOP Class
+ */
+struct parametric_map_sop_class_info {
+    std::string_view uid;           ///< SOP Class UID
+    std::string_view name;          ///< Human-readable name
+    std::string_view description;   ///< Brief description
+    bool is_retired;                ///< Whether this SOP class is retired
+};
+
+/**
+ * @brief Get all Parametric Map Storage SOP Class UIDs
+ * @return Vector of Parametric Map Storage SOP Class UIDs
+ */
+[[nodiscard]] std::vector<std::string> get_parametric_map_storage_sop_classes();
+
+/**
+ * @brief Get information about the Parametric Map SOP Class
+ * @param uid The SOP Class UID to look up
+ * @return Pointer to SOP class info, or nullptr if not a Parametric Map class
+ */
+[[nodiscard]] const parametric_map_sop_class_info*
+get_parametric_map_sop_class_info(std::string_view uid) noexcept;
+
+/**
+ * @brief Check if a SOP Class UID is Parametric Map Storage
+ * @param uid The SOP Class UID to check
+ * @return true if this is the Parametric Map Storage SOP class
+ */
+[[nodiscard]] bool is_parametric_map_storage_sop_class(std::string_view uid) noexcept;
+
+// =============================================================================
+// Parametric Map DICOM Tags
+// =============================================================================
+
+namespace parametric_map_tags {
+
+/// Real World Value Mapping Sequence (0040,9096)
+inline constexpr uint32_t real_world_value_mapping_sequence = 0x00409096;
+
+/// Real World Value Intercept (0040,9224)
+inline constexpr uint32_t real_world_value_intercept = 0x00409224;
+
+/// Real World Value Slope (0040,9225)
+inline constexpr uint32_t real_world_value_slope = 0x00409225;
+
+/// Real World Value First Value Mapped (0040,9216)
+inline constexpr uint32_t real_world_value_first_value_mapped = 0x00409216;
+
+/// Real World Value Last Value Mapped (0040,9211)
+inline constexpr uint32_t real_world_value_last_value_mapped = 0x00409211;
+
+/// Measurement Units Code Sequence (0040,08EA)
+inline constexpr uint32_t measurement_units_code_sequence = 0x004008EA;
+
+/// Content Label (0070,0080)
+inline constexpr uint32_t content_label = 0x00700080;
+
+/// Content Description (0070,0081)
+inline constexpr uint32_t content_description = 0x00700081;
+
+/// Content Creator Name (0070,0084)
+inline constexpr uint32_t content_creator_name = 0x00700084;
+
+}  // namespace parametric_map_tags
+
+// =============================================================================
+// Photometric Interpretation Validation
+// =============================================================================
+
+/**
+ * @brief Check if photometric interpretation is valid for parametric maps
+ *
+ * Parametric Maps use MONOCHROME2 for single-component float/double data.
+ *
+ * @param value The photometric interpretation string
+ * @return true if valid for parametric maps
+ */
+[[nodiscard]] bool is_valid_parametric_map_photometric(std::string_view value) noexcept;
+
+}  // namespace pacs::services::sop_classes
+
+#endif  // PACS_SERVICES_SOP_CLASSES_PARAMETRIC_MAP_STORAGE_HPP

--- a/src/services/sop_class_registry.cpp
+++ b/src/services/sop_class_registry.cpp
@@ -44,6 +44,7 @@
 #include "pacs/services/sop_classes/wsi_storage.hpp"
 #include "pacs/services/sop_classes/xa_storage.hpp"
 #include "pacs/services/sop_classes/ophthalmic_storage.hpp"
+#include "pacs/services/sop_classes/parametric_map_storage.hpp"
 
 #include <algorithm>
 
@@ -153,6 +154,7 @@ std::string_view sop_class_registry::modality_to_string(modality_type modality) 
         case modality_type::seg: return "SEG";
         case modality_type::sm: return "SM";
         case modality_type::op: return "OP";
+        case modality_type::pmap: return "RWV";
         case modality_type::other: return "OT";
     }
     return "OT";
@@ -179,6 +181,7 @@ modality_type sop_class_registry::parse_modality(std::string_view modality) noex
     if (modality == "SEG") return modality_type::seg;
     if (modality == "SM") return modality_type::sm;
     if (modality == "OP" || modality == "OPT") return modality_type::op;
+    if (modality == "RWV" || modality == "PMAP") return modality_type::pmap;
     return modality_type::other;
 }
 
@@ -201,6 +204,7 @@ void sop_class_registry::register_standard_sop_classes() {
     register_ups_sop_classes();
     register_wsi_sop_classes();
     register_ophthalmic_sop_classes();
+    register_parametric_map_sop_classes();
     register_other_sop_classes();
 }
 
@@ -1047,6 +1051,21 @@ void sop_class_registry::register_ophthalmic_sop_classes() {
             modality_type::op,
             false,
             true  // B-scan volume analysis is multi-frame
+        }
+    );
+}
+
+void sop_class_registry::register_parametric_map_sop_classes() {
+    // Parametric Map Storage
+    registry_.emplace(
+        std::string(sop_classes::parametric_map_storage_uid),
+        sop_class_info{
+            sop_classes::parametric_map_storage_uid,
+            "Parametric Map Storage",
+            sop_class_category::storage,
+            modality_type::pmap,
+            false,
+            true  // always multi-frame
         }
     );
 }

--- a/src/services/sop_classes/parametric_map_storage.cpp
+++ b/src/services/sop_classes/parametric_map_storage.cpp
@@ -1,0 +1,131 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file parametric_map_storage.cpp
+ * @brief Implementation of Parametric Map Storage SOP Class utilities
+ *
+ * @see Issue #833 - Add Parametric Map Storage SOP Class registration
+ */
+
+#include "pacs/services/sop_classes/parametric_map_storage.hpp"
+
+#include <array>
+
+namespace pacs::services::sop_classes {
+
+// =============================================================================
+// Transfer Syntaxes
+// =============================================================================
+
+std::vector<std::string> get_parametric_map_transfer_syntaxes() {
+    return {
+        // Explicit VR Little Endian (preferred for interoperability)
+        "1.2.840.10008.1.2.1",
+        // Implicit VR Little Endian (universal baseline)
+        "1.2.840.10008.1.2",
+        // JPEG 2000 Lossless (preserves float data integrity)
+        "1.2.840.10008.1.2.4.90",
+        // HTJ2K Lossless (high-throughput lossless)
+        "1.2.840.10008.1.2.4.201",
+        // RLE Lossless
+        "1.2.840.10008.1.2.5"
+    };
+}
+
+// =============================================================================
+// Pixel Value Representation
+// =============================================================================
+
+uint16_t get_bits_allocated(pixel_value_representation repr) noexcept {
+    switch (repr) {
+        case pixel_value_representation::float32:
+            return 32;
+        case pixel_value_representation::float64:
+            return 64;
+    }
+    return 32;
+}
+
+pixel_value_representation
+parse_pixel_value_representation(uint16_t bits_allocated) noexcept {
+    if (bits_allocated == 64) {
+        return pixel_value_representation::float64;
+    }
+    return pixel_value_representation::float32;
+}
+
+bool is_valid_parametric_map_bits_allocated(uint16_t bits_allocated) noexcept {
+    return bits_allocated == 32 || bits_allocated == 64;
+}
+
+// =============================================================================
+// SOP Class Information
+// =============================================================================
+
+namespace {
+
+constexpr std::array<parametric_map_sop_class_info, 1> pmap_sop_classes = {{
+    {
+        parametric_map_storage_uid,
+        "Parametric Map Storage",
+        "Voxel-level quantitative parameter maps (ADC, perfusion, T1/T2)",
+        false
+    }
+}};
+
+}  // namespace
+
+std::vector<std::string> get_parametric_map_storage_sop_classes() {
+    return {
+        std::string(parametric_map_storage_uid)
+    };
+}
+
+const parametric_map_sop_class_info*
+get_parametric_map_sop_class_info(std::string_view uid) noexcept {
+    if (uid == parametric_map_storage_uid) {
+        return &pmap_sop_classes[0];
+    }
+    return nullptr;
+}
+
+bool is_parametric_map_storage_sop_class(std::string_view uid) noexcept {
+    return uid == parametric_map_storage_uid;
+}
+
+// =============================================================================
+// Photometric Interpretation Validation
+// =============================================================================
+
+bool is_valid_parametric_map_photometric(std::string_view value) noexcept {
+    return value == "MONOCHROME2";
+}
+
+}  // namespace pacs::services::sop_classes

--- a/tests/services/parametric_map_storage_test.cpp
+++ b/tests/services/parametric_map_storage_test.cpp
@@ -1,0 +1,261 @@
+/**
+ * @file parametric_map_storage_test.cpp
+ * @brief Unit tests for Parametric Map Storage SOP Class
+ *
+ * @see Issue #833 - Add Parametric Map Storage SOP Class registration
+ */
+
+#include <pacs/services/sop_classes/parametric_map_storage.hpp>
+#include <pacs/services/sop_class_registry.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+
+using namespace pacs::services;
+using namespace pacs::services::sop_classes;
+
+// ============================================================================
+// SOP Class UID Tests
+// ============================================================================
+
+TEST_CASE("parametric map SOP Class UID is correct",
+          "[services][parametric_map][storage]") {
+    CHECK(parametric_map_storage_uid == "1.2.840.10008.5.1.4.1.1.30");
+}
+
+// ============================================================================
+// is_parametric_map_storage_sop_class Tests
+// ============================================================================
+
+TEST_CASE("is_parametric_map_storage_sop_class identifies parametric map SOP Class",
+          "[services][parametric_map][storage]") {
+    SECTION("Parametric Map Storage") {
+        CHECK(is_parametric_map_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.30"));
+    }
+
+    SECTION("non-parametric-map SOP Class - CT") {
+        CHECK_FALSE(is_parametric_map_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.2"));
+    }
+
+    SECTION("non-parametric-map SOP Class - SEG") {
+        CHECK_FALSE(is_parametric_map_storage_sop_class(
+            "1.2.840.10008.5.1.4.1.1.66.4"));
+    }
+
+    SECTION("empty string") {
+        CHECK_FALSE(is_parametric_map_storage_sop_class(""));
+    }
+
+    SECTION("invalid UID") {
+        CHECK_FALSE(is_parametric_map_storage_sop_class("invalid"));
+    }
+}
+
+// ============================================================================
+// get_parametric_map_storage_sop_classes Tests
+// ============================================================================
+
+TEST_CASE("get_parametric_map_storage_sop_classes returns all UIDs",
+          "[services][parametric_map][storage]") {
+    auto uids = get_parametric_map_storage_sop_classes();
+    CHECK(uids.size() == 1);
+    CHECK(uids[0] == "1.2.840.10008.5.1.4.1.1.30");
+}
+
+// ============================================================================
+// SOP Class Information Tests
+// ============================================================================
+
+TEST_CASE("get_parametric_map_sop_class_info returns correct information",
+          "[services][parametric_map][storage]") {
+    SECTION("Parametric Map Storage info") {
+        const auto* info = get_parametric_map_sop_class_info(
+            parametric_map_storage_uid);
+        REQUIRE(info != nullptr);
+        CHECK(info->uid == parametric_map_storage_uid);
+        CHECK(info->name == "Parametric Map Storage");
+        CHECK_FALSE(info->is_retired);
+    }
+
+    SECTION("returns nullptr for unknown UID") {
+        CHECK(get_parametric_map_sop_class_info("1.2.3.4.5.6.7") == nullptr);
+    }
+
+    SECTION("returns nullptr for empty string") {
+        CHECK(get_parametric_map_sop_class_info("") == nullptr);
+    }
+}
+
+// ============================================================================
+// Transfer Syntax Tests
+// ============================================================================
+
+TEST_CASE("get_parametric_map_transfer_syntaxes returns valid syntaxes",
+          "[services][parametric_map][transfer]") {
+    auto syntaxes = get_parametric_map_transfer_syntaxes();
+
+    CHECK(syntaxes.size() > 0);
+
+    // Should include Explicit VR Little Endian (most preferred)
+    CHECK(std::find(syntaxes.begin(), syntaxes.end(),
+                   "1.2.840.10008.1.2.1") != syntaxes.end());
+
+    // Should include Implicit VR Little Endian (universal baseline)
+    CHECK(std::find(syntaxes.begin(), syntaxes.end(),
+                   "1.2.840.10008.1.2") != syntaxes.end());
+}
+
+// ============================================================================
+// Pixel Value Representation Tests
+// ============================================================================
+
+TEST_CASE("pixel_value_representation conversions",
+          "[services][parametric_map][pixel_repr]") {
+    SECTION("get_bits_allocated returns correct values") {
+        CHECK(get_bits_allocated(pixel_value_representation::float32) == 32);
+        CHECK(get_bits_allocated(pixel_value_representation::float64) == 64);
+    }
+
+    SECTION("parse_pixel_value_representation parses correctly") {
+        CHECK(parse_pixel_value_representation(32)
+              == pixel_value_representation::float32);
+        CHECK(parse_pixel_value_representation(64)
+              == pixel_value_representation::float64);
+        CHECK(parse_pixel_value_representation(16)
+              == pixel_value_representation::float32);  // Default
+    }
+}
+
+TEST_CASE("is_valid_parametric_map_bits_allocated validates correctly",
+          "[services][parametric_map][pixel_repr]") {
+    CHECK(is_valid_parametric_map_bits_allocated(32));
+    CHECK(is_valid_parametric_map_bits_allocated(64));
+
+    CHECK_FALSE(is_valid_parametric_map_bits_allocated(8));
+    CHECK_FALSE(is_valid_parametric_map_bits_allocated(16));
+    CHECK_FALSE(is_valid_parametric_map_bits_allocated(0));
+    CHECK_FALSE(is_valid_parametric_map_bits_allocated(128));
+}
+
+// ============================================================================
+// Photometric Interpretation Tests
+// ============================================================================
+
+TEST_CASE("is_valid_parametric_map_photometric checks supported color models",
+          "[services][parametric_map][storage]") {
+    SECTION("MONOCHROME2 is valid") {
+        CHECK(is_valid_parametric_map_photometric("MONOCHROME2"));
+    }
+
+    SECTION("MONOCHROME1 is invalid for parametric maps") {
+        CHECK_FALSE(is_valid_parametric_map_photometric("MONOCHROME1"));
+    }
+
+    SECTION("RGB is invalid for parametric maps") {
+        CHECK_FALSE(is_valid_parametric_map_photometric("RGB"));
+    }
+
+    SECTION("empty string is invalid") {
+        CHECK_FALSE(is_valid_parametric_map_photometric(""));
+    }
+}
+
+// ============================================================================
+// DICOM Tag Constant Tests
+// ============================================================================
+
+TEST_CASE("parametric map DICOM tag constants are correct",
+          "[services][parametric_map][storage]") {
+    CHECK(parametric_map_tags::real_world_value_mapping_sequence == 0x00409096);
+    CHECK(parametric_map_tags::real_world_value_intercept == 0x00409224);
+    CHECK(parametric_map_tags::real_world_value_slope == 0x00409225);
+    CHECK(parametric_map_tags::real_world_value_first_value_mapped == 0x00409216);
+    CHECK(parametric_map_tags::real_world_value_last_value_mapped == 0x00409211);
+    CHECK(parametric_map_tags::measurement_units_code_sequence == 0x004008EA);
+    CHECK(parametric_map_tags::content_label == 0x00700080);
+    CHECK(parametric_map_tags::content_description == 0x00700081);
+    CHECK(parametric_map_tags::content_creator_name == 0x00700084);
+}
+
+// ============================================================================
+// SOP Class Registry Integration Tests
+// ============================================================================
+
+TEST_CASE("parametric map SOP Class is registered in sop_class_registry",
+          "[services][parametric_map][storage][registry]") {
+    auto& registry = sop_class_registry::instance();
+
+    SECTION("Parametric Map Storage is supported") {
+        CHECK(registry.is_supported(parametric_map_storage_uid));
+    }
+
+    SECTION("Parametric Map Storage info is correct") {
+        const auto* info = registry.get_info(parametric_map_storage_uid);
+        REQUIRE(info != nullptr);
+        CHECK(info->uid == parametric_map_storage_uid);
+        CHECK(info->name == "Parametric Map Storage");
+        CHECK(info->category == sop_class_category::storage);
+        CHECK(info->modality == modality_type::pmap);
+        CHECK(info->is_retired == false);
+        CHECK(info->supports_multiframe == true);
+    }
+
+    SECTION("parametric map appears in storage class list") {
+        auto storage_classes = registry.get_all_storage_classes();
+        auto it = std::find(storage_classes.begin(), storage_classes.end(),
+                            std::string(parametric_map_storage_uid));
+        CHECK(it != storage_classes.end());
+    }
+
+    SECTION("parametric map appears in PMAP modality query") {
+        auto pmap_classes = registry.get_by_modality(modality_type::pmap);
+        CHECK(pmap_classes.size() >= 1);
+        auto it = std::find(pmap_classes.begin(), pmap_classes.end(),
+                            std::string(parametric_map_storage_uid));
+        CHECK(it != pmap_classes.end());
+    }
+}
+
+// ============================================================================
+// Modality Conversion Tests
+// ============================================================================
+
+TEST_CASE("PMAP modality string conversion",
+          "[services][parametric_map][storage][registry]") {
+    SECTION("modality_to_string returns RWV") {
+        CHECK(sop_class_registry::modality_to_string(modality_type::pmap)
+              == "RWV");
+    }
+
+    SECTION("parse_modality recognizes RWV") {
+        CHECK(sop_class_registry::parse_modality("RWV") == modality_type::pmap);
+    }
+
+    SECTION("parse_modality recognizes PMAP") {
+        CHECK(sop_class_registry::parse_modality("PMAP") == modality_type::pmap);
+    }
+}
+
+// ============================================================================
+// Convenience Function Tests
+// ============================================================================
+
+TEST_CASE("convenience functions work for parametric map",
+          "[services][parametric_map][storage][registry]") {
+    SECTION("is_storage_sop_class") {
+        CHECK(is_storage_sop_class(parametric_map_storage_uid));
+    }
+
+    SECTION("get_storage_modality") {
+        CHECK(get_storage_modality(parametric_map_storage_uid)
+              == modality_type::pmap);
+    }
+
+    SECTION("get_sop_class_name") {
+        CHECK(get_sop_class_name(parametric_map_storage_uid)
+              == "Parametric Map Storage");
+    }
+}


### PR DESCRIPTION
Closes #833
Part of #794

## Summary
- Add Parametric Map Storage SOP Class definition (`1.2.840.10008.5.1.4.1.1.30`)
- Add `modality_type::pmap` to the central SOP Class registry with RWV/PMAP string mapping
- Add `pixel_value_representation` enum for 32-bit float and 64-bit double pixel data
- Add recommended transfer syntaxes prioritizing uncompressed/lossless for quantitative accuracy
- Add DICOM tag constants for Real World Value Mapping Sequence and related attributes
- Add `parametric_map_sop_class_info` struct and utility functions (`is_parametric_map_storage_sop_class`, `get_parametric_map_storage_sop_classes`, etc.)

## Files Changed
| File | Change |
|------|--------|
| `include/pacs/services/sop_classes/parametric_map_storage.hpp` | New: SOP Class definition |
| `src/services/sop_classes/parametric_map_storage.cpp` | New: Implementation |
| `tests/services/parametric_map_storage_test.cpp` | New: 10 unit tests |
| `include/pacs/services/sop_class_registry.hpp` | Modified: Add `modality_type::pmap` |
| `src/services/sop_class_registry.cpp` | Modified: Add registration and modality mapping |
| `CMakeLists.txt` | Modified: Add source and test files |

## Test Plan
- [x] All 10 parametric map unit tests pass (SOP Class UID, identification, info lookup, transfer syntaxes, pixel value representation, photometric validation, tag constants, registry integration, modality conversion, convenience functions)
- [x] All 2138 existing unit tests pass (no regressions)
- [x] Build succeeds with 48/48 targets