### PR TITLE
feat(validation): add Parametric Map IOD validator

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1082,6 +1082,7 @@ add_library(pacs_services
     src/services/validation/mr_iod_validator.cpp
     src/services/validation/wsi_iod_validator.cpp
     src/services/validation/ophthalmic_iod_validator.cpp
+    src/services/validation/parametric_map_iod_validator.cpp
     src/services/cache/query_cache.cpp
     src/services/cache/database_cursor.cpp
     src/services/cache/query_result_stream.cpp
@@ -1898,6 +1899,7 @@ if(PACS_BUILD_TESTS)
         tests/services/mr_iod_validator_test.cpp
         tests/services/wsi_iod_validator_test.cpp
         tests/services/ophthalmic_iod_validator_test.cpp
+        tests/services/parametric_map_iod_validator_test.cpp
         tests/services/cache/simple_lru_cache_test.cpp
         tests/services/cache/query_cache_test.cpp
         tests/services/cache/streaming_query_test.cpp

--- a/include/pacs/services/validation/parametric_map_iod_validator.hpp
+++ b/include/pacs/services/validation/parametric_map_iod_validator.hpp
@@ -1,0 +1,327 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file parametric_map_iod_validator.hpp
+ * @brief Parametric Map IOD Validator
+ *
+ * Provides validation for Parametric Map Information Object Definitions
+ * as specified in DICOM PS3.3 Section A.75 (Parametric Map IOD).
+ *
+ * Parametric Maps encode voxel-level quantitative data (ADC maps, perfusion
+ * maps, T1/T2 relaxometry maps) using IEEE 754 float or double pixel values.
+ * They are always multi-frame and require Real World Value Mapping sequences.
+ *
+ * @see DICOM PS3.3 Section A.75 - Parametric Map IOD
+ * @see DICOM PS3.3 Section C.7.6.16.2.17 - Real World Value Mapping
+ * @see Issue #834 - Add Parametric Map IOD validator
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SERVICES_VALIDATION_PARAMETRIC_MAP_IOD_VALIDATOR_HPP
+#define PACS_SERVICES_VALIDATION_PARAMETRIC_MAP_IOD_VALIDATOR_HPP
+
+#include "pacs/core/dicom_dataset.hpp"
+#include "pacs/core/dicom_tag.hpp"
+#include "pacs/services/validation/us_iod_validator.hpp"  // Reuse validation types
+
+#include <string>
+#include <vector>
+
+namespace pacs::services::validation {
+
+// =============================================================================
+// Parametric Map-Specific DICOM Tags for Validation
+// =============================================================================
+
+namespace pmap_iod_tags {
+
+/// Real World Value Mapping Sequence (0040,9096)
+inline constexpr core::dicom_tag real_world_value_mapping_sequence{0x0040, 0x9096};
+
+/// Real World Value Intercept (0040,9224)
+inline constexpr core::dicom_tag real_world_value_intercept{0x0040, 0x9224};
+
+/// Real World Value Slope (0040,9225)
+inline constexpr core::dicom_tag real_world_value_slope{0x0040, 0x9225};
+
+/// Measurement Units Code Sequence (0040,08EA)
+inline constexpr core::dicom_tag measurement_units_code_sequence{0x0040, 0x08EA};
+
+/// Content Label (0070,0080) — Type 1
+inline constexpr core::dicom_tag content_label{0x0070, 0x0080};
+
+/// Content Description (0070,0081) — Type 2
+inline constexpr core::dicom_tag content_description{0x0070, 0x0081};
+
+/// Content Creator's Name (0070,0084) — Type 2
+inline constexpr core::dicom_tag content_creator_name{0x0070, 0x0084};
+
+/// Number of Frames (0028,0008)
+inline constexpr core::dicom_tag number_of_frames{0x0028, 0x0008};
+
+/// Shared Functional Groups Sequence (5200,9229)
+inline constexpr core::dicom_tag shared_functional_groups_sequence{0x5200, 0x9229};
+
+/// Per-Frame Functional Groups Sequence (5200,9230)
+inline constexpr core::dicom_tag per_frame_functional_groups_sequence{0x5200, 0x9230};
+
+/// Dimension Organization Sequence (0020,9221)
+inline constexpr core::dicom_tag dimension_organization_sequence{0x0020, 0x9221};
+
+/// Dimension Index Sequence (0020,9222)
+inline constexpr core::dicom_tag dimension_index_sequence{0x0020, 0x9222};
+
+/// Referenced Series Sequence (0008,1115)
+inline constexpr core::dicom_tag referenced_series_sequence{0x0008, 0x1115};
+
+/// Manufacturer (0008,0070)
+inline constexpr core::dicom_tag manufacturer{0x0008, 0x0070};
+
+/// Manufacturer's Model Name (0008,1090)
+inline constexpr core::dicom_tag manufacturer_model_name{0x0008, 0x1090};
+
+/// Device Serial Number (0018,1000)
+inline constexpr core::dicom_tag device_serial_number{0x0018, 0x1000};
+
+/// Software Versions (0018,1020)
+inline constexpr core::dicom_tag software_versions{0x0018, 0x1020};
+
+/// Float Pixel Data (7FE0,0008)
+inline constexpr core::dicom_tag float_pixel_data{0x7FE0, 0x0008};
+
+/// Double Float Pixel Data (7FE0,0009)
+inline constexpr core::dicom_tag double_float_pixel_data{0x7FE0, 0x0009};
+
+}  // namespace pmap_iod_tags
+
+// =============================================================================
+// Parametric Map Validation Options
+// =============================================================================
+
+/**
+ * @brief Options for Parametric Map IOD validation
+ */
+struct pmap_validation_options {
+    /// Check Type 1 (required) attributes
+    bool check_type1 = true;
+
+    /// Check Type 2 (required, can be empty) attributes
+    bool check_type2 = true;
+
+    /// Check Type 1C/2C (conditionally required) attributes
+    bool check_conditional = true;
+
+    /// Validate pixel data consistency (bits, photometric, float constraints)
+    bool validate_pixel_data = true;
+
+    /// Validate Real World Value Mapping Sequence
+    bool validate_rwvm = true;
+
+    /// Validate multi-frame structure
+    bool validate_multiframe = true;
+
+    /// Validate referenced series/instances
+    bool validate_references = true;
+
+    /// Strict mode - treat warnings as errors
+    bool strict_mode = false;
+};
+
+// =============================================================================
+// Parametric Map IOD Validator
+// =============================================================================
+
+/**
+ * @brief Validator for Parametric Map IODs
+ *
+ * Validates DICOM datasets against the Parametric Map IOD specification.
+ * Checks required modules, attributes, float pixel data constraints,
+ * Real World Value Mapping, and multi-frame requirements.
+ *
+ * ## Validated Modules
+ *
+ * ### Mandatory Modules
+ * - Patient Module (M)
+ * - General Study Module (M)
+ * - General Series Module (M)
+ * - General Equipment Module (M)
+ * - Enhanced General Equipment Module (M)
+ * - Image Pixel Module (M)
+ * - Parametric Map Image Module (M)
+ * - Multi-frame Functional Groups Module (M)
+ * - Multi-frame Dimension Module (M)
+ * - Common Instance Reference Module (M)
+ * - SOP Common Module (M)
+ *
+ * @example
+ * @code
+ * parametric_map_iod_validator validator;
+ * auto result = validator.validate(dataset);
+ *
+ * if (!result.is_valid) {
+ *     for (const auto& finding : result.findings) {
+ *         std::cerr << finding.code << ": " << finding.message << "\n";
+ *     }
+ * }
+ * @endcode
+ */
+class parametric_map_iod_validator {
+public:
+    /**
+     * @brief Construct validator with default options
+     */
+    parametric_map_iod_validator() = default;
+
+    /**
+     * @brief Construct validator with custom options
+     * @param options Validation options
+     */
+    explicit parametric_map_iod_validator(const pmap_validation_options& options);
+
+    /**
+     * @brief Validate a DICOM dataset against Parametric Map IOD
+     * @param dataset The dataset to validate
+     * @return Validation result with all findings
+     */
+    [[nodiscard]] validation_result validate(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Quick check if dataset has minimum required parametric map attributes
+     * @param dataset The dataset to check
+     * @return true if all Type 1 attributes are present
+     */
+    [[nodiscard]] bool quick_check(
+        const core::dicom_dataset& dataset) const;
+
+    /**
+     * @brief Get the validation options
+     */
+    [[nodiscard]] const pmap_validation_options& options() const noexcept;
+
+    /**
+     * @brief Set validation options
+     */
+    void set_options(const pmap_validation_options& options);
+
+private:
+    // Module validation methods
+    void validate_patient_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_study_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_series_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_general_equipment_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_enhanced_general_equipment_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_image_pixel_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_parametric_map_image_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_multiframe_functional_groups_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_multiframe_dimension_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_common_instance_reference_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void validate_sop_common_module(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    // Attribute validation helpers
+    void check_type1_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_type2_attribute(
+        const core::dicom_dataset& dataset,
+        core::dicom_tag tag,
+        std::string_view name,
+        std::vector<validation_finding>& findings) const;
+
+    void check_modality(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    void check_pixel_data_consistency(
+        const core::dicom_dataset& dataset,
+        std::vector<validation_finding>& findings) const;
+
+    pmap_validation_options options_;
+};
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+/**
+ * @brief Validate a Parametric Map dataset with default options
+ * @param dataset The dataset to validate
+ * @return Validation result
+ */
+[[nodiscard]] validation_result validate_parametric_map_iod(
+    const core::dicom_dataset& dataset);
+
+/**
+ * @brief Quick check if a dataset is a valid Parametric Map object
+ * @param dataset The dataset to check
+ * @return true if the dataset passes basic Parametric Map IOD validation
+ */
+[[nodiscard]] bool is_valid_parametric_map_dataset(
+    const core::dicom_dataset& dataset);
+
+}  // namespace pacs::services::validation
+
+#endif  // PACS_SERVICES_VALIDATION_PARAMETRIC_MAP_IOD_VALIDATOR_HPP

--- a/src/services/validation/parametric_map_iod_validator.cpp
+++ b/src/services/validation/parametric_map_iod_validator.cpp
@@ -1,0 +1,572 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file parametric_map_iod_validator.cpp
+ * @brief Implementation of Parametric Map IOD Validator
+ *
+ * @see Issue #834 - Add Parametric Map IOD validator
+ */
+
+#include "pacs/services/validation/parametric_map_iod_validator.hpp"
+#include "pacs/core/dicom_tag_constants.hpp"
+#include "pacs/services/sop_classes/parametric_map_storage.hpp"
+
+namespace pacs::services::validation {
+
+using namespace pacs::core;
+
+// =============================================================================
+// parametric_map_iod_validator Implementation
+// =============================================================================
+
+parametric_map_iod_validator::parametric_map_iod_validator(
+    const pmap_validation_options& options)
+    : options_(options) {}
+
+validation_result
+parametric_map_iod_validator::validate(const dicom_dataset& dataset) const {
+    validation_result result;
+    result.is_valid = true;
+
+    // Validate mandatory modules
+    if (options_.check_type1 || options_.check_type2) {
+        validate_patient_module(dataset, result.findings);
+        validate_general_study_module(dataset, result.findings);
+        validate_general_series_module(dataset, result.findings);
+        validate_general_equipment_module(dataset, result.findings);
+        validate_enhanced_general_equipment_module(dataset, result.findings);
+        validate_sop_common_module(dataset, result.findings);
+    }
+
+    // Parametric Map Image Module (Content Label, RWVM)
+    validate_parametric_map_image_module(dataset, result.findings);
+
+    if (options_.validate_pixel_data) {
+        validate_image_pixel_module(dataset, result.findings);
+    }
+
+    if (options_.validate_multiframe) {
+        validate_multiframe_functional_groups_module(dataset, result.findings);
+        validate_multiframe_dimension_module(dataset, result.findings);
+    }
+
+    if (options_.validate_references) {
+        validate_common_instance_reference_module(dataset, result.findings);
+    }
+
+    // Check for errors
+    for (const auto& finding : result.findings) {
+        if (finding.severity == validation_severity::error) {
+            result.is_valid = false;
+            break;
+        }
+        if (options_.strict_mode
+            && finding.severity == validation_severity::warning) {
+            result.is_valid = false;
+            break;
+        }
+    }
+
+    return result;
+}
+
+bool parametric_map_iod_validator::quick_check(
+    const dicom_dataset& dataset) const {
+
+    // General Study Module
+    if (!dataset.contains(tags::study_instance_uid)) return false;
+
+    // General Series Module
+    if (!dataset.contains(tags::modality)) return false;
+    if (!dataset.contains(tags::series_instance_uid)) return false;
+
+    // Check modality
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "RWV" && modality != "PMAP") return false;
+
+    // Parametric Map Image Module
+    if (!dataset.contains(pmap_iod_tags::content_label)) return false;
+    if (!dataset.contains(pmap_iod_tags::real_world_value_mapping_sequence))
+        return false;
+
+    // Multi-frame
+    if (!dataset.contains(pmap_iod_tags::number_of_frames)) return false;
+
+    // Image Pixel Module
+    if (!dataset.contains(tags::rows)) return false;
+    if (!dataset.contains(tags::columns)) return false;
+
+    // SOP Common Module
+    if (!dataset.contains(tags::sop_class_uid)) return false;
+    if (!dataset.contains(tags::sop_instance_uid)) return false;
+
+    // Verify SOP Class is Parametric Map
+    auto sop_class = dataset.get_string(tags::sop_class_uid);
+    if (!sop_classes::is_parametric_map_storage_sop_class(sop_class))
+        return false;
+
+    return true;
+}
+
+const pmap_validation_options&
+parametric_map_iod_validator::options() const noexcept {
+    return options_;
+}
+
+void parametric_map_iod_validator::set_options(
+    const pmap_validation_options& options) {
+    options_ = options;
+}
+
+// =============================================================================
+// Module Validation Methods
+// =============================================================================
+
+void parametric_map_iod_validator::validate_patient_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::patient_name,
+                             "PatientName", findings);
+        check_type2_attribute(dataset, tags::patient_id,
+                             "PatientID", findings);
+        check_type2_attribute(dataset, tags::patient_birth_date,
+                             "PatientBirthDate", findings);
+        check_type2_attribute(dataset, tags::patient_sex,
+                             "PatientSex", findings);
+    }
+}
+
+void parametric_map_iod_validator::validate_general_study_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::study_instance_uid,
+                             "StudyInstanceUID", findings);
+    }
+
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::study_date,
+                             "StudyDate", findings);
+        check_type2_attribute(dataset, tags::study_time,
+                             "StudyTime", findings);
+        check_type2_attribute(dataset, tags::referring_physician_name,
+                             "ReferringPhysicianName", findings);
+        check_type2_attribute(dataset, tags::study_id,
+                             "StudyID", findings);
+        check_type2_attribute(dataset, tags::accession_number,
+                             "AccessionNumber", findings);
+    }
+}
+
+void parametric_map_iod_validator::validate_general_series_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::modality,
+                             "Modality", findings);
+        check_type1_attribute(dataset, tags::series_instance_uid,
+                             "SeriesInstanceUID", findings);
+        check_modality(dataset, findings);
+    }
+
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, tags::series_number,
+                             "SeriesNumber", findings);
+    }
+}
+
+void parametric_map_iod_validator::validate_general_equipment_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, pmap_iod_tags::manufacturer,
+                             "Manufacturer", findings);
+    }
+}
+
+void parametric_map_iod_validator::validate_enhanced_general_equipment_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, pmap_iod_tags::manufacturer,
+                             "Manufacturer", findings);
+        check_type1_attribute(dataset, pmap_iod_tags::manufacturer_model_name,
+                             "ManufacturerModelName", findings);
+        check_type1_attribute(dataset, pmap_iod_tags::device_serial_number,
+                             "DeviceSerialNumber", findings);
+        check_type1_attribute(dataset, pmap_iod_tags::software_versions,
+                             "SoftwareVersions", findings);
+    }
+}
+
+void parametric_map_iod_validator::validate_image_pixel_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::samples_per_pixel,
+                             "SamplesPerPixel", findings);
+        check_type1_attribute(dataset, tags::photometric_interpretation,
+                             "PhotometricInterpretation", findings);
+        check_type1_attribute(dataset, tags::rows, "Rows", findings);
+        check_type1_attribute(dataset, tags::columns, "Columns", findings);
+        check_type1_attribute(dataset, tags::bits_allocated,
+                             "BitsAllocated", findings);
+        check_type1_attribute(dataset, tags::bits_stored,
+                             "BitsStored", findings);
+        check_type1_attribute(dataset, tags::high_bit,
+                             "HighBit", findings);
+        check_type1_attribute(dataset, tags::pixel_representation,
+                             "PixelRepresentation", findings);
+    }
+
+    // Parametric Map-specific pixel data constraints
+    check_pixel_data_consistency(dataset, findings);
+}
+
+void parametric_map_iod_validator::validate_parametric_map_image_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // Content Label is Type 1
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, pmap_iod_tags::content_label,
+                             "ContentLabel", findings);
+    }
+
+    // Content Description is Type 2
+    if (options_.check_type2) {
+        check_type2_attribute(dataset, pmap_iod_tags::content_description,
+                             "ContentDescription", findings);
+        check_type2_attribute(dataset, pmap_iod_tags::content_creator_name,
+                             "ContentCreatorName", findings);
+    }
+
+    // Real World Value Mapping Sequence is Type 1
+    if (options_.validate_rwvm) {
+        if (!dataset.contains(pmap_iod_tags::real_world_value_mapping_sequence)) {
+            findings.push_back({
+                validation_severity::error,
+                pmap_iod_tags::real_world_value_mapping_sequence,
+                "RealWorldValueMappingSequence (0040,9096) is required for "
+                "Parametric Map objects",
+                "PMAP-ERR-004"
+            });
+        }
+    }
+}
+
+void parametric_map_iod_validator::validate_multiframe_functional_groups_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // NumberOfFrames is Type 1 (Parametric Maps are always multi-frame)
+    if (!dataset.contains(pmap_iod_tags::number_of_frames)) {
+        findings.push_back({
+            validation_severity::error,
+            pmap_iod_tags::number_of_frames,
+            "NumberOfFrames (0028,0008) is required for Parametric Map objects "
+            "(always multi-frame)",
+            "PMAP-ERR-001"
+        });
+    }
+
+    if (options_.check_type1) {
+        if (!dataset.contains(
+                pmap_iod_tags::shared_functional_groups_sequence)) {
+            findings.push_back({
+                validation_severity::warning,
+                pmap_iod_tags::shared_functional_groups_sequence,
+                "SharedFunctionalGroupsSequence (5200,9229) should be present "
+                "for multi-frame Parametric Map objects",
+                "PMAP-WARN-001"
+            });
+        }
+
+        if (!dataset.contains(
+                pmap_iod_tags::per_frame_functional_groups_sequence)) {
+            findings.push_back({
+                validation_severity::warning,
+                pmap_iod_tags::per_frame_functional_groups_sequence,
+                "PerFrameFunctionalGroupsSequence (5200,9230) should be present "
+                "for multi-frame Parametric Map objects",
+                "PMAP-WARN-004"
+            });
+        }
+    }
+}
+
+void parametric_map_iod_validator::validate_multiframe_dimension_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type1) {
+        if (!dataset.contains(
+                pmap_iod_tags::dimension_organization_sequence)) {
+            findings.push_back({
+                validation_severity::error,
+                pmap_iod_tags::dimension_organization_sequence,
+                "Type 1 attribute missing: DimensionOrganizationSequence "
+                "(0020,9221)",
+                "PMAP-TYPE1-MISSING"
+            });
+        }
+        if (!dataset.contains(pmap_iod_tags::dimension_index_sequence)) {
+            findings.push_back({
+                validation_severity::error,
+                pmap_iod_tags::dimension_index_sequence,
+                "Type 1 attribute missing: DimensionIndexSequence "
+                "(0020,9222)",
+                "PMAP-TYPE1-MISSING"
+            });
+        }
+    }
+}
+
+void parametric_map_iod_validator::validate_common_instance_reference_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_conditional) {
+        if (!dataset.contains(pmap_iod_tags::referenced_series_sequence)) {
+            findings.push_back({
+                validation_severity::warning,
+                pmap_iod_tags::referenced_series_sequence,
+                "ReferencedSeriesSequence (0008,1115) should be present for "
+                "source image references",
+                "PMAP-WARN-003"
+            });
+        }
+    }
+}
+
+void parametric_map_iod_validator::validate_sop_common_module(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (options_.check_type1) {
+        check_type1_attribute(dataset, tags::sop_class_uid,
+                             "SOPClassUID", findings);
+        check_type1_attribute(dataset, tags::sop_instance_uid,
+                             "SOPInstanceUID", findings);
+    }
+
+    // Validate SOP Class UID is a Parametric Map storage class
+    if (dataset.contains(tags::sop_class_uid)) {
+        auto sop_class = dataset.get_string(tags::sop_class_uid);
+        if (!sop_classes::is_parametric_map_storage_sop_class(sop_class)) {
+            findings.push_back({
+                validation_severity::error,
+                tags::sop_class_uid,
+                "SOPClassUID is not a recognized Parametric Map Storage SOP "
+                "Class: " + sop_class,
+                "PMAP-ERR-002"
+            });
+        }
+    }
+}
+
+// =============================================================================
+// Attribute Validation Helpers
+// =============================================================================
+
+void parametric_map_iod_validator::check_type1_attribute(
+    const dicom_dataset& dataset,
+    dicom_tag tag,
+    std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tag)) {
+        findings.push_back({
+            validation_severity::error,
+            tag,
+            std::string("Type 1 attribute missing: ") + std::string(name) +
+            " (" + tag.to_string() + ")",
+            "PMAP-TYPE1-MISSING"
+        });
+    } else {
+        const auto* element = dataset.get(tag);
+        if (element != nullptr) {
+            if (element->is_sequence()) {
+                if (element->sequence_items().empty()) {
+                    findings.push_back({
+                        validation_severity::error,
+                        tag,
+                        std::string("Type 1 sequence has no items: ") +
+                        std::string(name) + " (" + tag.to_string() + ")",
+                        "PMAP-TYPE1-EMPTY"
+                    });
+                }
+            } else {
+                auto value = dataset.get_string(tag);
+                if (value.empty()) {
+                    findings.push_back({
+                        validation_severity::error,
+                        tag,
+                        std::string("Type 1 attribute has empty value: ") +
+                        std::string(name) + " (" + tag.to_string() + ")",
+                        "PMAP-TYPE1-EMPTY"
+                    });
+                }
+            }
+        }
+    }
+}
+
+void parametric_map_iod_validator::check_type2_attribute(
+    const dicom_dataset& dataset,
+    dicom_tag tag,
+    std::string_view name,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tag)) {
+        findings.push_back({
+            validation_severity::warning,
+            tag,
+            std::string("Type 2 attribute missing: ") + std::string(name) +
+            " (" + tag.to_string() + ")",
+            "PMAP-TYPE2-MISSING"
+        });
+    }
+}
+
+void parametric_map_iod_validator::check_modality(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    if (!dataset.contains(tags::modality)) {
+        return;  // Already reported
+    }
+
+    auto modality = dataset.get_string(tags::modality);
+    if (modality != "RWV" && modality != "PMAP") {
+        findings.push_back({
+            validation_severity::error,
+            tags::modality,
+            "Modality must be 'RWV' or 'PMAP' for Parametric Map objects, "
+            "found: " + modality,
+            "PMAP-ERR-003"
+        });
+    }
+}
+
+void parametric_map_iod_validator::check_pixel_data_consistency(
+    const dicom_dataset& dataset,
+    std::vector<validation_finding>& findings) const {
+
+    // SamplesPerPixel must be 1
+    auto samples = dataset.get_numeric<uint16_t>(tags::samples_per_pixel);
+    if (samples && *samples != 1) {
+        findings.push_back({
+            validation_severity::error,
+            tags::samples_per_pixel,
+            "SamplesPerPixel must be 1 for Parametric Map objects",
+            "PMAP-ERR-007"
+        });
+    }
+
+    // PhotometricInterpretation must be MONOCHROME2
+    if (dataset.contains(tags::photometric_interpretation)) {
+        auto photometric = dataset.get_string(
+            tags::photometric_interpretation);
+        if (!sop_classes::is_valid_parametric_map_photometric(photometric)) {
+            findings.push_back({
+                validation_severity::error,
+                tags::photometric_interpretation,
+                "PhotometricInterpretation must be MONOCHROME2 for Parametric "
+                "Map objects, found: " + photometric,
+                "PMAP-ERR-006"
+            });
+        }
+    }
+
+    // BitsAllocated must be 32 or 64 (float or double)
+    auto bits_allocated = dataset.get_numeric<uint16_t>(tags::bits_allocated);
+    if (bits_allocated
+        && !sop_classes::is_valid_parametric_map_bits_allocated(
+               *bits_allocated)) {
+        findings.push_back({
+            validation_severity::error,
+            tags::bits_allocated,
+            "BitsAllocated must be 32 or 64 for Parametric Map objects "
+            "(float or double), found: " +
+            std::to_string(*bits_allocated),
+            "PMAP-ERR-008"
+        });
+    }
+
+    // BitsStored must not exceed BitsAllocated
+    auto bits_stored = dataset.get_numeric<uint16_t>(tags::bits_stored);
+    if (bits_allocated && bits_stored && *bits_stored > *bits_allocated) {
+        findings.push_back({
+            validation_severity::error,
+            tags::bits_stored,
+            "BitsStored (" + std::to_string(*bits_stored) +
+            ") exceeds BitsAllocated (" +
+            std::to_string(*bits_allocated) + ")",
+            "PMAP-ERR-005"
+        });
+    }
+
+    // HighBit should be BitsStored - 1
+    auto high_bit = dataset.get_numeric<uint16_t>(tags::high_bit);
+    if (bits_stored && high_bit && *high_bit != (*bits_stored - 1)) {
+        findings.push_back({
+            validation_severity::warning,
+            tags::high_bit,
+            "HighBit (" + std::to_string(*high_bit) +
+            ") does not match BitsStored-1 (" +
+            std::to_string(*bits_stored - 1) + ")",
+            "PMAP-WARN-002"
+        });
+    }
+}
+
+// =============================================================================
+// Convenience Functions
+// =============================================================================
+
+validation_result validate_parametric_map_iod(const dicom_dataset& dataset) {
+    parametric_map_iod_validator validator;
+    return validator.validate(dataset);
+}
+
+bool is_valid_parametric_map_dataset(const dicom_dataset& dataset) {
+    parametric_map_iod_validator validator;
+    return validator.quick_check(dataset);
+}
+
+}  // namespace pacs::services::validation

--- a/tests/services/parametric_map_iod_validator_test.cpp
+++ b/tests/services/parametric_map_iod_validator_test.cpp
@@ -1,0 +1,855 @@
+/**
+ * @file parametric_map_iod_validator_test.cpp
+ * @brief Unit tests for Parametric Map IOD Validator
+ *
+ * @see DICOM PS3.3 Section A.75 - Parametric Map IOD
+ * @see Issue #834 - Add Parametric Map IOD validator
+ */
+
+#include <pacs/services/validation/parametric_map_iod_validator.hpp>
+#include <pacs/services/sop_classes/parametric_map_storage.hpp>
+#include <pacs/core/dicom_dataset.hpp>
+#include <pacs/core/dicom_element.hpp>
+#include <pacs/core/dicom_tag_constants.hpp>
+#include <pacs/encoding/vr_type.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+using namespace pacs::services::validation;
+using namespace pacs::services::sop_classes;
+using namespace pacs::core;
+using namespace pacs::encoding;
+
+// ============================================================================
+// Test Fixtures - Helper Functions
+// ============================================================================
+
+namespace {
+
+/// Helper to create a minimal valid parametric map dataset (float32 ADC map)
+dicom_dataset create_minimal_parametric_map_dataset() {
+    dicom_dataset ds;
+
+    // Patient Module (Type 2)
+    ds.set_string(tags::patient_name, vr_type::PN, "Test^Patient");
+    ds.set_string(tags::patient_id, vr_type::LO, "PMAP12345");
+    ds.set_string(tags::patient_birth_date, vr_type::DA, "19700101");
+    ds.set_string(tags::patient_sex, vr_type::CS, "M");
+
+    // General Study Module
+    ds.set_string(tags::study_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9");
+    ds.set_string(tags::study_date, vr_type::DA, "20240601");
+    ds.set_string(tags::study_time, vr_type::TM, "093000");
+    ds.set_string(tags::referring_physician_name, vr_type::PN,
+                  "Dr^Radiologist");
+    ds.set_string(tags::study_id, vr_type::SH, "STUDY001");
+    ds.set_string(tags::accession_number, vr_type::SH, "ACC001");
+
+    // General Series Module — Modality = "RWV"
+    ds.set_string(tags::modality, vr_type::CS, "RWV");
+    ds.set_string(tags::series_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.1");
+    ds.set_string(tags::series_number, vr_type::IS, "100");
+
+    // Enhanced General Equipment Module
+    ds.set_string(pmap_iod_tags::manufacturer, vr_type::LO, "TestVendor");
+    ds.set_string(pmap_iod_tags::manufacturer_model_name, vr_type::LO,
+                  "PMAP-Generator");
+    ds.set_string(pmap_iod_tags::device_serial_number, vr_type::LO,
+                  "SN12345");
+    ds.set_string(pmap_iod_tags::software_versions, vr_type::LO, "1.0.0");
+
+    // Image Pixel Module — float32 MONOCHROME2
+    ds.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 1);
+    ds.set_string(tags::photometric_interpretation, vr_type::CS,
+                  "MONOCHROME2");
+    ds.set_numeric<uint16_t>(tags::rows, vr_type::US, 256);
+    ds.set_numeric<uint16_t>(tags::columns, vr_type::US, 256);
+    ds.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 32);
+    ds.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 32);
+    ds.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 31);
+    ds.set_numeric<uint16_t>(tags::pixel_representation, vr_type::US, 0);
+
+    // Multi-frame (always required for Parametric Map)
+    ds.set_string(pmap_iod_tags::number_of_frames, vr_type::IS, "10");
+    ds.set_string(pmap_iod_tags::shared_functional_groups_sequence,
+                  vr_type::SQ, "");
+    ds.set_string(pmap_iod_tags::per_frame_functional_groups_sequence,
+                  vr_type::SQ, "");
+    ds.set_string(pmap_iod_tags::dimension_organization_sequence,
+                  vr_type::SQ, "");
+    ds.set_string(pmap_iod_tags::dimension_index_sequence,
+                  vr_type::SQ, "");
+
+    // Parametric Map Image Module
+    ds.set_string(pmap_iod_tags::content_label, vr_type::CS, "ADC_MAP");
+    ds.set_string(pmap_iod_tags::content_description, vr_type::LO,
+                  "Apparent Diffusion Coefficient Map");
+    ds.set_string(pmap_iod_tags::content_creator_name, vr_type::PN,
+                  "AutoProcessor");
+    ds.set_string(pmap_iod_tags::real_world_value_mapping_sequence,
+                  vr_type::SQ, "");
+
+    // SOP Common Module
+    ds.set_string(tags::sop_class_uid, vr_type::UI,
+                  std::string(parametric_map_storage_uid));
+    ds.set_string(tags::sop_instance_uid, vr_type::UI,
+                  "1.2.3.4.5.6.7.8.9.2");
+
+    return ds;
+}
+
+/// Helper to create a float64 parametric map dataset
+dicom_dataset create_float64_parametric_map_dataset() {
+    auto ds = create_minimal_parametric_map_dataset();
+
+    // Override for float64
+    ds.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 64);
+    ds.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 64);
+    ds.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 63);
+
+    return ds;
+}
+
+}  // namespace
+
+// ============================================================================
+// Parametric Map IOD Validator Basic Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator validates minimal valid dataset",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    auto result = validator.validate(dataset);
+
+    CHECK(result.is_valid);
+    CHECK_FALSE(result.has_errors());
+}
+
+TEST_CASE("parametric_map_iod_validator validates float64 dataset",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_float64_parametric_map_dataset();
+
+    auto result = validator.validate(dataset);
+
+    CHECK(result.is_valid);
+    CHECK_FALSE(result.has_errors());
+}
+
+// ============================================================================
+// Type 1 Attribute Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator detects missing Type 1 attributes",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    SECTION("missing StudyInstanceUID") {
+        dataset.remove(tags::study_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+        CHECK(result.has_errors());
+    }
+
+    SECTION("missing Modality") {
+        dataset.remove(tags::modality);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SeriesInstanceUID") {
+        dataset.remove(tags::series_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPClassUID") {
+        dataset.remove(tags::sop_class_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing SOPInstanceUID") {
+        dataset.remove(tags::sop_instance_uid);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing Rows") {
+        dataset.remove(tags::rows);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing ContentLabel") {
+        dataset.remove(pmap_iod_tags::content_label);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("missing Manufacturer") {
+        dataset.remove(pmap_iod_tags::manufacturer);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// Type 2 Attribute Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator detects missing Type 2 attributes",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    SECTION("missing PatientName generates warning") {
+        dataset.remove(tags::patient_name);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing StudyDate generates warning") {
+        dataset.remove(tags::study_date);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing SeriesNumber generates warning") {
+        dataset.remove(tags::series_number);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing ContentDescription generates warning") {
+        dataset.remove(pmap_iod_tags::content_description);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+
+    SECTION("missing ContentCreatorName generates warning") {
+        dataset.remove(pmap_iod_tags::content_creator_name);
+        auto result = validator.validate(dataset);
+        CHECK(result.is_valid);
+        CHECK(result.has_warnings());
+    }
+}
+
+// ============================================================================
+// Modality Validation Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator checks modality value",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    SECTION("RWV modality is valid") {
+        dataset.set_string(tags::modality, vr_type::CS, "RWV");
+        auto result = validator.validate(dataset);
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-003") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_modality_error);
+    }
+
+    SECTION("PMAP modality is valid") {
+        dataset.set_string(tags::modality, vr_type::CS, "PMAP");
+        auto result = validator.validate(dataset);
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-003") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_modality_error);
+    }
+
+    SECTION("wrong modality - CT") {
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_modality_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-003") {
+                found_modality_error = true;
+                break;
+            }
+        }
+        CHECK(found_modality_error);
+    }
+
+    SECTION("wrong modality - SEG") {
+        dataset.set_string(tags::modality, vr_type::CS, "SEG");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+}
+
+// ============================================================================
+// SOP Class UID Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator checks SOP Class UID",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    SECTION("Parametric Map Storage SOP Class is valid") {
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          std::string(parametric_map_storage_uid));
+        auto result = validator.validate(dataset);
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-002") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_sop_error);
+    }
+
+    SECTION("non-parametric-map SOP Class is invalid") {
+        // CT SOP Class
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          "1.2.840.10008.5.1.4.1.1.2");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_sop_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-002") {
+                found_sop_error = true;
+                break;
+            }
+        }
+        CHECK(found_sop_error);
+    }
+}
+
+// ============================================================================
+// Pixel Data Consistency Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator checks pixel data consistency",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    SECTION("BitsStored exceeds BitsAllocated") {
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 64);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-005") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK(found_bits_error);
+    }
+
+    SECTION("wrong HighBit generates warning") {
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 15);
+        auto result = validator.validate(dataset);
+        CHECK(result.has_warnings());
+
+        bool found_highbit_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-WARN-002") {
+                found_highbit_warning = true;
+                break;
+            }
+        }
+        CHECK(found_highbit_warning);
+    }
+
+    SECTION("invalid PhotometricInterpretation - RGB") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "RGB");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-006") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK(found_photometric_error);
+    }
+
+    SECTION("invalid PhotometricInterpretation - MONOCHROME1") {
+        dataset.set_string(tags::photometric_interpretation, vr_type::CS,
+                          "MONOCHROME1");
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_photometric_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-006") {
+                found_photometric_error = true;
+                break;
+            }
+        }
+        CHECK(found_photometric_error);
+    }
+
+    SECTION("invalid SamplesPerPixel (not 1)") {
+        dataset.set_numeric<uint16_t>(tags::samples_per_pixel, vr_type::US, 3);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_samples_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-007") {
+                found_samples_error = true;
+                break;
+            }
+        }
+        CHECK(found_samples_error);
+    }
+
+    SECTION("invalid BitsAllocated - 8") {
+        dataset.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 8);
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 8);
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 7);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-008") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK(found_bits_error);
+    }
+
+    SECTION("invalid BitsAllocated - 16") {
+        dataset.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 16);
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 16);
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 15);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-008") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK(found_bits_error);
+    }
+
+    SECTION("valid BitsAllocated - 32") {
+        dataset.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 32);
+        auto result = validator.validate(dataset);
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-008") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_bits_error);
+    }
+
+    SECTION("valid BitsAllocated - 64") {
+        dataset.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 64);
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 64);
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 63);
+        auto result = validator.validate(dataset);
+        bool found_bits_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-008") {
+                found_bits_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_bits_error);
+    }
+}
+
+// ============================================================================
+// Multi-frame Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator checks multi-frame requirements",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+
+    SECTION("missing NumberOfFrames generates error") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::number_of_frames);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_frames_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-001") {
+                found_frames_error = true;
+                break;
+            }
+        }
+        CHECK(found_frames_error);
+    }
+
+    SECTION("present NumberOfFrames is valid") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        auto result = validator.validate(dataset);
+        bool found_frames_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-001") {
+                found_frames_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_frames_error);
+    }
+
+    SECTION("missing SharedFunctionalGroupsSequence generates warning") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::shared_functional_groups_sequence);
+        auto result = validator.validate(dataset);
+
+        bool found_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-WARN-001") {
+                found_warning = true;
+                break;
+            }
+        }
+        CHECK(found_warning);
+    }
+
+    SECTION("missing PerFrameFunctionalGroupsSequence generates warning") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::per_frame_functional_groups_sequence);
+        auto result = validator.validate(dataset);
+
+        bool found_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-WARN-004") {
+                found_warning = true;
+                break;
+            }
+        }
+        CHECK(found_warning);
+    }
+}
+
+// ============================================================================
+// Real World Value Mapping Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator checks RWVM sequence",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    SECTION("missing RWVM sequence generates error") {
+        dataset.remove(pmap_iod_tags::real_world_value_mapping_sequence);
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+
+        bool found_rwvm_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-004") {
+                found_rwvm_error = true;
+                break;
+            }
+        }
+        CHECK(found_rwvm_error);
+    }
+
+    SECTION("present RWVM sequence is valid") {
+        auto result = validator.validate(dataset);
+        bool found_rwvm_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-004") {
+                found_rwvm_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_rwvm_error);
+    }
+}
+
+// ============================================================================
+// Referenced Series Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator checks referenced series",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+    auto dataset = create_minimal_parametric_map_dataset();
+
+    SECTION("missing ReferencedSeriesSequence generates warning") {
+        auto result = validator.validate(dataset);
+
+        bool found_ref_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-WARN-003") {
+                found_ref_warning = true;
+                break;
+            }
+        }
+        CHECK(found_ref_warning);
+    }
+
+    SECTION("present ReferencedSeriesSequence suppresses warning") {
+        dataset.set_string(pmap_iod_tags::referenced_series_sequence,
+                          vr_type::SQ, "");
+        auto result = validator.validate(dataset);
+
+        bool found_ref_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-WARN-003") {
+                found_ref_warning = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_ref_warning);
+    }
+}
+
+// ============================================================================
+// Quick Check Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator quick_check works correctly",
+          "[services][parametric_map][validator]") {
+    parametric_map_iod_validator validator;
+
+    SECTION("valid dataset passes quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        CHECK(validator.quick_check(dataset));
+    }
+
+    SECTION("valid float64 dataset passes quick check") {
+        auto dataset = create_float64_parametric_map_dataset();
+        CHECK(validator.quick_check(dataset));
+    }
+
+    SECTION("invalid modality fails quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing required attribute fails quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(tags::rows);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing ContentLabel fails quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::content_label);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing RWVM sequence fails quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::real_world_value_mapping_sequence);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing NumberOfFrames fails quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::number_of_frames);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("missing SOPClassUID fails quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(tags::sop_class_uid);
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("non-parametric-map SOP Class fails quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.set_string(tags::sop_class_uid, vr_type::UI,
+                          "1.2.840.10008.5.1.4.1.1.2");
+        CHECK_FALSE(validator.quick_check(dataset));
+    }
+
+    SECTION("PMAP modality also passes quick check") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "PMAP");
+        CHECK(validator.quick_check(dataset));
+    }
+}
+
+// ============================================================================
+// Custom Options Tests
+// ============================================================================
+
+TEST_CASE("parametric_map_iod_validator with custom options",
+          "[services][parametric_map][validator]") {
+
+    SECTION("strict mode treats warnings as errors") {
+        pmap_validation_options options;
+        options.strict_mode = true;
+
+        parametric_map_iod_validator validator(options);
+        auto dataset = create_minimal_parametric_map_dataset();
+
+        // Remove a Type 2 attribute to get a warning
+        dataset.remove(tags::patient_name);
+
+        auto result = validator.validate(dataset);
+        CHECK_FALSE(result.is_valid);
+    }
+
+    SECTION("can disable pixel data validation") {
+        pmap_validation_options options;
+        options.validate_pixel_data = false;
+
+        parametric_map_iod_validator validator(options);
+        auto dataset = create_minimal_parametric_map_dataset();
+        // Set invalid BitsAllocated — should be ignored
+        dataset.set_numeric<uint16_t>(tags::bits_allocated, vr_type::US, 8);
+        dataset.set_numeric<uint16_t>(tags::bits_stored, vr_type::US, 8);
+        dataset.set_numeric<uint16_t>(tags::high_bit, vr_type::US, 7);
+
+        auto result = validator.validate(dataset);
+        bool found_pixel_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-008") {
+                found_pixel_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_pixel_error);
+    }
+
+    SECTION("can disable RWVM validation") {
+        pmap_validation_options options;
+        options.validate_rwvm = false;
+
+        parametric_map_iod_validator validator(options);
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::real_world_value_mapping_sequence);
+
+        auto result = validator.validate(dataset);
+        bool found_rwvm_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-004") {
+                found_rwvm_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_rwvm_error);
+    }
+
+    SECTION("can disable multi-frame validation") {
+        pmap_validation_options options;
+        options.validate_multiframe = false;
+
+        parametric_map_iod_validator validator(options);
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::number_of_frames);
+
+        auto result = validator.validate(dataset);
+        bool found_frames_error = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-ERR-001") {
+                found_frames_error = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_frames_error);
+    }
+
+    SECTION("can disable reference validation") {
+        pmap_validation_options options;
+        options.validate_references = false;
+
+        parametric_map_iod_validator validator(options);
+        auto dataset = create_minimal_parametric_map_dataset();
+
+        auto result = validator.validate(dataset);
+        bool found_ref_warning = false;
+        for (const auto& f : result.findings) {
+            if (f.code == "PMAP-WARN-003") {
+                found_ref_warning = true;
+                break;
+            }
+        }
+        CHECK_FALSE(found_ref_warning);
+    }
+
+    SECTION("options getter returns current options") {
+        pmap_validation_options options;
+        options.strict_mode = true;
+        options.validate_rwvm = false;
+
+        parametric_map_iod_validator validator(options);
+        CHECK(validator.options().strict_mode);
+        CHECK_FALSE(validator.options().validate_rwvm);
+    }
+
+    SECTION("set_options updates options") {
+        parametric_map_iod_validator validator;
+        CHECK_FALSE(validator.options().strict_mode);
+
+        pmap_validation_options new_options;
+        new_options.strict_mode = true;
+        validator.set_options(new_options);
+
+        CHECK(validator.options().strict_mode);
+    }
+}
+
+// ============================================================================
+// Convenience Function Tests
+// ============================================================================
+
+TEST_CASE("validate_parametric_map_iod convenience function",
+          "[services][parametric_map][validator]") {
+    auto dataset = create_minimal_parametric_map_dataset();
+    auto result = validate_parametric_map_iod(dataset);
+    CHECK(result.is_valid);
+}
+
+TEST_CASE("is_valid_parametric_map_dataset convenience function",
+          "[services][parametric_map][validator]") {
+    SECTION("valid dataset") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        CHECK(is_valid_parametric_map_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - wrong modality") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.set_string(tags::modality, vr_type::CS, "CT");
+        CHECK_FALSE(is_valid_parametric_map_dataset(dataset));
+    }
+
+    SECTION("invalid dataset - missing RWVM") {
+        auto dataset = create_minimal_parametric_map_dataset();
+        dataset.remove(pmap_iod_tags::real_world_value_mapping_sequence);
+        CHECK_FALSE(is_valid_parametric_map_dataset(dataset));
+    }
+}


### PR DESCRIPTION
Closes #834

## Summary

- Add `parametric_map_iod_validator` class implementing DICOM Parametric Map IOD (PS3.3 Section A.75) validation
- Validate all 11 mandatory modules: Patient, General Study, General Series, General Equipment, Enhanced General Equipment, Image Pixel, Parametric Map Image, Multi-frame Functional Groups, Multi-frame Dimension, Common Instance Reference, and SOP Common
- Enforce IEEE 754 float pixel data constraints (BitsAllocated 32 or 64, MONOCHROME2, SamplesPerPixel=1)
- Validate Real World Value Mapping Sequence (0040,9096) presence
- Validate multi-frame structure requirements (NumberOfFrames, SharedFunctionalGroupsSequence, PerFrameFunctionalGroupsSequence)
- Provide configurable validation options via `pmap_validation_options` struct
- Add convenience functions `validate_parametric_map_iod()` and `is_valid_parametric_map_dataset()`
- Add 14 test cases covering all validation scenarios

## Test Plan

- [x] All 24 parametric map tests pass (14 IOD validator + 10 storage from #835)
- [x] All 143 IOD validator tests pass (regression check across US, DX, MG, PET, NM, RT, SEG, SR, CT, MR, WSI, Ophthalmic, Parametric Map)
- [x] Full build successful (48/48 targets)