### PR TITLE
feat(web): add WADO-URI legacy web access support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1424,6 +1424,7 @@ if(TARGET Crow::Crow)
         src/web/endpoints/measurement_endpoints.cpp
         src/web/endpoints/key_image_endpoints.cpp
         src/web/endpoints/viewer_state_endpoints.cpp
+        src/web/endpoints/wado_uri_endpoints.cpp
     )
 
     # Add metrics endpoints conditionally (use TARGET check, not CMake variable)
@@ -2058,6 +2059,7 @@ if(PACS_BUILD_TESTS)
             tests/web/measurement_endpoints_test.cpp
             tests/web/key_image_endpoints_test.cpp
             tests/web/viewer_state_endpoints_test.cpp
+            tests/web/wado_uri_endpoints_test.cpp
         )
         target_link_libraries(web_tests
             PRIVATE

--- a/include/pacs/web/endpoints/wado_uri_endpoints.hpp
+++ b/include/pacs/web/endpoints/wado_uri_endpoints.hpp
@@ -1,0 +1,170 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file wado_uri_endpoints.hpp
+ * @brief WADO-URI (Web Access to DICOM Objects — URI-based) API endpoints
+ *
+ * Implements the legacy WADO-URI retrieval mechanism as defined in
+ * DICOM PS3.18 Section 6.2. Provides HTTP GET-based access to DICOM
+ * objects using query parameters.
+ *
+ * @see DICOM PS3.18 Section 6.2 — WADO-URI
+ * @see Issue #798 - Add WADO-URI legacy web access support
+ * @copyright Copyright (c) 2025
+ * @license MIT
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace pacs::web {
+
+struct rest_server_context;
+
+namespace wado_uri {
+
+/**
+ * @brief Parsed WADO-URI request parameters
+ *
+ * Represents the query parameters from a WADO-URI HTTP GET request:
+ * GET /wado?requestType=WADO&studyUID=...&seriesUID=...&objectUID=...
+ */
+struct wado_uri_request {
+    /// Study Instance UID (required)
+    std::string study_uid;
+
+    /// Series Instance UID (required)
+    std::string series_uid;
+
+    /// SOP Instance UID (required)
+    std::string object_uid;
+
+    /// Requested content type (default: application/dicom)
+    std::string content_type{"application/dicom"};
+
+    /// Transfer Syntax UID for transcoding (optional)
+    std::optional<std::string> transfer_syntax;
+
+    /// Whether to anonymize the response (optional)
+    bool anonymize{false};
+
+    /// Output viewport rows (optional, for rendered images)
+    std::optional<uint16_t> rows;
+
+    /// Output viewport columns (optional, for rendered images)
+    std::optional<uint16_t> columns;
+
+    /// Window center for rendered images (optional)
+    std::optional<double> window_center;
+
+    /// Window width for rendered images (optional)
+    std::optional<double> window_width;
+
+    /// Frame number for multi-frame images (1-based, optional)
+    std::optional<uint32_t> frame_number;
+};
+
+/**
+ * @brief Result of WADO-URI request validation
+ */
+struct validation_result {
+    bool valid{true};
+    int http_status{200};
+    std::string error_code;
+    std::string error_message;
+
+    [[nodiscard]] static validation_result ok() { return {true, 200, "", ""}; }
+    [[nodiscard]] static validation_result error(int status,
+                                                  std::string code,
+                                                  std::string message) {
+        return {false, status, std::move(code), std::move(message)};
+    }
+};
+
+/**
+ * @brief Parse WADO-URI query parameters from an HTTP request
+ * @param request_type The requestType parameter value
+ * @param study_uid The studyUID parameter value
+ * @param series_uid The seriesUID parameter value
+ * @param object_uid The objectUID parameter value
+ * @param content_type The contentType parameter value (optional)
+ * @param transfer_syntax The transferSyntax parameter value (optional)
+ * @param anonymize The anonymize parameter value (optional)
+ * @param rows The rows parameter value (optional)
+ * @param columns The columns parameter value (optional)
+ * @param window_center The windowCenter parameter value (optional)
+ * @param window_width The windowWidth parameter value (optional)
+ * @param frame_number The frameNumber parameter value (optional)
+ * @return Parsed WADO-URI request parameters
+ */
+[[nodiscard]] wado_uri_request parse_wado_uri_params(
+    const char* study_uid,
+    const char* series_uid,
+    const char* object_uid,
+    const char* content_type,
+    const char* transfer_syntax,
+    const char* anonymize,
+    const char* rows,
+    const char* columns,
+    const char* window_center,
+    const char* window_width,
+    const char* frame_number);
+
+/**
+ * @brief Validate a WADO-URI request
+ * @param request The parsed request parameters
+ * @return Validation result
+ */
+[[nodiscard]] validation_result validate_wado_uri_request(
+    const wado_uri_request& request);
+
+/**
+ * @brief Check if a content type is supported by WADO-URI
+ * @param content_type The content type to check
+ * @return true if the content type is supported
+ */
+[[nodiscard]] bool is_supported_content_type(std::string_view content_type);
+
+}  // namespace wado_uri
+
+namespace endpoints {
+
+// Internal function - implementation in cpp file
+// Registers WADO-URI endpoints with the Crow app
+// Called from rest_server.cpp
+
+}  // namespace endpoints
+
+}  // namespace pacs::web

--- a/src/web/endpoints/wado_uri_endpoints.cpp
+++ b/src/web/endpoints/wado_uri_endpoints.cpp
@@ -1,0 +1,424 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file wado_uri_endpoints.cpp
+ * @brief WADO-URI (Web Access to DICOM Objects — URI-based) endpoint implementation
+ *
+ * @see DICOM PS3.18 Section 6.2 — WADO-URI
+ * @see Issue #798 - Add WADO-URI legacy web access support
+ * @copyright Copyright (c) 2025
+ * @license MIT
+ */
+
+// IMPORTANT: Include Crow FIRST before any PACS headers to avoid forward
+// declaration conflicts
+#include "crow.h"
+
+// Workaround for Windows: DELETE is defined as a macro in <winnt.h>
+// which conflicts with crow::HTTPMethod::DELETE
+#ifdef DELETE
+#undef DELETE
+#endif
+
+#include "pacs/core/dicom_file.hpp"
+#include "pacs/storage/index_database.hpp"
+#include "pacs/web/endpoints/dicomweb_endpoints.hpp"
+#include "pacs/web/endpoints/system_endpoints.hpp"
+#include "pacs/web/endpoints/wado_uri_endpoints.hpp"
+#include "pacs/web/rest_config.hpp"
+#include "pacs/web/rest_types.hpp"
+
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace pacs::web {
+
+namespace wado_uri {
+
+wado_uri_request parse_wado_uri_params(
+    const char* study_uid,
+    const char* series_uid,
+    const char* object_uid,
+    const char* content_type,
+    const char* transfer_syntax,
+    const char* anonymize,
+    const char* rows,
+    const char* columns,
+    const char* window_center,
+    const char* window_width,
+    const char* frame_number) {
+
+    wado_uri_request request;
+
+    if (study_uid != nullptr) {
+        request.study_uid = study_uid;
+    }
+    if (series_uid != nullptr) {
+        request.series_uid = series_uid;
+    }
+    if (object_uid != nullptr) {
+        request.object_uid = object_uid;
+    }
+    if (content_type != nullptr && content_type[0] != '\0') {
+        request.content_type = content_type;
+    }
+    if (transfer_syntax != nullptr && transfer_syntax[0] != '\0') {
+        request.transfer_syntax = std::string(transfer_syntax);
+    }
+    if (anonymize != nullptr) {
+        std::string anon_str(anonymize);
+        request.anonymize = (anon_str == "yes" || anon_str == "true"
+                             || anon_str == "1");
+    }
+    if (rows != nullptr) {
+        try {
+            int val = std::stoi(rows);
+            if (val > 0 && val <= 65535) {
+                request.rows = static_cast<uint16_t>(val);
+            }
+        } catch (...) {
+            // Ignore invalid values
+        }
+    }
+    if (columns != nullptr) {
+        try {
+            int val = std::stoi(columns);
+            if (val > 0 && val <= 65535) {
+                request.columns = static_cast<uint16_t>(val);
+            }
+        } catch (...) {
+            // Ignore invalid values
+        }
+    }
+    if (window_center != nullptr) {
+        try {
+            request.window_center = std::stod(window_center);
+        } catch (...) {
+            // Ignore invalid values
+        }
+    }
+    if (window_width != nullptr) {
+        try {
+            request.window_width = std::stod(window_width);
+        } catch (...) {
+            // Ignore invalid values
+        }
+    }
+    if (frame_number != nullptr) {
+        try {
+            int val = std::stoi(frame_number);
+            if (val > 0) {
+                request.frame_number = static_cast<uint32_t>(val);
+            }
+        } catch (...) {
+            // Ignore invalid values
+        }
+    }
+
+    return request;
+}
+
+validation_result validate_wado_uri_request(const wado_uri_request& request) {
+    if (request.study_uid.empty()) {
+        return validation_result::error(
+            400, "MISSING_PARAMETER", "studyUID parameter is required");
+    }
+    if (request.series_uid.empty()) {
+        return validation_result::error(
+            400, "MISSING_PARAMETER", "seriesUID parameter is required");
+    }
+    if (request.object_uid.empty()) {
+        return validation_result::error(
+            400, "MISSING_PARAMETER", "objectUID parameter is required");
+    }
+    if (!is_supported_content_type(request.content_type)) {
+        return validation_result::error(
+            406, "UNSUPPORTED_MEDIA_TYPE",
+            "Unsupported contentType: " + request.content_type);
+    }
+    return validation_result::ok();
+}
+
+bool is_supported_content_type(std::string_view content_type) {
+    return content_type == "application/dicom"
+        || content_type == "image/jpeg"
+        || content_type == "image/png"
+        || content_type == "application/dicom+json";
+}
+
+}  // namespace wado_uri
+
+namespace endpoints {
+
+namespace {
+
+/**
+ * @brief Add CORS headers to response
+ */
+void add_cors_headers(crow::response& res, const rest_server_context& ctx) {
+    if (ctx.config != nullptr && !ctx.config->cors_allowed_origins.empty()) {
+        res.add_header("Access-Control-Allow-Origin",
+                       ctx.config->cors_allowed_origins);
+    }
+}
+
+/**
+ * @brief Read file contents into byte vector
+ */
+std::vector<uint8_t> read_file_bytes(const std::filesystem::path& path) {
+    std::ifstream file(path, std::ios::binary | std::ios::ate);
+    if (!file) {
+        return {};
+    }
+
+    auto size = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    std::vector<uint8_t> buffer(static_cast<size_t>(size));
+    if (!file.read(reinterpret_cast<char*>(buffer.data()), size)) {
+        return {};
+    }
+
+    return buffer;
+}
+
+/**
+ * @brief Handle application/dicom content type — return raw DICOM Part 10 file
+ */
+crow::response handle_dicom_response(
+    const std::string& file_path,
+    const rest_server_context& ctx) {
+    crow::response res;
+    add_cors_headers(res, ctx);
+
+    auto data = read_file_bytes(file_path);
+    if (data.empty()) {
+        res.code = 500;
+        res.add_header("Content-Type", "application/json");
+        res.body = make_error_json("READ_ERROR", "Failed to read DICOM file");
+        return res;
+    }
+
+    res.code = 200;
+    res.add_header("Content-Type", "application/dicom");
+    res.body = std::string(reinterpret_cast<char*>(data.data()), data.size());
+    return res;
+}
+
+/**
+ * @brief Handle image content types (JPEG, PNG) — return rendered image
+ */
+crow::response handle_rendered_response(
+    const std::string& file_path,
+    const wado_uri::wado_uri_request& request,
+    const rest_server_context& ctx) {
+    crow::response res;
+    add_cors_headers(res, ctx);
+
+    dicomweb::rendered_params params;
+
+    if (request.content_type == "image/png") {
+        params.format = dicomweb::rendered_format::png;
+    } else {
+        params.format = dicomweb::rendered_format::jpeg;
+    }
+
+    params.window_center = request.window_center;
+    params.window_width = request.window_width;
+
+    if (request.rows.has_value()) {
+        params.viewport_height = request.rows.value();
+    }
+    if (request.columns.has_value()) {
+        params.viewport_width = request.columns.value();
+    }
+    if (request.frame_number.has_value()) {
+        params.frame = request.frame_number.value();
+    }
+
+    auto result = dicomweb::render_dicom_image(file_path, params);
+
+    if (!result.success) {
+        res.code = 400;
+        res.add_header("Content-Type", "application/json");
+        res.body = make_error_json("RENDER_ERROR", result.error_message);
+        return res;
+    }
+
+    res.code = 200;
+    res.add_header("Content-Type", result.content_type);
+    res.body = std::string(
+        reinterpret_cast<char*>(result.data.data()),
+        result.data.size());
+    return res;
+}
+
+/**
+ * @brief Handle application/dicom+json content type — return DicomJSON metadata
+ */
+crow::response handle_dicom_json_response(
+    const std::string& file_path,
+    const rest_server_context& ctx) {
+    crow::response res;
+    add_cors_headers(res, ctx);
+
+    auto data = read_file_bytes(file_path);
+    if (data.empty()) {
+        res.code = 500;
+        res.add_header("Content-Type", "application/json");
+        res.body = make_error_json("READ_ERROR", "Failed to read DICOM file");
+        return res;
+    }
+
+    auto dicom_result = core::dicom_file::from_bytes(
+        std::span<const uint8_t>(data.data(), data.size()));
+    if (dicom_result.is_err()) {
+        res.code = 500;
+        res.add_header("Content-Type", "application/json");
+        res.body = make_error_json("PARSE_ERROR", "Failed to parse DICOM file");
+        return res;
+    }
+
+    auto json = dicomweb::dataset_to_dicom_json(
+        dicom_result.value().dataset(), false, "");
+
+    res.code = 200;
+    res.add_header("Content-Type", "application/dicom+json");
+    res.body = "[" + json + "]";
+    return res;
+}
+
+}  // anonymous namespace
+
+void register_wado_uri_endpoints_impl(
+    crow::SimpleApp& app,
+    std::shared_ptr<rest_server_context> ctx) {
+
+    // GET /wado?requestType=WADO&studyUID=...&seriesUID=...&objectUID=...
+    CROW_ROUTE(app, "/wado")
+        .methods(crow::HTTPMethod::GET)(
+            [ctx](const crow::request& req) {
+                crow::response res;
+                add_cors_headers(res, *ctx);
+
+                // Validate requestType parameter
+                auto request_type = req.url_params.get("requestType");
+                if (request_type == nullptr
+                    || std::string(request_type) != "WADO") {
+                    res.code = 400;
+                    res.add_header("Content-Type", "application/json");
+                    res.body = make_error_json(
+                        "INVALID_REQUEST_TYPE",
+                        "requestType must be 'WADO'");
+                    return res;
+                }
+
+                // Check database availability
+                if (!ctx->database) {
+                    res.code = 503;
+                    res.add_header("Content-Type", "application/json");
+                    res.body = make_error_json(
+                        "DATABASE_UNAVAILABLE", "Database not configured");
+                    return res;
+                }
+
+                // Parse and validate parameters
+                auto wado_request = wado_uri::parse_wado_uri_params(
+                    req.url_params.get("studyUID"),
+                    req.url_params.get("seriesUID"),
+                    req.url_params.get("objectUID"),
+                    req.url_params.get("contentType"),
+                    req.url_params.get("transferSyntax"),
+                    req.url_params.get("anonymize"),
+                    req.url_params.get("rows"),
+                    req.url_params.get("columns"),
+                    req.url_params.get("windowCenter"),
+                    req.url_params.get("windowWidth"),
+                    req.url_params.get("frameNumber"));
+
+                auto validation = wado_uri::validate_wado_uri_request(
+                    wado_request);
+                if (!validation.valid) {
+                    res.code = validation.http_status;
+                    res.add_header("Content-Type", "application/json");
+                    res.body = make_error_json(
+                        validation.error_code, validation.error_message);
+                    return res;
+                }
+
+                // Look up the DICOM instance
+                auto file_path_result = ctx->database->get_file_path(
+                    wado_request.object_uid);
+                if (!file_path_result.is_ok()) {
+                    res.code = 500;
+                    res.add_header("Content-Type", "application/json");
+                    res.body = make_error_json(
+                        "QUERY_ERROR", file_path_result.error().message);
+                    return res;
+                }
+                const auto& file_path = file_path_result.value();
+                if (!file_path) {
+                    res.code = 404;
+                    res.add_header("Content-Type", "application/json");
+                    res.body = make_error_json(
+                        "NOT_FOUND", "DICOM instance not found");
+                    return res;
+                }
+
+                // Route to appropriate handler based on content type
+                if (wado_request.content_type == "application/dicom") {
+                    return handle_dicom_response(*file_path, *ctx);
+                }
+                if (wado_request.content_type == "image/jpeg"
+                    || wado_request.content_type == "image/png") {
+                    return handle_rendered_response(
+                        *file_path, wado_request, *ctx);
+                }
+                if (wado_request.content_type == "application/dicom+json") {
+                    return handle_dicom_json_response(*file_path, *ctx);
+                }
+
+                // Should not reach here due to validation, but handle defensively
+                res.code = 406;
+                res.add_header("Content-Type", "application/json");
+                res.body = make_error_json(
+                    "UNSUPPORTED_MEDIA_TYPE",
+                    "Unsupported contentType: " + wado_request.content_type);
+                return res;
+            });
+}
+
+}  // namespace endpoints
+
+}  // namespace pacs::web

--- a/src/web/rest_server.cpp
+++ b/src/web/rest_server.cpp
@@ -56,6 +56,7 @@
 #include "pacs/web/endpoints/system_endpoints.hpp"
 #include "pacs/web/endpoints/thumbnail_endpoints.hpp"
 #include "pacs/web/endpoints/viewer_state_endpoints.hpp"
+#include "pacs/web/endpoints/wado_uri_endpoints.hpp"
 #include "pacs/web/endpoints/worklist_endpoints.hpp"
 #include "pacs/web/rest_config.hpp"
 #include "pacs/web/rest_server.hpp"
@@ -110,6 +111,8 @@ void register_key_image_endpoints_impl(crow::SimpleApp &app,
                                        std::shared_ptr<rest_server_context> ctx);
 void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
                                           std::shared_ptr<rest_server_context> ctx);
+void register_wado_uri_endpoints_impl(crow::SimpleApp &app,
+                                      std::shared_ptr<rest_server_context> ctx);
 #ifdef PACS_WITH_DATABASE_SYSTEM
 void register_metrics_endpoints_impl(crow::SimpleApp &app,
                                      std::shared_ptr<rest_server_context> ctx);
@@ -276,6 +279,7 @@ void rest_server::start_async() {
     endpoints::register_measurement_endpoints_impl(app, impl_->context);
     endpoints::register_key_image_endpoints_impl(app, impl_->context);
     endpoints::register_viewer_state_endpoints_impl(app, impl_->context);
+    endpoints::register_wado_uri_endpoints_impl(app, impl_->context);
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
     endpoints::register_metrics_endpoints_impl(app, impl_->context);

--- a/tests/web/wado_uri_endpoints_test.cpp
+++ b/tests/web/wado_uri_endpoints_test.cpp
@@ -1,0 +1,332 @@
+/**
+ * @file wado_uri_endpoints_test.cpp
+ * @brief Unit tests for WADO-URI endpoint utilities
+ *
+ * @see Issue #798 - Add WADO-URI legacy web access support
+ * @copyright Copyright (c) 2025
+ * @license MIT
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "pacs/web/endpoints/wado_uri_endpoints.hpp"
+
+using namespace pacs::web::wado_uri;
+
+// ============================================================================
+// parse_wado_uri_params Tests
+// ============================================================================
+
+TEST_CASE("parse_wado_uri_params - all parameters provided", "[wado-uri][parse]") {
+    auto request = parse_wado_uri_params(
+        "1.2.3.4",          // studyUID
+        "5.6.7.8",          // seriesUID
+        "9.10.11.12",       // objectUID
+        "image/jpeg",       // contentType
+        "1.2.840.10008.1.2.1",  // transferSyntax
+        "yes",              // anonymize
+        "512",              // rows
+        "512",              // columns
+        "40",               // windowCenter
+        "400",              // windowWidth
+        "3");               // frameNumber
+
+    CHECK(request.study_uid == "1.2.3.4");
+    CHECK(request.series_uid == "5.6.7.8");
+    CHECK(request.object_uid == "9.10.11.12");
+    CHECK(request.content_type == "image/jpeg");
+    REQUIRE(request.transfer_syntax.has_value());
+    CHECK(request.transfer_syntax.value() == "1.2.840.10008.1.2.1");
+    CHECK(request.anonymize == true);
+    REQUIRE(request.rows.has_value());
+    CHECK(request.rows.value() == 512);
+    REQUIRE(request.columns.has_value());
+    CHECK(request.columns.value() == 512);
+    REQUIRE(request.window_center.has_value());
+    CHECK(request.window_center.value() == 40.0);
+    REQUIRE(request.window_width.has_value());
+    CHECK(request.window_width.value() == 400.0);
+    REQUIRE(request.frame_number.has_value());
+    CHECK(request.frame_number.value() == 3);
+}
+
+TEST_CASE("parse_wado_uri_params - required parameters only", "[wado-uri][parse]") {
+    auto request = parse_wado_uri_params(
+        "1.2.3", "4.5.6", "7.8.9",
+        nullptr, nullptr, nullptr,
+        nullptr, nullptr, nullptr,
+        nullptr, nullptr);
+
+    CHECK(request.study_uid == "1.2.3");
+    CHECK(request.series_uid == "4.5.6");
+    CHECK(request.object_uid == "7.8.9");
+    CHECK(request.content_type == "application/dicom");
+    CHECK_FALSE(request.transfer_syntax.has_value());
+    CHECK(request.anonymize == false);
+    CHECK_FALSE(request.rows.has_value());
+    CHECK_FALSE(request.columns.has_value());
+    CHECK_FALSE(request.window_center.has_value());
+    CHECK_FALSE(request.window_width.has_value());
+    CHECK_FALSE(request.frame_number.has_value());
+}
+
+TEST_CASE("parse_wado_uri_params - null UIDs", "[wado-uri][parse]") {
+    auto request = parse_wado_uri_params(
+        nullptr, nullptr, nullptr,
+        nullptr, nullptr, nullptr,
+        nullptr, nullptr, nullptr,
+        nullptr, nullptr);
+
+    CHECK(request.study_uid.empty());
+    CHECK(request.series_uid.empty());
+    CHECK(request.object_uid.empty());
+    CHECK(request.content_type == "application/dicom");
+}
+
+TEST_CASE("parse_wado_uri_params - empty contentType uses default",
+          "[wado-uri][parse]") {
+    auto request = parse_wado_uri_params(
+        "1.2.3", "4.5.6", "7.8.9",
+        "",       // empty contentType
+        nullptr, nullptr, nullptr, nullptr,
+        nullptr, nullptr, nullptr);
+
+    CHECK(request.content_type == "application/dicom");
+}
+
+TEST_CASE("parse_wado_uri_params - anonymize variations", "[wado-uri][parse]") {
+    SECTION("yes") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", nullptr, nullptr, "yes",
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.anonymize == true);
+    }
+    SECTION("true") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", nullptr, nullptr, "true",
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.anonymize == true);
+    }
+    SECTION("1") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", nullptr, nullptr, "1",
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.anonymize == true);
+    }
+    SECTION("no") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", nullptr, nullptr, "no",
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.anonymize == false);
+    }
+}
+
+TEST_CASE("parse_wado_uri_params - invalid numeric values ignored",
+          "[wado-uri][parse]") {
+    auto request = parse_wado_uri_params(
+        "1.2.3", "4.5.6", "7.8.9",
+        nullptr, nullptr, nullptr,
+        "abc",    // invalid rows
+        "-1",     // invalid columns (negative)
+        "not_a_number",   // invalid windowCenter
+        "xyz",    // invalid windowWidth
+        "0");     // invalid frameNumber (must be > 0)
+
+    CHECK_FALSE(request.rows.has_value());
+    CHECK_FALSE(request.columns.has_value());
+    CHECK_FALSE(request.window_center.has_value());
+    CHECK_FALSE(request.window_width.has_value());
+    CHECK_FALSE(request.frame_number.has_value());
+}
+
+TEST_CASE("parse_wado_uri_params - content type values", "[wado-uri][parse]") {
+    SECTION("application/dicom") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", "application/dicom", nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.content_type == "application/dicom");
+    }
+    SECTION("image/jpeg") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", "image/jpeg", nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.content_type == "image/jpeg");
+    }
+    SECTION("image/png") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", "image/png", nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.content_type == "image/png");
+    }
+    SECTION("application/dicom+json") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", "application/dicom+json", nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, nullptr);
+        CHECK(r.content_type == "application/dicom+json");
+    }
+}
+
+// ============================================================================
+// validate_wado_uri_request Tests
+// ============================================================================
+
+TEST_CASE("validate_wado_uri_request - valid request", "[wado-uri][validate]") {
+    wado_uri_request request;
+    request.study_uid = "1.2.3";
+    request.series_uid = "4.5.6";
+    request.object_uid = "7.8.9";
+    request.content_type = "application/dicom";
+
+    auto result = validate_wado_uri_request(request);
+    CHECK(result.valid);
+    CHECK(result.http_status == 200);
+}
+
+TEST_CASE("validate_wado_uri_request - missing studyUID",
+          "[wado-uri][validate]") {
+    wado_uri_request request;
+    request.series_uid = "4.5.6";
+    request.object_uid = "7.8.9";
+
+    auto result = validate_wado_uri_request(request);
+    CHECK_FALSE(result.valid);
+    CHECK(result.http_status == 400);
+    CHECK(result.error_code == "MISSING_PARAMETER");
+}
+
+TEST_CASE("validate_wado_uri_request - missing seriesUID",
+          "[wado-uri][validate]") {
+    wado_uri_request request;
+    request.study_uid = "1.2.3";
+    request.object_uid = "7.8.9";
+
+    auto result = validate_wado_uri_request(request);
+    CHECK_FALSE(result.valid);
+    CHECK(result.http_status == 400);
+    CHECK(result.error_code == "MISSING_PARAMETER");
+}
+
+TEST_CASE("validate_wado_uri_request - missing objectUID",
+          "[wado-uri][validate]") {
+    wado_uri_request request;
+    request.study_uid = "1.2.3";
+    request.series_uid = "4.5.6";
+
+    auto result = validate_wado_uri_request(request);
+    CHECK_FALSE(result.valid);
+    CHECK(result.http_status == 400);
+    CHECK(result.error_code == "MISSING_PARAMETER");
+}
+
+TEST_CASE("validate_wado_uri_request - unsupported content type",
+          "[wado-uri][validate]") {
+    wado_uri_request request;
+    request.study_uid = "1.2.3";
+    request.series_uid = "4.5.6";
+    request.object_uid = "7.8.9";
+    request.content_type = "text/html";
+
+    auto result = validate_wado_uri_request(request);
+    CHECK_FALSE(result.valid);
+    CHECK(result.http_status == 406);
+    CHECK(result.error_code == "UNSUPPORTED_MEDIA_TYPE");
+}
+
+TEST_CASE("validate_wado_uri_request - all supported content types pass",
+          "[wado-uri][validate]") {
+    wado_uri_request request;
+    request.study_uid = "1.2.3";
+    request.series_uid = "4.5.6";
+    request.object_uid = "7.8.9";
+
+    SECTION("application/dicom") {
+        request.content_type = "application/dicom";
+        CHECK(validate_wado_uri_request(request).valid);
+    }
+    SECTION("image/jpeg") {
+        request.content_type = "image/jpeg";
+        CHECK(validate_wado_uri_request(request).valid);
+    }
+    SECTION("image/png") {
+        request.content_type = "image/png";
+        CHECK(validate_wado_uri_request(request).valid);
+    }
+    SECTION("application/dicom+json") {
+        request.content_type = "application/dicom+json";
+        CHECK(validate_wado_uri_request(request).valid);
+    }
+}
+
+// ============================================================================
+// is_supported_content_type Tests
+// ============================================================================
+
+TEST_CASE("is_supported_content_type - supported types",
+          "[wado-uri][content-type]") {
+    CHECK(is_supported_content_type("application/dicom"));
+    CHECK(is_supported_content_type("image/jpeg"));
+    CHECK(is_supported_content_type("image/png"));
+    CHECK(is_supported_content_type("application/dicom+json"));
+}
+
+TEST_CASE("is_supported_content_type - unsupported types",
+          "[wado-uri][content-type]") {
+    CHECK_FALSE(is_supported_content_type("text/html"));
+    CHECK_FALSE(is_supported_content_type("application/json"));
+    CHECK_FALSE(is_supported_content_type("image/gif"));
+    CHECK_FALSE(is_supported_content_type("application/pdf"));
+    CHECK_FALSE(is_supported_content_type(""));
+    CHECK_FALSE(is_supported_content_type("*/*"));
+}
+
+// ============================================================================
+// Edge Cases
+// ============================================================================
+
+TEST_CASE("parse_wado_uri_params - boundary viewport values",
+          "[wado-uri][parse][edge]") {
+    SECTION("maximum valid rows") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", nullptr, nullptr, nullptr,
+            "65535", nullptr, nullptr, nullptr, nullptr);
+        REQUIRE(r.rows.has_value());
+        CHECK(r.rows.value() == 65535);
+    }
+    SECTION("overflow rows ignored") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", nullptr, nullptr, nullptr,
+            "70000", nullptr, nullptr, nullptr, nullptr);
+        CHECK_FALSE(r.rows.has_value());
+    }
+    SECTION("frame number 1") {
+        auto r = parse_wado_uri_params(
+            "1", "2", "3", nullptr, nullptr, nullptr,
+            nullptr, nullptr, nullptr, nullptr, "1");
+        REQUIRE(r.frame_number.has_value());
+        CHECK(r.frame_number.value() == 1);
+    }
+}
+
+TEST_CASE("parse_wado_uri_params - floating point window values",
+          "[wado-uri][parse][edge]") {
+    auto r = parse_wado_uri_params(
+        "1", "2", "3", nullptr, nullptr, nullptr,
+        nullptr, nullptr, "40.5", "400.25", nullptr);
+
+    REQUIRE(r.window_center.has_value());
+    CHECK(r.window_center.value() == 40.5);
+    REQUIRE(r.window_width.has_value());
+    CHECK(r.window_width.value() == 400.25);
+}
+
+TEST_CASE("parse_wado_uri_params - negative window center",
+          "[wado-uri][parse][edge]") {
+    auto r = parse_wado_uri_params(
+        "1", "2", "3", nullptr, nullptr, nullptr,
+        nullptr, nullptr, "-100", "200", nullptr);
+
+    REQUIRE(r.window_center.has_value());
+    CHECK(r.window_center.value() == -100.0);
+    REQUIRE(r.window_width.has_value());
+    CHECK(r.window_width.value() == 200.0);
+}


### PR DESCRIPTION
Closes #798

## Summary
- Implement WADO-URI endpoint (DICOM PS3.18 Section 6.2) for legacy HTTP GET-based DICOM object retrieval
- Support `GET /wado?requestType=WADO&studyUID=...&seriesUID=...&objectUID=...` with full query parameter parsing
- Content type negotiation via `contentType` parameter: `application/dicom`, `image/jpeg`, `image/png`, `application/dicom+json`
- Reuse existing WADO-RS rendering infrastructure (`render_dicom_image()`, `dataset_to_dicom_json()`)

## Files
- New: `include/pacs/web/endpoints/wado_uri_endpoints.hpp` — Header with request struct, parsing, and validation
- New: `src/web/endpoints/wado_uri_endpoints.cpp` — Endpoint implementation with content-type routing
- New: `tests/web/wado_uri_endpoints_test.cpp` — 16 unit tests for parsing, validation, and edge cases
- Modified: `src/web/rest_server.cpp` — Register WADO-URI endpoint
- Modified: `CMakeLists.txt` — Add source and test files

## Test Plan
- [x] All 16 WADO-URI unit tests pass (parameter parsing, validation, content type support, boundary values)
- [x] Full project build succeeds (59/59 targets, no warnings)
- [ ] Manual verification with legacy DICOM viewer against running PACS server