### PR TITLE
feat(encoding): enable HTJ2K Transfer Syntax support (Sup 235)

### DIFF
--- a/docs/DICOM_CONFORMANCE_STATEMENT.md
+++ b/docs/DICOM_CONFORMANCE_STATEMENT.md
@@ -45,6 +45,7 @@ monitoring_system, network_system).
 
 | Date | Version | Description |
 |------|---------|-------------|
+| 2026-03-04 | 1.3.0 | Add HTJ2K Transfer Syntax support (Supplement 235) |
 | 2026-02-20 | 1.2.0 | Add Print Management SCP/SCU (PS3.4 Annex H), update Cloud Storage to real SDK |
 | 2026-02-18 | 1.1.0 | Add Storage Commitment Push Model SCP/SCU, update known limitations |
 | 2026-02-17 | 1.0.0 | Initial Conformance Statement |
@@ -455,6 +456,9 @@ Workstation (Print SCU)                      Printer (Print SCP)
 | JPEG 2000 Image Compression (Lossless Only) | 1.2.840.10008.1.2.4.90 | Lossless | Full |
 | JPEG 2000 Image Compression | 1.2.840.10008.1.2.4.91 | Lossy | Full |
 | RLE Lossless | 1.2.840.10008.1.2.5 | Lossless | Full |
+| High-Throughput JPEG 2000 (Lossless Only) | 1.2.840.10008.1.2.4.201 | Lossless | Full |
+| High-Throughput JPEG 2000 with RPCL (Lossless Only) | 1.2.840.10008.1.2.4.202 | Lossless | Full |
+| High-Throughput JPEG 2000 | 1.2.840.10008.1.2.4.203 | Lossless/Lossy | Full |
 
 ### 4.3 Default Transfer Syntax
 
@@ -610,6 +614,7 @@ The implementation supports DICOMweb services as defined in PS3.18:
 | application/octet-stream | Raw binary data |
 | image/jpeg | Rendered images |
 | image/png | Rendered images |
+| image/jphc | HTJ2K compressed images |
 | multipart/related | Multi-part responses/requests |
 
 ---
@@ -674,6 +679,7 @@ attributes as defined in the corresponding IOD specifications in PS3.3.
 |------|-----------|-----------|
 | Character Sets | CJK character sets (ISO 2022 IR 87/149/58/13) fully supported | Issue #700 (resolved) |
 | Storage Commitment | Push Model SCP/SCU fully implemented (N-ACTION, N-EVENT-REPORT) | Issue #701 (resolved) |
+| HTJ2K Codec | Requires OpenJPH library at build time (`PACS_WITH_HTJ2K_CODEC`) | Optional dependency |
 | Asynchronous Operations | Not supported (single operation per association) | N/A |
 | Print Management | Not supported | N/A |
 

--- a/include/pacs/encoding/compression/htj2k_codec.hpp
+++ b/include/pacs/encoding/compression/htj2k_codec.hpp
@@ -46,7 +46,7 @@ namespace pacs::encoding::compression {
  * Implements DICOM Transfer Syntaxes defined in Supplement 235:
  * - 1.2.840.10008.1.2.4.201 (HTJ2K Lossless Only)
  * - 1.2.840.10008.1.2.4.202 (HTJ2K with RPCL Options - Lossless Only)
- * - 1.2.840.10008.1.2.4.203 (HTJ2K - Lossy)
+ * - 1.2.840.10008.1.2.4.203 (HTJ2K - Lossless or Lossy)
  *
  * HTJ2K provides 10-50x faster decoding than legacy JPEG 2000 while
  * maintaining comparable compression ratios. Uses the Part 15 (HTJ2K)

--- a/include/pacs/encoding/transfer_syntax.hpp
+++ b/include/pacs/encoding/transfer_syntax.hpp
@@ -161,10 +161,10 @@ public:
     /// HTJ2K Lossless Only (1.2.840.10008.1.2.4.201)
     static const transfer_syntax htj2k_lossless;
 
-    /// HTJ2K RPCL (1.2.840.10008.1.2.4.202) - Lossless or Lossy
+    /// HTJ2K RPCL (1.2.840.10008.1.2.4.202) - Lossless Only
     static const transfer_syntax htj2k_rpcl;
 
-    /// HTJ2K (1.2.840.10008.1.2.4.203) - Lossy
+    /// HTJ2K (1.2.840.10008.1.2.4.203) - Lossless or Lossy
     static const transfer_syntax htj2k_lossy;
 
     /// @}

--- a/src/encoding/transfer_syntax.cpp
+++ b/src/encoding/transfer_syntax.cpp
@@ -122,19 +122,19 @@ static constexpr std::array<ts_entry, 12> TS_REGISTRY = {{
      "High-Throughput JPEG 2000 Image Compression (Lossless Only)",
      byte_order::little_endian,
      vr_encoding::explicit_vr,
-     true, false, false},
+     true, false, true},
 
     {"1.2.840.10008.1.2.4.202",
      "High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)",
      byte_order::little_endian,
      vr_encoding::explicit_vr,
-     true, false, false},
+     true, false, true},
 
     {"1.2.840.10008.1.2.4.203",
      "High-Throughput JPEG 2000 Image Compression",
      byte_order::little_endian,
      vr_encoding::explicit_vr,
-     true, false, false},
+     true, false, true},
 }};
 
 /**
@@ -221,21 +221,21 @@ const transfer_syntax transfer_syntax::htj2k_lossless{
     "High-Throughput JPEG 2000 Image Compression (Lossless Only)",
     byte_order::little_endian,
     vr_encoding::explicit_vr,
-    true, false, false};
+    true, false, true};
 
 const transfer_syntax transfer_syntax::htj2k_rpcl{
     "1.2.840.10008.1.2.4.202",
     "High-Throughput JPEG 2000 with RPCL Options Image Compression (Lossless Only)",
     byte_order::little_endian,
     vr_encoding::explicit_vr,
-    true, false, false};
+    true, false, true};
 
 const transfer_syntax transfer_syntax::htj2k_lossy{
     "1.2.840.10008.1.2.4.203",
     "High-Throughput JPEG 2000 Image Compression",
     byte_order::little_endian,
     vr_encoding::explicit_vr,
-    true, false, false};
+    true, false, true};
 
 // Public constructor - looks up UID in registry
 transfer_syntax::transfer_syntax(std::string_view uid)

--- a/src/network/dicom_server.cpp
+++ b/src/network/dicom_server.cpp
@@ -624,8 +624,8 @@ Result<associate_ac> dicom_server::simulate_association_request(const associate_
     // Accept compressed and uncompressed transfer syntaxes
     negotiation_config.supported_transfer_syntaxes = {
         "1.2.840.10008.1.2.4.201", // HTJ2K Lossless Only
-        "1.2.840.10008.1.2.4.202", // HTJ2K RPCL (Lossless or Lossy)
-        "1.2.840.10008.1.2.4.203", // HTJ2K Lossy
+        "1.2.840.10008.1.2.4.202", // HTJ2K RPCL Lossless Only
+        "1.2.840.10008.1.2.4.203", // HTJ2K (Lossless or Lossy)
         "1.2.840.10008.1.2.4.90",  // JPEG 2000 Lossless
         "1.2.840.10008.1.2.4.91",  // JPEG 2000 Lossy
         "1.2.840.10008.1.2.4.80",  // JPEG-LS Lossless

--- a/src/network/v2/dicom_association_handler.cpp
+++ b/src/network/v2/dicom_association_handler.cpp
@@ -476,8 +476,8 @@ void dicom_association_handler::handle_associate_rq(const std::vector<uint8_t>& 
     // Accept compressed and uncompressed transfer syntaxes
     scp_cfg.supported_transfer_syntaxes = {
         "1.2.840.10008.1.2.4.201", // HTJ2K Lossless Only
-        "1.2.840.10008.1.2.4.202", // HTJ2K RPCL (Lossless or Lossy)
-        "1.2.840.10008.1.2.4.203", // HTJ2K Lossy
+        "1.2.840.10008.1.2.4.202", // HTJ2K RPCL Lossless Only
+        "1.2.840.10008.1.2.4.203", // HTJ2K (Lossless or Lossy)
         "1.2.840.10008.1.2.4.90",  // JPEG 2000 Lossless
         "1.2.840.10008.1.2.4.91",  // JPEG 2000 Lossy
         "1.2.840.10008.1.2.4.80",  // JPEG-LS Lossless

--- a/tests/encoding/transfer_syntax_test.cpp
+++ b/tests/encoding/transfer_syntax_test.cpp
@@ -102,7 +102,7 @@ TEST_CASE("transfer_syntax properties", "[encoding][transfer_syntax]") {
         CHECK(ts.is_encapsulated());
         CHECK_FALSE(ts.is_deflated());
         CHECK(ts.is_valid());
-        CHECK_FALSE(ts.is_supported());
+        CHECK(ts.is_supported());
     }
 
     SECTION("HTJ2K RPCL") {
@@ -114,7 +114,7 @@ TEST_CASE("transfer_syntax properties", "[encoding][transfer_syntax]") {
         CHECK(ts.is_encapsulated());
         CHECK_FALSE(ts.is_deflated());
         CHECK(ts.is_valid());
-        CHECK_FALSE(ts.is_supported());
+        CHECK(ts.is_supported());
     }
 
     SECTION("HTJ2K Lossy") {
@@ -126,7 +126,7 @@ TEST_CASE("transfer_syntax properties", "[encoding][transfer_syntax]") {
         CHECK(ts.is_encapsulated());
         CHECK_FALSE(ts.is_deflated());
         CHECK(ts.is_valid());
-        CHECK_FALSE(ts.is_supported());
+        CHECK(ts.is_supported());
     }
 }
 
@@ -163,7 +163,7 @@ TEST_CASE("transfer_syntax construction from HTJ2K UID", "[encoding][transfer_sy
         CHECK(ts.is_valid());
         CHECK(ts.uid() == "1.2.840.10008.1.2.4.201");
         CHECK(ts.is_encapsulated());
-        CHECK_FALSE(ts.is_supported());
+        CHECK(ts.is_supported());
     }
 
     SECTION("HTJ2K RPCL UID creates valid transfer_syntax") {
@@ -209,8 +209,8 @@ TEST_CASE("transfer_syntax support enumeration", "[encoding][transfer_syntax]") 
     SECTION("supported_transfer_syntaxes returns only supported ones") {
         auto supported = supported_transfer_syntaxes();
 
-        // Phase 3: uncompressed syntaxes (3) + JPEG Baseline (1) + RLE Lossless (1)
-        CHECK(supported.size() == 5);
+        // Uncompressed (3) + JPEG Baseline (1) + RLE Lossless (1) + HTJ2K (3)
+        CHECK(supported.size() == 8);
 
         for (const auto& ts : supported) {
             CHECK(ts.is_supported());


### PR DESCRIPTION
Closes #844

## Summary

- Mark three official HTJ2K Transfer Syntaxes as `supported: true` in the transfer syntax registry, enabling `is_supported()` and inclusion in `supported_transfer_syntaxes()` results
- Fix inaccurate comments for UIDs .202 (RPCL is Lossless Only, not "Lossless or Lossy") and .203 (general HTJ2K, not exclusively "Lossy") per DICOM PS3.5 2025c
- Add HTJ2K entries to DICOM Conformance Statement (Section 4.2 and 8.4 media types)
- Update transfer syntax tests to verify `is_supported() == true` and correct supported count (5 -> 8)

## Transfer Syntax UIDs (Supplement 235)

| UID | Name | Mode |
|-----|------|------|
| 1.2.840.10008.1.2.4.201 | HTJ2K Lossless Only | Lossless |
| 1.2.840.10008.1.2.4.202 | HTJ2K with RPCL Options (Lossless Only) | Lossless |
| 1.2.840.10008.1.2.4.203 | HTJ2K | Lossless/Lossy |

## Files Changed

| File | Change |
|------|--------|
| `src/encoding/transfer_syntax.cpp` | Set `supported=true` for 3 HTJ2K entries (registry + static instances) |
| `include/pacs/encoding/transfer_syntax.hpp` | Fix .202/.203 comments |
| `include/pacs/encoding/compression/htj2k_codec.hpp` | Fix .203 comment |
| `src/network/v2/dicom_association_handler.cpp` | Fix .202/.203 comments |
| `src/network/dicom_server.cpp` | Fix .202/.203 comments |
| `tests/encoding/transfer_syntax_test.cpp` | Update is_supported checks and count |
| `docs/DICOM_CONFORMANCE_STATEMENT.md` | Add HTJ2K to Section 4.2, 8.4, Appendix B |

## Test Plan

- [x] All 31 transfer_syntax and htj2k tests pass
- [x] Full build succeeds (Release config)
- [ ] Verify association negotiation accepts HTJ2K UIDs from conformant peers