### PR TITLE
feat(auth): add OAuth 2.0 middleware and JWKS provider for DICOMweb endpoints

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1427,6 +1427,8 @@ if(TARGET Crow::Crow)
         src/web/endpoints/viewer_state_endpoints.cpp
         src/web/endpoints/wado_uri_endpoints.cpp
         src/web/auth/jwt_validator.cpp
+        src/web/auth/jwks_provider.cpp
+        src/web/auth/oauth2_middleware.cpp
     )
 
     # Add metrics endpoints conditionally (use TARGET check, not CMake variable)
@@ -2070,6 +2072,7 @@ if(PACS_BUILD_TESTS)
             tests/web/viewer_state_endpoints_test.cpp
             tests/web/wado_uri_endpoints_test.cpp
             tests/web/auth/jwt_validator_test.cpp
+            tests/web/auth/oauth2_middleware_test.cpp
         )
         target_link_libraries(web_tests
             PRIVATE

--- a/include/pacs/web/auth/jwks_provider.hpp
+++ b/include/pacs/web/auth/jwks_provider.hpp
@@ -1,0 +1,172 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file jwks_provider.hpp
+ * @brief JSON Web Key Set (JWKS) provider with key caching
+ *
+ * Manages public keys for JWT signature verification. Supports loading
+ * JWKS from JSON strings and callback-based URL fetching with TTL caching.
+ *
+ * @see RFC 7517 - JSON Web Key (JWK)
+ * @see Issue #852 - Implement OAuth 2.0 authorization for DICOMweb endpoints
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::web::auth {
+
+/**
+ * @brief Represents a single JSON Web Key converted to PEM format
+ */
+struct jwk_key {
+    std::string kid;    ///< Key ID
+    std::string kty;    ///< Key type (RSA, EC)
+    std::string alg;    ///< Algorithm (RS256, ES256)
+    std::string use;    ///< Key use (sig)
+    std::string pem;    ///< PEM-encoded public key
+};
+
+/**
+ * @brief Callback type for fetching JWKS JSON from a URL
+ *
+ * The callback receives a URL string and should return the JWKS JSON
+ * response body, or std::nullopt on failure.
+ */
+using jwks_fetch_callback =
+    std::function<std::optional<std::string>(const std::string& url)>;
+
+/**
+ * @brief JWKS provider with key caching and lazy refresh
+ *
+ * Manages JSON Web Key Sets for JWT signature verification. Keys can be
+ * loaded statically from JSON or fetched dynamically via a callback.
+ *
+ * @example
+ * @code
+ * jwks_provider provider;
+ * provider.load_from_json(R"({"keys":[...]})");
+ *
+ * auto key = provider.get_key("key-1");
+ * if (key) {
+ *     validator.verify_rs256(token, key->pem);
+ * }
+ * @endcode
+ */
+class jwks_provider {
+public:
+    jwks_provider();
+
+    /**
+     * @brief Load keys from a JWKS JSON string
+     *
+     * Parses the JWKS JSON and converts JWK keys to PEM format.
+     * Replaces any previously loaded keys.
+     *
+     * @param jwks_json JSON string containing {"keys": [...]}
+     * @return true if at least one key was successfully loaded
+     */
+    bool load_from_json(std::string_view jwks_json);
+
+    /**
+     * @brief Set a callback for fetching JWKS from a URL
+     * @param fetcher Callback that receives URL and returns JSON body
+     */
+    void set_fetcher(jwks_fetch_callback fetcher);
+
+    /**
+     * @brief Set the JWKS endpoint URL for fetching
+     * @param url JWKS endpoint URL
+     */
+    void set_jwks_url(const std::string& url);
+
+    /**
+     * @brief Get a key by Key ID (kid)
+     *
+     * If keys are not loaded or cache has expired, attempts to refresh
+     * using the configured fetcher and JWKS URL.
+     *
+     * @param kid Key ID to look up
+     * @return Key if found, std::nullopt otherwise
+     */
+    [[nodiscard]] std::optional<jwk_key> get_key(
+        std::string_view kid) const;
+
+    /**
+     * @brief Get the first key matching the given algorithm
+     * @param alg Algorithm name (e.g., "RS256")
+     * @return Key if found, std::nullopt otherwise
+     */
+    [[nodiscard]] std::optional<jwk_key> get_key_by_alg(
+        std::string_view alg) const;
+
+    /**
+     * @brief Force refresh keys from the configured JWKS URL
+     * @return true if refresh was successful
+     */
+    bool refresh();
+
+    /**
+     * @brief Get all currently loaded keys
+     */
+    [[nodiscard]] const std::vector<jwk_key>& keys() const;
+
+    /**
+     * @brief Set cache TTL in seconds (default: 3600)
+     */
+    void set_cache_ttl(std::uint32_t seconds);
+
+    /**
+     * @brief Check if the cache has expired
+     */
+    [[nodiscard]] bool is_cache_expired() const;
+
+private:
+    mutable std::vector<jwk_key> keys_;
+    jwks_fetch_callback fetcher_;
+    std::string jwks_url_;
+    std::uint32_t cache_ttl_seconds_{3600};
+    mutable std::chrono::steady_clock::time_point last_fetch_{};
+    mutable std::mutex mutex_;
+
+    bool try_refresh() const;
+};
+
+}  // namespace pacs::web::auth

--- a/include/pacs/web/auth/oauth2_middleware.hpp
+++ b/include/pacs/web/auth/oauth2_middleware.hpp
@@ -1,0 +1,223 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file oauth2_middleware.hpp
+ * @brief OAuth 2.0 middleware for DICOMweb endpoint authorization
+ *
+ * Provides Bearer token extraction, JWT validation, scope-based access
+ * control, and integration with the existing RBAC system. When OAuth 2.0
+ * is disabled, falls back to X-User-ID header authentication.
+ *
+ * @see RFC 6749 - OAuth 2.0 Authorization Framework
+ * @see Issue #852 - Implement OAuth 2.0 authorization for DICOMweb endpoints
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include "pacs/web/auth/jwks_provider.hpp"
+#include "pacs/web/auth/jwt_validator.hpp"
+#include "pacs/web/auth/oauth2_config.hpp"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+// Forward declarations
+namespace crow {
+struct request;
+struct response;
+}  // namespace crow
+
+namespace pacs::security {
+class access_control_manager;
+}  // namespace pacs::security
+
+// user_context must be fully defined for std::optional<user_context>
+#include "pacs/security/user_context.hpp"
+
+namespace pacs::web::auth {
+
+// =============================================================================
+// DICOMweb OAuth Scopes
+// =============================================================================
+
+/**
+ * @brief Standard OAuth 2.0 scopes for DICOMweb operations
+ */
+namespace dicomweb_scopes {
+constexpr std::string_view read = "dicomweb.read";
+constexpr std::string_view search = "dicomweb.search";
+constexpr std::string_view write = "dicomweb.write";
+constexpr std::string_view delete_resource = "dicomweb.delete";
+}  // namespace dicomweb_scopes
+
+// =============================================================================
+// OAuth 2.0 Middleware
+// =============================================================================
+
+/**
+ * @brief OAuth 2.0 middleware for DICOMweb endpoint authorization
+ *
+ * When OAuth 2.0 is enabled, the middleware:
+ * 1. Extracts the Bearer token from the Authorization header
+ * 2. Decodes and validates the JWT (issuer, audience, expiration)
+ * 3. Verifies the token signature using JWKS keys
+ * 4. Checks required scopes for the DICOMweb operation
+ * 5. Creates a user_context for the downstream endpoint
+ *
+ * When OAuth 2.0 is disabled, the middleware is a no-op and the system
+ * falls back to the existing X-User-ID header-based authentication.
+ *
+ * @example
+ * @code
+ * oauth2_config config;
+ * config.enabled = true;
+ * config.issuer = "https://auth.example.com";
+ *
+ * oauth2_middleware middleware(config);
+ * middleware.set_jwks_provider(jwks);
+ *
+ * // In endpoint handler:
+ * auto ctx = middleware.authenticate(req, res);
+ * if (!ctx) return res;  // Error response already set
+ *
+ * if (!middleware.require_scope(req, res, dicomweb_scopes::read)) {
+ *     return res;  // 403 Forbidden
+ * }
+ * @endcode
+ */
+class oauth2_middleware {
+public:
+    /**
+     * @brief Construct middleware with OAuth 2.0 configuration
+     * @param config The OAuth 2.0 configuration
+     */
+    explicit oauth2_middleware(const oauth2_config& config);
+
+    /**
+     * @brief Set the JWKS provider for signature verification
+     * @param provider Shared pointer to JWKS provider
+     */
+    void set_jwks_provider(std::shared_ptr<jwks_provider> provider);
+
+    /**
+     * @brief Set the access control manager for RBAC integration
+     * @param manager Shared pointer to access control manager
+     */
+    void set_access_control_manager(
+        std::shared_ptr<security::access_control_manager> manager);
+
+    /**
+     * @brief Authenticate a request using OAuth 2.0 Bearer token
+     *
+     * Extracts the Bearer token, validates JWT claims, verifies the
+     * signature, and creates a user_context. On failure, sets an
+     * appropriate error response (401 or 403).
+     *
+     * @param req The HTTP request
+     * @param res The HTTP response (set on error)
+     * @return user_context on success, std::nullopt on failure
+     */
+    [[nodiscard]] std::optional<security::user_context> authenticate(
+        const crow::request& req, crow::response& res) const;
+
+    /**
+     * @brief Check if the authenticated request has a required scope
+     *
+     * Must be called after authenticate(). Reads the cached token claims
+     * from the request. Returns false and sets 403 response if the
+     * required scope is missing.
+     *
+     * @param claims JWT claims from a previously validated token
+     * @param res The HTTP response (set on failure)
+     * @param required_scope The required OAuth scope
+     * @return true if the scope is present
+     */
+    [[nodiscard]] bool require_scope(
+        const jwt_claims& claims,
+        crow::response& res,
+        std::string_view required_scope) const;
+
+    /**
+     * @brief Check if the request has any of the required scopes
+     *
+     * @param claims JWT claims from a previously validated token
+     * @param res The HTTP response (set on failure)
+     * @param required_scopes List of acceptable scopes
+     * @return true if at least one scope is present
+     */
+    [[nodiscard]] bool require_any_scope(
+        const jwt_claims& claims,
+        crow::response& res,
+        const std::vector<std::string>& required_scopes) const;
+
+    /**
+     * @brief Check if OAuth 2.0 is enabled
+     */
+    [[nodiscard]] bool enabled() const noexcept;
+
+    /**
+     * @brief Get the underlying JWT validator
+     */
+    [[nodiscard]] const jwt_validator& validator() const noexcept;
+
+    /**
+     * @brief Get the last validated claims (for scope checking after authenticate)
+     */
+    [[nodiscard]] const jwt_claims& last_claims() const noexcept;
+
+private:
+    oauth2_config config_;
+    jwt_validator validator_;
+    std::shared_ptr<jwks_provider> jwks_provider_;
+    std::shared_ptr<security::access_control_manager> security_manager_;
+    mutable jwt_claims last_claims_;
+
+    /// Extract Bearer token from Authorization header
+    [[nodiscard]] std::optional<std::string_view> extract_bearer_token(
+        const crow::request& req) const;
+
+    /// Verify token signature using JWKS keys
+    [[nodiscard]] bool verify_signature(const jwt_token& token) const;
+
+    /// Set 401 Unauthorized response
+    static void set_unauthorized(crow::response& res,
+                                 std::string_view message);
+
+    /// Set 403 Forbidden response
+    static void set_forbidden(crow::response& res,
+                              std::string_view message);
+};
+
+}  // namespace pacs::web::auth

--- a/include/pacs/web/endpoints/system_endpoints.hpp
+++ b/include/pacs/web/endpoints/system_endpoints.hpp
@@ -57,6 +57,10 @@ namespace pacs::security {
 class access_control_manager;
 } // namespace pacs::security
 
+namespace pacs::web::auth {
+class oauth2_middleware;
+} // namespace pacs::web::auth
+
 namespace pacs::storage {
 class index_database;
 class file_storage;
@@ -113,6 +117,9 @@ struct rest_server_context {
 
   /// Database metrics service for monitoring
   std::shared_ptr<services::monitoring::database_metrics_service> database_metrics;
+
+  /// OAuth 2.0 middleware for DICOMweb endpoint authorization
+  std::shared_ptr<auth::oauth2_middleware> oauth2;
 };
 
 namespace endpoints {

--- a/include/pacs/web/rest_server.hpp
+++ b/include/pacs/web/rest_server.hpp
@@ -58,6 +58,12 @@ namespace pacs::security {
 class access_control_manager;
 } // namespace pacs::security
 
+namespace pacs::web::auth {
+struct oauth2_config;
+class oauth2_middleware;
+class jwks_provider;
+} // namespace pacs::web::auth
+
 namespace pacs::storage {
 class index_database;
 class file_storage;
@@ -205,6 +211,13 @@ public:
    * @param server DICOM server instance
    */
   void set_dicom_server(std::shared_ptr<network::dicom_server> server);
+
+  /**
+   * @brief Set OAuth 2.0 middleware for DICOMweb endpoint authorization
+   * @param middleware OAuth 2.0 middleware instance
+   */
+  void set_oauth2_middleware(
+      std::shared_ptr<auth::oauth2_middleware> middleware);
 
   // =========================================================================
   // Lifecycle

--- a/src/web/auth/jwks_provider.cpp
+++ b/src/web/auth/jwks_provider.cpp
@@ -1,0 +1,360 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file jwks_provider.cpp
+ * @brief Implementation of JWKS key management and JWK-to-PEM conversion
+ *
+ * @see RFC 7517 - JSON Web Key (JWK)
+ * @see RFC 7518 - JSON Web Algorithms (JWA)
+ * @see Issue #852 - Implement OAuth 2.0 authorization for DICOMweb endpoints
+ */
+
+#include "pacs/web/auth/jwks_provider.hpp"
+#include "pacs/web/auth/jwt_validator.hpp"
+
+#include <crow/json.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstring>
+
+// OpenSSL for JWK-to-PEM conversion (conditional)
+#ifdef PACS_WITH_DIGITAL_SIGNATURES
+#include <openssl/bio.h>
+#include <openssl/bn.h>
+#include <openssl/ec.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/rsa.h>
+#endif
+
+namespace pacs::web::auth {
+
+// =============================================================================
+// JWK to PEM Conversion (OpenSSL)
+// =============================================================================
+
+#ifdef PACS_WITH_DIGITAL_SIGNATURES
+
+namespace {
+
+/// RAII wrapper for OpenSSL BIGNUM
+struct bn_deleter {
+    void operator()(BIGNUM* bn) const { BN_free(bn); }
+};
+using bn_ptr = std::unique_ptr<BIGNUM, bn_deleter>;
+
+/// RAII wrapper for OpenSSL EVP_PKEY
+struct pkey_deleter {
+    void operator()(EVP_PKEY* key) const { EVP_PKEY_free(key); }
+};
+using pkey_ptr = std::unique_ptr<EVP_PKEY, pkey_deleter>;
+
+/// RAII wrapper for OpenSSL BIO
+struct bio_deleter {
+    void operator()(BIO* bio) const { BIO_free_all(bio); }
+};
+using bio_ptr = std::unique_ptr<BIO, bio_deleter>;
+
+/// RAII wrapper for OpenSSL EVP_PKEY_CTX
+struct pkey_ctx_deleter {
+    void operator()(EVP_PKEY_CTX* ctx) const { EVP_PKEY_CTX_free(ctx); }
+};
+using pkey_ctx_ptr = std::unique_ptr<EVP_PKEY_CTX, pkey_ctx_deleter>;
+
+/// Convert decoded bytes to BIGNUM
+bn_ptr bytes_to_bn(const std::string& bytes) {
+    return bn_ptr(BN_bin2bn(
+        reinterpret_cast<const unsigned char*>(bytes.data()),
+        static_cast<int>(bytes.size()), nullptr));
+}
+
+/// Serialize EVP_PKEY to PEM string
+std::string pkey_to_pem(EVP_PKEY* key) {
+    bio_ptr bio(BIO_new(BIO_s_mem()));
+    if (!bio) return {};
+
+    if (PEM_write_bio_PUBKEY(bio.get(), key) != 1) return {};
+
+    char* data = nullptr;
+    long len = BIO_get_mem_data(bio.get(), &data);
+    if (len <= 0 || !data) return {};
+
+    return std::string(data, static_cast<size_t>(len));
+}
+
+/// Convert RSA JWK (n, e) to PEM public key
+std::string rsa_jwk_to_pem(const std::string& n_b64, const std::string& e_b64) {
+    auto n_bytes = base64url_decode(n_b64);
+    auto e_bytes = base64url_decode(e_b64);
+    if (!n_bytes || !e_bytes) return {};
+
+    auto n = bytes_to_bn(*n_bytes);
+    auto e = bytes_to_bn(*e_bytes);
+    if (!n || !e) return {};
+
+    // Create RSA key using EVP_PKEY_fromdata (OpenSSL 3.0+)
+    pkey_ctx_ptr ctx(EVP_PKEY_CTX_new_from_name(nullptr, "RSA", nullptr));
+    if (!ctx) return {};
+
+    if (EVP_PKEY_fromdata_init(ctx.get()) != 1) return {};
+
+    OSSL_PARAM params[3];
+    params[0] = OSSL_PARAM_construct_BN("n",
+        const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(n_bytes->data())),
+        n_bytes->size());
+    params[1] = OSSL_PARAM_construct_BN("e",
+        const_cast<unsigned char*>(reinterpret_cast<const unsigned char*>(e_bytes->data())),
+        e_bytes->size());
+    params[2] = OSSL_PARAM_construct_end();
+
+    EVP_PKEY* pkey = nullptr;
+    if (EVP_PKEY_fromdata(ctx.get(), &pkey, EVP_PKEY_PUBLIC_KEY, params) != 1) {
+        return {};
+    }
+    pkey_ptr key(pkey);
+
+    return pkey_to_pem(key.get());
+}
+
+/// Convert EC JWK (x, y, crv) to PEM public key
+std::string ec_jwk_to_pem(const std::string& x_b64, const std::string& y_b64,
+                           const std::string& crv) {
+    auto x_bytes = base64url_decode(x_b64);
+    auto y_bytes = base64url_decode(y_b64);
+    if (!x_bytes || !y_bytes) return {};
+
+    // Only P-256 (ES256) supported
+    if (crv != "P-256") return {};
+
+    // Build uncompressed point: 0x04 || x || y
+    std::string point;
+    point.reserve(1 + x_bytes->size() + y_bytes->size());
+    point += '\x04';
+    point += *x_bytes;
+    point += *y_bytes;
+
+    // Create EC key using EVP_PKEY_fromdata (OpenSSL 3.0+)
+    pkey_ctx_ptr ctx(EVP_PKEY_CTX_new_from_name(nullptr, "EC", nullptr));
+    if (!ctx) return {};
+
+    if (EVP_PKEY_fromdata_init(ctx.get()) != 1) return {};
+
+    const char* group_name = "P-256";
+    OSSL_PARAM params[3];
+    params[0] = OSSL_PARAM_construct_utf8_string("group",
+        const_cast<char*>(group_name), 0);
+    params[1] = OSSL_PARAM_construct_octet_string("pub",
+        const_cast<char*>(point.data()), point.size());
+    params[2] = OSSL_PARAM_construct_end();
+
+    EVP_PKEY* pkey = nullptr;
+    if (EVP_PKEY_fromdata(ctx.get(), &pkey, EVP_PKEY_PUBLIC_KEY, params) != 1) {
+        return {};
+    }
+    pkey_ptr key(pkey);
+
+    return pkey_to_pem(key.get());
+}
+
+/// Parse a single JWK object and convert to jwk_key
+std::optional<jwk_key> parse_jwk(const crow::json::rvalue& jwk) {
+    jwk_key key;
+
+    if (jwk.has("kid") && jwk["kid"].t() == crow::json::type::String) {
+        key.kid = std::string(jwk["kid"].s());
+    }
+    if (jwk.has("kty") && jwk["kty"].t() == crow::json::type::String) {
+        key.kty = std::string(jwk["kty"].s());
+    }
+    if (jwk.has("alg") && jwk["alg"].t() == crow::json::type::String) {
+        key.alg = std::string(jwk["alg"].s());
+    }
+    if (jwk.has("use") && jwk["use"].t() == crow::json::type::String) {
+        key.use = std::string(jwk["use"].s());
+    }
+
+    // Skip non-signature keys
+    if (!key.use.empty() && key.use != "sig") return std::nullopt;
+
+    if (key.kty == "RSA") {
+        if (!jwk.has("n") || !jwk.has("e")) return std::nullopt;
+        auto n = std::string(jwk["n"].s());
+        auto e = std::string(jwk["e"].s());
+        key.pem = rsa_jwk_to_pem(n, e);
+        if (key.pem.empty()) return std::nullopt;
+
+        // Infer algorithm if not specified
+        if (key.alg.empty()) key.alg = "RS256";
+    } else if (key.kty == "EC") {
+        if (!jwk.has("x") || !jwk.has("y")) return std::nullopt;
+        auto x = std::string(jwk["x"].s());
+        auto y = std::string(jwk["y"].s());
+        auto crv = jwk.has("crv") ? std::string(jwk["crv"].s()) : std::string("P-256");
+        key.pem = ec_jwk_to_pem(x, y, crv);
+        if (key.pem.empty()) return std::nullopt;
+
+        if (key.alg.empty()) key.alg = "ES256";
+    } else {
+        return std::nullopt;  // Unsupported key type
+    }
+
+    return key;
+}
+
+}  // namespace
+
+#else  // !PACS_WITH_DIGITAL_SIGNATURES
+
+namespace {
+
+std::optional<jwk_key> parse_jwk(const crow::json::rvalue& /*jwk*/) {
+    return std::nullopt;  // Cannot convert without OpenSSL
+}
+
+}  // namespace
+
+#endif  // PACS_WITH_DIGITAL_SIGNATURES
+
+// =============================================================================
+// jwks_provider Implementation
+// =============================================================================
+
+jwks_provider::jwks_provider() = default;
+
+bool jwks_provider::load_from_json(std::string_view jwks_json) {
+    auto json = crow::json::load(std::string(jwks_json));
+    if (!json || !json.has("keys")) return false;
+
+    auto& keys_arr = json["keys"];
+    if (keys_arr.t() != crow::json::type::List) return false;
+
+    std::vector<jwk_key> new_keys;
+    for (size_t i = 0; i < keys_arr.size(); ++i) {
+        auto key = parse_jwk(keys_arr[i]);
+        if (key) {
+            new_keys.push_back(std::move(*key));
+        }
+    }
+
+    if (new_keys.empty()) return false;
+
+    std::lock_guard<std::mutex> lock(mutex_);
+    keys_ = std::move(new_keys);
+    last_fetch_ = std::chrono::steady_clock::now();
+    return true;
+}
+
+void jwks_provider::set_fetcher(jwks_fetch_callback fetcher) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    fetcher_ = std::move(fetcher);
+}
+
+void jwks_provider::set_jwks_url(const std::string& url) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    jwks_url_ = url;
+}
+
+std::optional<jwk_key> jwks_provider::get_key(std::string_view kid) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    // Try refresh if cache expired and fetcher available
+    if (is_cache_expired() && fetcher_ && !jwks_url_.empty()) {
+        try_refresh();
+    }
+
+    for (const auto& key : keys_) {
+        if (key.kid == kid) return key;
+    }
+    return std::nullopt;
+}
+
+std::optional<jwk_key> jwks_provider::get_key_by_alg(
+    std::string_view alg) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (is_cache_expired() && fetcher_ && !jwks_url_.empty()) {
+        try_refresh();
+    }
+
+    for (const auto& key : keys_) {
+        if (key.alg == alg) return key;
+    }
+    return std::nullopt;
+}
+
+bool jwks_provider::refresh() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return try_refresh();
+}
+
+const std::vector<jwk_key>& jwks_provider::keys() const {
+    return keys_;
+}
+
+void jwks_provider::set_cache_ttl(std::uint32_t seconds) {
+    cache_ttl_seconds_ = seconds;
+}
+
+bool jwks_provider::is_cache_expired() const {
+    if (last_fetch_ == std::chrono::steady_clock::time_point{}) return true;
+
+    auto elapsed = std::chrono::steady_clock::now() - last_fetch_;
+    return elapsed > std::chrono::seconds(cache_ttl_seconds_);
+}
+
+bool jwks_provider::try_refresh() const {
+    if (!fetcher_ || jwks_url_.empty()) return false;
+
+    auto json_body = fetcher_(jwks_url_);
+    if (!json_body) return false;
+
+    auto json = crow::json::load(*json_body);
+    if (!json || !json.has("keys")) return false;
+
+    auto& keys_arr = json["keys"];
+    if (keys_arr.t() != crow::json::type::List) return false;
+
+    std::vector<jwk_key> new_keys;
+    for (size_t i = 0; i < keys_arr.size(); ++i) {
+        auto key = parse_jwk(keys_arr[i]);
+        if (key) {
+            new_keys.push_back(std::move(*key));
+        }
+    }
+
+    if (new_keys.empty()) return false;
+
+    keys_ = std::move(new_keys);
+    last_fetch_ = std::chrono::steady_clock::now();
+    return true;
+}
+
+}  // namespace pacs::web::auth

--- a/src/web/auth/oauth2_middleware.cpp
+++ b/src/web/auth/oauth2_middleware.cpp
@@ -1,0 +1,240 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file oauth2_middleware.cpp
+ * @brief Implementation of OAuth 2.0 middleware for DICOMweb endpoints
+ *
+ * @see RFC 6749 - OAuth 2.0 Authorization Framework
+ * @see Issue #852 - Implement OAuth 2.0 authorization for DICOMweb endpoints
+ */
+
+// IMPORTANT: Include Crow FIRST before any PACS headers
+#include "crow.h"
+
+#include "pacs/web/auth/oauth2_middleware.hpp"
+
+#include "pacs/security/access_control_manager.hpp"
+#include "pacs/security/role.hpp"
+#include "pacs/security/user.hpp"
+#include "pacs/security/user_context.hpp"
+#include "pacs/web/rest_types.hpp"
+
+#include <string>
+
+namespace pacs::web::auth {
+
+// =============================================================================
+// oauth2_middleware Implementation
+// =============================================================================
+
+oauth2_middleware::oauth2_middleware(const oauth2_config& config)
+    : config_(config), validator_(config) {}
+
+void oauth2_middleware::set_jwks_provider(
+    std::shared_ptr<jwks_provider> provider) {
+    jwks_provider_ = std::move(provider);
+}
+
+void oauth2_middleware::set_access_control_manager(
+    std::shared_ptr<security::access_control_manager> manager) {
+    security_manager_ = std::move(manager);
+}
+
+std::optional<security::user_context> oauth2_middleware::authenticate(
+    const crow::request& req, crow::response& res) const {
+
+    // Extract Bearer token from Authorization header
+    auto bearer = extract_bearer_token(req);
+    if (!bearer) {
+        set_unauthorized(res, "Missing or invalid Authorization header");
+        return std::nullopt;
+    }
+
+    // Decode JWT
+    auto [token, decode_err] = validator_.decode(*bearer);
+    if (decode_err != jwt_error::none) {
+        set_unauthorized(res, std::string(jwt_error_message(decode_err)));
+        return std::nullopt;
+    }
+
+    // Validate claims (issuer, audience, expiration)
+    auto claims_err = validator_.validate_claims(token.claims);
+    if (claims_err != jwt_error::none) {
+        set_unauthorized(res, std::string(jwt_error_message(claims_err)));
+        return std::nullopt;
+    }
+
+    // Verify signature using JWKS
+    if (!verify_signature(token)) {
+        set_unauthorized(res, "Token signature verification failed");
+        return std::nullopt;
+    }
+
+    // Cache the validated claims for subsequent scope checks
+    last_claims_ = token.claims;
+
+    // Create user_context from JWT subject
+    // Try to find existing user in RBAC system, or create an OAuth-based context
+    security::User user;
+    user.id = token.claims.sub;
+    user.username = token.claims.sub;
+    user.active = true;
+
+    // If we have an access control manager, try to look up the user
+    if (security_manager_) {
+        auto user_result = security_manager_->get_user(token.claims.sub);
+        if (user_result.is_ok()) {
+            user = user_result.unwrap();
+        } else {
+            // OAuth user not in RBAC system: grant Viewer role by default
+            user.roles = {security::Role::Viewer};
+        }
+    } else {
+        user.roles = {security::Role::Viewer};
+    }
+
+    auto ctx = security::user_context(std::move(user), token.claims.jti);
+    ctx.set_source_ip(std::string(req.remote_ip_address));
+    ctx.touch();
+
+    return ctx;
+}
+
+bool oauth2_middleware::require_scope(
+    const jwt_claims& claims,
+    crow::response& res,
+    std::string_view required_scope) const {
+
+    if (!jwt_validator::has_scope(claims, required_scope)) {
+        set_forbidden(res,
+            "Insufficient scope: requires " + std::string(required_scope));
+        return false;
+    }
+    return true;
+}
+
+bool oauth2_middleware::require_any_scope(
+    const jwt_claims& claims,
+    crow::response& res,
+    const std::vector<std::string>& required_scopes) const {
+
+    if (!jwt_validator::has_any_scope(claims, required_scopes)) {
+        std::string scope_list;
+        for (size_t i = 0; i < required_scopes.size(); ++i) {
+            if (i > 0) scope_list += " or ";
+            scope_list += required_scopes[i];
+        }
+        set_forbidden(res, "Insufficient scope: requires " + scope_list);
+        return false;
+    }
+    return true;
+}
+
+bool oauth2_middleware::enabled() const noexcept {
+    return config_.enabled;
+}
+
+const jwt_validator& oauth2_middleware::validator() const noexcept {
+    return validator_;
+}
+
+const jwt_claims& oauth2_middleware::last_claims() const noexcept {
+    return last_claims_;
+}
+
+// =============================================================================
+// Private Helpers
+// =============================================================================
+
+std::optional<std::string_view> oauth2_middleware::extract_bearer_token(
+    const crow::request& req) const {
+
+    auto auth_header = req.get_header_value("Authorization");
+    if (auth_header.empty()) return std::nullopt;
+
+    std::string_view header_view(auth_header);
+
+    // Check for "Bearer " prefix (case-insensitive for "Bearer")
+    constexpr std::string_view bearer_prefix = "Bearer ";
+    if (header_view.size() <= bearer_prefix.size()) return std::nullopt;
+
+    // Case-sensitive check per RFC 6750
+    if (header_view.substr(0, bearer_prefix.size()) != bearer_prefix) {
+        return std::nullopt;
+    }
+
+    auto token = header_view.substr(bearer_prefix.size());
+    if (token.empty()) return std::nullopt;
+
+    return token;
+}
+
+bool oauth2_middleware::verify_signature(const jwt_token& token) const {
+    if (!jwks_provider_) return false;
+
+    // Try to get key by kid from the token header
+    std::optional<jwk_key> key;
+    if (!token.header.kid.empty()) {
+        key = jwks_provider_->get_key(token.header.kid);
+    }
+
+    // Fall back to algorithm-based lookup
+    if (!key) {
+        key = jwks_provider_->get_key_by_alg(token.header.alg);
+    }
+
+    if (!key) return false;
+
+    // Verify based on algorithm
+    if (token.header.alg == "RS256") {
+        return validator_.verify_rs256(token, key->pem);
+    } else if (token.header.alg == "ES256") {
+        return validator_.verify_es256(token, key->pem);
+    }
+
+    return false;
+}
+
+void oauth2_middleware::set_unauthorized(crow::response& res,
+                                         std::string_view message) {
+    res.code = 401;
+    res.add_header("Content-Type", "application/json");
+    res.add_header("WWW-Authenticate", "Bearer");
+    res.body = make_error_json("UNAUTHORIZED", message);
+}
+
+void oauth2_middleware::set_forbidden(crow::response& res,
+                                      std::string_view message) {
+    res.code = 403;
+    res.add_header("Content-Type", "application/json");
+    res.body = make_error_json("FORBIDDEN", message);
+}
+
+}  // namespace pacs::web::auth

--- a/src/web/endpoints/dicomweb_endpoints.cpp
+++ b/src/web/endpoints/dicomweb_endpoints.cpp
@@ -59,6 +59,7 @@
 #include "pacs/storage/patient_record.hpp"
 #include "pacs/storage/series_record.hpp"
 #include "pacs/storage/study_record.hpp"
+#include "pacs/web/auth/oauth2_middleware.hpp"
 #include "pacs/web/endpoints/dicomweb_endpoints.hpp"
 #include "pacs/web/endpoints/system_endpoints.hpp"
 #include "pacs/web/rest_config.hpp"
@@ -1536,6 +1537,31 @@ namespace pacs::web::endpoints {
 namespace {
 
 /**
+ * @brief Authenticate DICOMweb request using OAuth 2.0 or legacy X-User-ID
+ *
+ * When OAuth 2.0 is enabled, validates the Bearer token and checks the
+ * required scope. Falls back to legacy authentication when disabled.
+ */
+bool check_dicomweb_auth(const std::shared_ptr<rest_server_context>& ctx,
+                          const crow::request& req,
+                          crow::response& res,
+                          const std::vector<std::string>& required_scopes) {
+    if (ctx->oauth2 && ctx->oauth2->enabled()) {
+        auto user_ctx = ctx->oauth2->authenticate(req, res);
+        if (!user_ctx) return false;
+
+        if (!required_scopes.empty()) {
+            return ctx->oauth2->require_any_scope(
+                ctx->oauth2->last_claims(), res, required_scopes);
+        }
+        return true;
+    }
+
+    // Legacy X-User-ID fallback (no scope checking)
+    return true;
+}
+
+/**
  * @brief Add CORS headers to response
  */
 void add_cors_headers(crow::response& res, const rest_server_context& ctx) {
@@ -1801,6 +1827,12 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
                 crow::response res;
                 add_cors_headers(res, *ctx);
 
+                // OAuth 2.0 / legacy auth check
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.read"})) {
+                    return res;
+                }
+
                 if (!ctx->database) {
                     res.code = 503;
                     res.add_header("Content-Type", "application/json");
@@ -1845,9 +1877,15 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
     // GET /dicomweb/studies/{studyUID}/metadata - Study metadata
     CROW_ROUTE(app, "/dicomweb/studies/<string>/metadata")
         .methods(crow::HTTPMethod::GET)(
-            [ctx](const crow::request& /*req*/, const std::string& study_uid) {
+            [ctx](const crow::request& req, const std::string& study_uid) {
                 crow::response res;
                 add_cors_headers(res, *ctx);
+
+                // OAuth 2.0 / legacy auth check
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.read"})) {
+                    return res;
+                }
 
                 if (!ctx->database) {
                     res.code = 503;
@@ -2385,6 +2423,12 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
                 crow::response res;
                 add_cors_headers(res, *ctx);
 
+                // OAuth 2.0 / legacy auth check (write scope)
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.write"})) {
+                    return res;
+                }
+
                 if (!ctx->database || !ctx->file_storage) {
                     res.code = 503;
                     res.add_header("Content-Type", "application/json");
@@ -2540,6 +2584,12 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
             [ctx](const crow::request& req, const std::string& target_study_uid) {
                 crow::response res;
                 add_cors_headers(res, *ctx);
+
+                // OAuth 2.0 / legacy auth check (write scope)
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.write"})) {
+                    return res;
+                }
 
                 if (!ctx->database || !ctx->file_storage) {
                     res.code = 503;
@@ -2699,6 +2749,12 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
                 add_cors_headers(res, *ctx);
                 res.add_header("Content-Type",
                                std::string(dicomweb::media_type::dicom_json));
+
+                // OAuth 2.0 / legacy auth check (read or search scope)
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.read", "dicomweb.search"})) {
+                    return res;
+                }
 
                 if (!ctx->database) {
                     res.code = 503;
@@ -2882,6 +2938,12 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
                 res.add_header("Content-Type",
                                std::string(dicomweb::media_type::dicom_json));
 
+                // OAuth 2.0 / legacy auth check
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.read", "dicomweb.search"})) {
+                    return res;
+                }
+
                 if (!ctx->database) {
                     res.code = 503;
                     res.body = make_error_json("DATABASE_UNAVAILABLE",
@@ -2942,6 +3004,12 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
                 add_cors_headers(res, *ctx);
                 res.add_header("Content-Type",
                                std::string(dicomweb::media_type::dicom_json));
+
+                // OAuth 2.0 / legacy auth check
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.read", "dicomweb.search"})) {
+                    return res;
+                }
 
                 if (!ctx->database) {
                     res.code = 503;
@@ -3039,6 +3107,12 @@ void register_dicomweb_endpoints_impl(crow::SimpleApp& app,
                 add_cors_headers(res, *ctx);
                 res.add_header("Content-Type",
                                std::string(dicomweb::media_type::dicom_json));
+
+                // OAuth 2.0 / legacy auth check
+                if (!check_dicomweb_auth(ctx, req, res,
+                        {"dicomweb.read", "dicomweb.search"})) {
+                    return res;
+                }
 
                 if (!ctx->database) {
                     res.code = 503;

--- a/src/web/endpoints/wado_uri_endpoints.cpp
+++ b/src/web/endpoints/wado_uri_endpoints.cpp
@@ -49,6 +49,7 @@
 
 #include "pacs/core/dicom_file.hpp"
 #include "pacs/storage/index_database.hpp"
+#include "pacs/web/auth/oauth2_middleware.hpp"
 #include "pacs/web/endpoints/dicomweb_endpoints.hpp"
 #include "pacs/web/endpoints/system_endpoints.hpp"
 #include "pacs/web/endpoints/wado_uri_endpoints.hpp"
@@ -331,6 +332,17 @@ void register_wado_uri_endpoints_impl(
             [ctx](const crow::request& req) {
                 crow::response res;
                 add_cors_headers(res, *ctx);
+
+                // OAuth 2.0 / legacy auth check (read scope for WADO-URI)
+                if (ctx->oauth2 && ctx->oauth2->enabled()) {
+                    auto user_ctx = ctx->oauth2->authenticate(req, res);
+                    if (!user_ctx) return res;
+                    if (!ctx->oauth2->require_any_scope(
+                            ctx->oauth2->last_claims(), res,
+                            {"dicomweb.read"})) {
+                        return res;
+                    }
+                }
 
                 // Validate requestType parameter
                 auto request_type = req.url_params.get("requestType");

--- a/src/web/rest_server.cpp
+++ b/src/web/rest_server.cpp
@@ -58,6 +58,7 @@
 #include "pacs/web/endpoints/viewer_state_endpoints.hpp"
 #include "pacs/web/endpoints/wado_uri_endpoints.hpp"
 #include "pacs/web/endpoints/worklist_endpoints.hpp"
+#include "pacs/web/auth/oauth2_middleware.hpp"
 #include "pacs/web/rest_config.hpp"
 #include "pacs/web/rest_server.hpp"
 #include "pacs/web/rest_types.hpp"
@@ -211,6 +212,12 @@ void rest_server::set_dicom_server(
     std::shared_ptr<network::dicom_server> server) {
   std::lock_guard<std::mutex> lock(impl_->mutex);
   impl_->context->dicom_server = std::move(server);
+}
+
+void rest_server::set_oauth2_middleware(
+    std::shared_ptr<auth::oauth2_middleware> middleware) {
+  std::lock_guard<std::mutex> lock(impl_->mutex);
+  impl_->context->oauth2 = std::move(middleware);
 }
 
 void rest_server::start() {

--- a/tests/web/auth/oauth2_middleware_test.cpp
+++ b/tests/web/auth/oauth2_middleware_test.cpp
@@ -1,0 +1,387 @@
+/**
+ * @file oauth2_middleware_test.cpp
+ * @brief Unit tests for OAuth 2.0 middleware and JWKS provider
+ *
+ * @see RFC 6749 - OAuth 2.0 Authorization Framework
+ * @see Issue #852 - Implement OAuth 2.0 authorization for DICOMweb endpoints
+ */
+
+// IMPORTANT: Include Crow FIRST before any PACS headers
+#include "crow.h"
+
+#include <pacs/web/auth/jwks_provider.hpp>
+#include <pacs/web/auth/jwt_validator.hpp>
+#include <pacs/web/auth/oauth2_config.hpp>
+#include <pacs/web/auth/oauth2_middleware.hpp>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+using namespace pacs::web::auth;
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+namespace {
+
+/// Base64url encode a string (for test token construction)
+std::string base64url_encode(std::string_view input) {
+    static constexpr char table[] =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+
+    std::string result;
+    result.reserve(((input.size() + 2) / 3) * 4);
+
+    size_t i = 0;
+    while (i + 2 < input.size()) {
+        auto b0 = static_cast<unsigned char>(input[i]);
+        auto b1 = static_cast<unsigned char>(input[i + 1]);
+        auto b2 = static_cast<unsigned char>(input[i + 2]);
+        result += table[b0 >> 2];
+        result += table[((b0 & 0x03) << 4) | (b1 >> 4)];
+        result += table[((b1 & 0x0F) << 2) | (b2 >> 6)];
+        result += table[b2 & 0x3F];
+        i += 3;
+    }
+
+    if (i + 1 == input.size()) {
+        auto b0 = static_cast<unsigned char>(input[i]);
+        result += table[b0 >> 2];
+        result += table[(b0 & 0x03) << 4];
+    } else if (i + 2 == input.size()) {
+        auto b0 = static_cast<unsigned char>(input[i]);
+        auto b1 = static_cast<unsigned char>(input[i + 1]);
+        result += table[b0 >> 2];
+        result += table[((b0 & 0x03) << 4) | (b1 >> 4)];
+        result += table[(b1 & 0x0F) << 2];
+    }
+
+    return result;
+}
+
+std::int64_t now_timestamp() {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+               std::chrono::system_clock::now().time_since_epoch())
+        .count();
+}
+
+std::string make_test_token(const std::string& header_json,
+                            const std::string& payload_json,
+                            const std::string& sig = "test-signature") {
+    return base64url_encode(header_json) + "." +
+           base64url_encode(payload_json) + "." +
+           base64url_encode(sig);
+}
+
+oauth2_config test_config() {
+    oauth2_config config;
+    config.enabled = true;
+    config.issuer = "https://auth.example.com";
+    config.audience = "pacs-api";
+    config.clock_skew_seconds = 60;
+    config.allowed_algorithms = {"RS256", "ES256"};
+    return config;
+}
+
+std::string valid_header(const std::string& alg = "RS256") {
+    return R"({"alg":")" + alg + R"(","typ":"JWT","kid":"key-1"})";
+}
+
+std::string valid_payload(std::int64_t exp_offset = 3600,
+                          const std::string& scope = "dicomweb.read dicomweb.write") {
+    auto now = now_timestamp();
+    return R"({"iss":"https://auth.example.com","sub":"user-123",)"
+           R"("aud":"pacs-api","exp":)" + std::to_string(now + exp_offset) +
+           R"(,"iat":)" + std::to_string(now) +
+           R"(,"nbf":)" + std::to_string(now - 10) +
+           R"(,"jti":"token-abc-123",)"
+           R"("scope":")" + scope + R"("})";
+}
+
+}  // namespace
+
+// ============================================================================
+// JWKS Provider Tests
+// ============================================================================
+
+TEST_CASE("jwks_provider basic operations", "[web][auth][jwks]") {
+
+    SECTION("default state has no keys") {
+        jwks_provider provider;
+        CHECK(provider.keys().empty());
+        CHECK(provider.is_cache_expired());
+    }
+
+    SECTION("load_from_json rejects invalid JSON") {
+        jwks_provider provider;
+        CHECK_FALSE(provider.load_from_json("not json"));
+        CHECK_FALSE(provider.load_from_json(R"({"nokeys":true})"));
+        CHECK_FALSE(provider.load_from_json(R"({"keys":"not array"})"));
+    }
+
+    SECTION("load_from_json rejects empty key set") {
+        jwks_provider provider;
+        CHECK_FALSE(provider.load_from_json(R"({"keys":[]})"));
+    }
+
+#ifdef PACS_WITH_DIGITAL_SIGNATURES
+    SECTION("load_from_json loads RSA key") {
+        jwks_provider provider;
+        // A minimal RSA JWK with test key data
+        std::string jwks = R"({
+            "keys": [{
+                "kty": "RSA",
+                "kid": "test-key-1",
+                "alg": "RS256",
+                "use": "sig",
+                "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+                "e": "AQAB"
+            }]
+        })";
+
+        CHECK(provider.load_from_json(jwks));
+        REQUIRE(provider.keys().size() == 1);
+        CHECK(provider.keys()[0].kid == "test-key-1");
+        CHECK(provider.keys()[0].kty == "RSA");
+        CHECK(provider.keys()[0].alg == "RS256");
+        CHECK_FALSE(provider.keys()[0].pem.empty());
+        CHECK(provider.keys()[0].pem.find("BEGIN PUBLIC KEY") != std::string::npos);
+    }
+
+    SECTION("get_key returns key by kid") {
+        jwks_provider provider;
+        std::string jwks = R"({
+            "keys": [{
+                "kty": "RSA",
+                "kid": "key-abc",
+                "alg": "RS256",
+                "use": "sig",
+                "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+                "e": "AQAB"
+            }]
+        })";
+        provider.load_from_json(jwks);
+
+        auto key = provider.get_key("key-abc");
+        REQUIRE(key.has_value());
+        CHECK(key->kid == "key-abc");
+
+        CHECK_FALSE(provider.get_key("nonexistent").has_value());
+    }
+
+    SECTION("get_key_by_alg returns key by algorithm") {
+        jwks_provider provider;
+        std::string jwks = R"({
+            "keys": [{
+                "kty": "RSA",
+                "kid": "rs-key",
+                "alg": "RS256",
+                "use": "sig",
+                "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+                "e": "AQAB"
+            }]
+        })";
+        provider.load_from_json(jwks);
+
+        auto key = provider.get_key_by_alg("RS256");
+        REQUIRE(key.has_value());
+        CHECK(key->alg == "RS256");
+
+        CHECK_FALSE(provider.get_key_by_alg("ES256").has_value());
+    }
+#endif  // PACS_WITH_DIGITAL_SIGNATURES
+
+    SECTION("set_cache_ttl and is_cache_expired") {
+        jwks_provider provider;
+        provider.set_cache_ttl(0);  // Immediately expired
+
+        // No keys loaded yet, so always expired
+        CHECK(provider.is_cache_expired());
+    }
+
+    SECTION("fetcher callback is invoked on refresh") {
+        jwks_provider provider;
+        bool fetcher_called = false;
+        provider.set_fetcher([&](const std::string& url) -> std::optional<std::string> {
+            fetcher_called = true;
+            CHECK(url == "https://auth.example.com/.well-known/jwks.json");
+            return std::nullopt;  // Simulate failure
+        });
+        provider.set_jwks_url("https://auth.example.com/.well-known/jwks.json");
+
+        CHECK_FALSE(provider.refresh());
+        CHECK(fetcher_called);
+    }
+
+    SECTION("skips non-signature keys") {
+        jwks_provider provider;
+        // Key with use=enc should be skipped
+        std::string jwks = R"({
+            "keys": [{
+                "kty": "RSA",
+                "kid": "enc-key",
+                "use": "enc",
+                "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+                "e": "AQAB"
+            }]
+        })";
+        CHECK_FALSE(provider.load_from_json(jwks));
+    }
+}
+
+// ============================================================================
+// OAuth 2.0 Middleware Tests
+// ============================================================================
+
+TEST_CASE("oauth2_middleware enabled/disabled state", "[web][auth][middleware]") {
+
+    SECTION("disabled by default") {
+        oauth2_config config;
+        oauth2_middleware middleware(config);
+        CHECK_FALSE(middleware.enabled());
+    }
+
+    SECTION("enabled when config.enabled is true") {
+        auto config = test_config();
+        oauth2_middleware middleware(config);
+        CHECK(middleware.enabled());
+    }
+}
+
+TEST_CASE("oauth2_middleware authenticate extracts Bearer token",
+          "[web][auth][middleware]") {
+
+    auto config = test_config();
+    oauth2_middleware middleware(config);
+
+    SECTION("missing Authorization header returns 401") {
+        crow::request req;
+        crow::response res;
+
+        auto ctx = middleware.authenticate(req, res);
+        CHECK_FALSE(ctx.has_value());
+        CHECK(res.code == 401);
+    }
+
+    SECTION("non-Bearer authorization returns 401") {
+        crow::request req;
+        req.add_header("Authorization", "Basic dXNlcjpwYXNz");
+        crow::response res;
+
+        auto ctx = middleware.authenticate(req, res);
+        CHECK_FALSE(ctx.has_value());
+        CHECK(res.code == 401);
+    }
+
+    SECTION("empty Bearer token returns 401") {
+        crow::request req;
+        req.add_header("Authorization", "Bearer ");
+        crow::response res;
+
+        auto ctx = middleware.authenticate(req, res);
+        CHECK_FALSE(ctx.has_value());
+        CHECK(res.code == 401);
+    }
+
+    SECTION("malformed JWT returns 401") {
+        crow::request req;
+        req.add_header("Authorization", "Bearer not-a-jwt");
+        crow::response res;
+
+        auto ctx = middleware.authenticate(req, res);
+        CHECK_FALSE(ctx.has_value());
+        CHECK(res.code == 401);
+    }
+
+    SECTION("expired token returns 401") {
+        auto token = make_test_token(valid_header(), valid_payload(-3600));
+        crow::request req;
+        req.add_header("Authorization", "Bearer " + token);
+        crow::response res;
+
+        auto ctx = middleware.authenticate(req, res);
+        CHECK_FALSE(ctx.has_value());
+        CHECK(res.code == 401);
+    }
+
+    SECTION("valid token without JWKS provider fails signature verification") {
+        auto token = make_test_token(valid_header(), valid_payload());
+        crow::request req;
+        req.add_header("Authorization", "Bearer " + token);
+        crow::response res;
+
+        // No JWKS provider set, so signature verification fails
+        auto ctx = middleware.authenticate(req, res);
+        CHECK_FALSE(ctx.has_value());
+        CHECK(res.code == 401);
+    }
+}
+
+TEST_CASE("oauth2_middleware require_scope checks scopes",
+          "[web][auth][middleware]") {
+
+    auto config = test_config();
+    oauth2_middleware middleware(config);
+
+    SECTION("require_scope succeeds with matching scope") {
+        jwt_claims claims;
+        claims.scopes = {"dicomweb.read", "dicomweb.write"};
+        crow::response res;
+
+        CHECK(middleware.require_scope(claims, res, "dicomweb.read"));
+        CHECK(middleware.require_scope(claims, res, "dicomweb.write"));
+    }
+
+    SECTION("require_scope fails with missing scope") {
+        jwt_claims claims;
+        claims.scopes = {"dicomweb.read"};
+        crow::response res;
+
+        CHECK_FALSE(middleware.require_scope(claims, res, "dicomweb.write"));
+        CHECK(res.code == 403);
+    }
+
+    SECTION("require_any_scope succeeds with one matching scope") {
+        jwt_claims claims;
+        claims.scopes = {"dicomweb.read"};
+        crow::response res;
+
+        CHECK(middleware.require_any_scope(claims, res,
+            {"dicomweb.read", "dicomweb.search"}));
+    }
+
+    SECTION("require_any_scope fails with no matching scope") {
+        jwt_claims claims;
+        claims.scopes = {"dicomweb.read"};
+        crow::response res;
+
+        CHECK_FALSE(middleware.require_any_scope(claims, res,
+            {"dicomweb.write", "dicomweb.delete"}));
+        CHECK(res.code == 403);
+    }
+
+    SECTION("require_any_scope fails with empty claims") {
+        jwt_claims claims;
+        crow::response res;
+
+        CHECK_FALSE(middleware.require_any_scope(claims, res,
+            {"dicomweb.read"}));
+        CHECK(res.code == 403);
+    }
+}
+
+// ============================================================================
+// DICOMweb Scope Constants Tests
+// ============================================================================
+
+TEST_CASE("dicomweb_scopes constants are defined",
+          "[web][auth][scopes]") {
+    CHECK(dicomweb_scopes::read == "dicomweb.read");
+    CHECK(dicomweb_scopes::search == "dicomweb.search");
+    CHECK(dicomweb_scopes::write == "dicomweb.write");
+    CHECK(dicomweb_scopes::delete_resource == "dicomweb.delete");
+}


### PR DESCRIPTION
Closes #852

## Summary
- Add JWKS provider (`jwks_provider`) with RSA/EC JWK-to-PEM conversion using OpenSSL 3.0+ `EVP_PKEY_fromdata` API, configurable cache TTL, and pluggable HTTP fetcher callback
- Add OAuth 2.0 middleware (`oauth2_middleware`) with Bearer token extraction (RFC 6750), JWT validation, JWKS-based signature verification, and scope-based access control
- Define DICOMweb OAuth scopes: `dicomweb.read`, `dicomweb.search`, `dicomweb.write`, `dicomweb.delete`
- Integrate auth checks into all DICOMweb endpoints: WADO-RS (retrieve, metadata), STOW-RS (store), QIDO-RS (search), and WADO-URI
- Add `rest_server::set_oauth2_middleware()` for server-level OAuth configuration
- Graceful fallback: when OAuth is disabled, endpoints continue using existing X-User-ID header auth

## Architecture

Built on top of the JWT validation core from #863. The middleware layer adds:

1. **JWKS Provider** — Manages public keys for signature verification with automatic cache expiration
2. **OAuth 2.0 Middleware** — Orchestrates the full auth flow: extract token → decode JWT → validate claims → verify signature → check scopes → create user_context
3. **Endpoint Integration** — Each DICOMweb endpoint calls `check_dicomweb_auth()` with required scopes before processing

## Files Changed

| File | Change |
|------|--------|
| `include/pacs/web/auth/jwks_provider.hpp` | New — JWKS key management |
| `src/web/auth/jwks_provider.cpp` | New — JWK-to-PEM conversion (OpenSSL) |
| `include/pacs/web/auth/oauth2_middleware.hpp` | New — Middleware interface |
| `src/web/auth/oauth2_middleware.cpp` | New — Middleware implementation |
| `tests/web/auth/oauth2_middleware_test.cpp` | New — Unit tests |
| `include/pacs/web/endpoints/system_endpoints.hpp` | Add oauth2 to rest_server_context |
| `include/pacs/web/rest_server.hpp` | Add set_oauth2_middleware() |
| `src/web/rest_server.cpp` | Implement set_oauth2_middleware() |
| `src/web/endpoints/dicomweb_endpoints.cpp` | Add auth checks to all endpoints |
| `src/web/endpoints/wado_uri_endpoints.cpp` | Add auth check to WADO-URI |
| `CMakeLists.txt` | Add new source and test files |

## Test Plan
- [x] Build `pacs_web` target — passes with no errors
- [x] Build and run `web_tests` — all 1504 assertions in 246 test cases pass
- [x] JWKS provider tests: JSON parsing, RSA key loading, cache TTL, fetcher callback
- [x] Middleware tests: enabled/disabled state, Bearer extraction, scope checking
- [x] Backward compatibility: disabled OAuth falls through to legacy auth