### PR TITLE
feat(encoding): add HEVC/H.265 Transfer Syntax support (Main/Main 10 Profile)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -818,6 +818,7 @@ add_library(pacs_encoding
     src/encoding/dataset_charset.cpp
     src/encoding/compression/jpeg_baseline_codec.cpp
     src/encoding/compression/jpeg_lossless_codec.cpp
+    src/encoding/compression/hevc_codec.cpp
     src/encoding/compression/htj2k_codec.cpp
     src/encoding/compression/jpeg2000_codec.cpp
     src/encoding/compression/jpeg_ls_codec.cpp
@@ -1823,6 +1824,7 @@ if(PACS_BUILD_TESTS)
         tests/encoding/explicit_vr_big_endian_codec_test.cpp
         tests/encoding/compression/jpeg_baseline_codec_test.cpp
         tests/encoding/compression/jpeg_lossless_codec_test.cpp
+        tests/encoding/compression/hevc_codec_test.cpp
         tests/encoding/compression/htj2k_codec_test.cpp
         tests/encoding/compression/jpeg2000_codec_test.cpp
         tests/encoding/compression/jpeg_ls_codec_test.cpp

--- a/include/pacs/encoding/compression/hevc_codec.hpp
+++ b/include/pacs/encoding/compression/hevc_codec.hpp
@@ -1,0 +1,150 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file hevc_codec.hpp
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_ENCODING_COMPRESSION_HEVC_CODEC_HPP
+#define PACS_ENCODING_COMPRESSION_HEVC_CODEC_HPP
+
+#include "pacs/encoding/compression/compression_codec.hpp"
+
+namespace pacs::encoding::compression {
+
+/**
+ * @brief HEVC/H.265 codec implementation for video-encoded multi-frame DICOM.
+ *
+ * Implements DICOM Transfer Syntaxes for HEVC:
+ * - 1.2.840.10008.1.2.4.107 (HEVC/H.265 Main Profile / Level 5.1)
+ * - 1.2.840.10008.1.2.4.108 (HEVC/H.265 Main 10 Profile / Level 5.1)
+ *
+ * HEVC provides approximately 50% bitrate reduction compared to H.264/AVC
+ * for equivalent video quality. Intended for video-encoded multi-frame
+ * DICOM objects such as cine MRI, ultrasound clips, and XA sequences.
+ *
+ * Supported Features:
+ * - 8-bit grayscale and color images (Main Profile)
+ * - 10-bit grayscale and color images (Main 10 Profile)
+ * - Lossy compression with configurable quality
+ * - Encapsulated pixel data per PS3.5 Annex A.4
+ *
+ * Thread Safety:
+ * - This class is NOT thread-safe
+ * - Create separate instances per thread for concurrent operations
+ *
+ * @note Actual encode/decode operations require an HEVC library (libde265,
+ *       x265, or ffmpeg). Without a library, encode/decode return an error.
+ *
+ * @see DICOM PS3.5 -- HEVC/H.265 Transfer Syntax
+ * @see ITU-T H.265 / ISO/IEC 23008-2
+ */
+class hevc_codec final : public compression_codec {
+public:
+    /// DICOM Transfer Syntax UID for HEVC/H.265 Main Profile / Level 5.1
+    static constexpr std::string_view kTransferSyntaxUIDMain =
+        "1.2.840.10008.1.2.4.107";
+
+    /// DICOM Transfer Syntax UID for HEVC/H.265 Main 10 Profile / Level 5.1
+    static constexpr std::string_view kTransferSyntaxUIDMain10 =
+        "1.2.840.10008.1.2.4.108";
+
+    /// Default quality for lossy encoding (CRF value, 0-51, lower = better)
+    static constexpr int kDefaultQuality = 23;
+
+    /**
+     * @brief Constructs an HEVC codec instance.
+     *
+     * @param main10 If true, use Main 10 Profile (10-bit, UID .108).
+     *               If false, use Main Profile (8-bit, UID .107).
+     * @param quality Constant Rate Factor for encoding (0-51, lower = better).
+     */
+    explicit hevc_codec(bool main10 = false,
+                        int quality = kDefaultQuality);
+
+    ~hevc_codec() override;
+
+    // Non-copyable but movable
+    hevc_codec(const hevc_codec&) = delete;
+    hevc_codec& operator=(const hevc_codec&) = delete;
+    hevc_codec(hevc_codec&&) noexcept;
+    hevc_codec& operator=(hevc_codec&&) noexcept;
+
+    /// @name Codec Information
+    /// @{
+
+    [[nodiscard]] std::string_view transfer_syntax_uid() const noexcept override;
+    [[nodiscard]] std::string_view name() const noexcept override;
+    [[nodiscard]] bool is_lossy() const noexcept override;
+    [[nodiscard]] bool can_encode(const image_params& params) const noexcept override;
+    [[nodiscard]] bool can_decode(const image_params& params) const noexcept override;
+
+    /// @}
+
+    /// @name Configuration
+    /// @{
+
+    /**
+     * @brief Checks if this codec is configured for Main 10 Profile.
+     * @return true if Main 10 (10-bit), false if Main (8-bit)
+     */
+    [[nodiscard]] bool is_main10_profile() const noexcept;
+
+    /**
+     * @brief Gets the current quality setting (CRF).
+     * @return Quality value (0-51)
+     */
+    [[nodiscard]] int quality() const noexcept;
+
+    /// @}
+
+    /// @name Compression Operations
+    /// @{
+
+    [[nodiscard]] codec_result encode(
+        std::span<const uint8_t> pixel_data,
+        const image_params& params,
+        const compression_options& options = {}) const override;
+
+    [[nodiscard]] codec_result decode(
+        std::span<const uint8_t> compressed_data,
+        const image_params& params) const override;
+
+    /// @}
+
+private:
+    bool main10_;
+    int quality_;
+};
+
+}  // namespace pacs::encoding::compression
+
+#endif  // PACS_ENCODING_COMPRESSION_HEVC_CODEC_HPP

--- a/include/pacs/encoding/transfer_syntax.hpp
+++ b/include/pacs/encoding/transfer_syntax.hpp
@@ -167,6 +167,12 @@ public:
     /// HTJ2K (1.2.840.10008.1.2.4.203) - Lossless or Lossy
     static const transfer_syntax htj2k_lossy;
 
+    /// HEVC/H.265 Main Profile / Level 5.1 (1.2.840.10008.1.2.4.107)
+    static const transfer_syntax hevc_main;
+
+    /// HEVC/H.265 Main 10 Profile / Level 5.1 (1.2.840.10008.1.2.4.108)
+    static const transfer_syntax hevc_main10;
+
     /// @}
 
     /// @name Comparison Operators

--- a/src/encoding/compression/codec_factory.cpp
+++ b/src/encoding/compression/codec_factory.cpp
@@ -28,6 +28,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "pacs/encoding/compression/codec_factory.hpp"
+#include "pacs/encoding/compression/hevc_codec.hpp"
 #include "pacs/encoding/compression/htj2k_codec.hpp"
 #include "pacs/encoding/compression/jpeg_baseline_codec.hpp"
 #include "pacs/encoding/compression/jpeg_lossless_codec.hpp"
@@ -47,7 +48,7 @@ namespace {
  * As more codecs are implemented (RLE, etc.),
  * they should be added to this list.
  */
-static constexpr std::array<std::string_view, 10> kSupportedTransferSyntaxes = {{
+static constexpr std::array<std::string_view, 12> kSupportedTransferSyntaxes = {{
     rle_codec::kTransferSyntaxUID,                   // 1.2.840.10008.1.2.5
     jpeg_baseline_codec::kTransferSyntaxUID,         // 1.2.840.10008.1.2.4.50
     jpeg_lossless_codec::kTransferSyntaxUID,         // 1.2.840.10008.1.2.4.70
@@ -55,6 +56,8 @@ static constexpr std::array<std::string_view, 10> kSupportedTransferSyntaxes = {
     jpeg_ls_codec::kTransferSyntaxUIDNearLossless,   // 1.2.840.10008.1.2.4.81
     jpeg2000_codec::kTransferSyntaxUIDLossless,      // 1.2.840.10008.1.2.4.90
     jpeg2000_codec::kTransferSyntaxUIDLossy,         // 1.2.840.10008.1.2.4.91
+    hevc_codec::kTransferSyntaxUIDMain,              // 1.2.840.10008.1.2.4.107
+    hevc_codec::kTransferSyntaxUIDMain10,            // 1.2.840.10008.1.2.4.108
     htj2k_codec::kTransferSyntaxUIDLossless,         // 1.2.840.10008.1.2.4.201
     htj2k_codec::kTransferSyntaxUIDRPCL,             // 1.2.840.10008.1.2.4.202
     htj2k_codec::kTransferSyntaxUIDLossy,            // 1.2.840.10008.1.2.4.203
@@ -98,6 +101,16 @@ std::unique_ptr<compression_codec> codec_factory::create(
     // JPEG 2000 (1.2.840.10008.1.2.4.91) - can be lossy or lossless
     if (transfer_syntax_uid == jpeg2000_codec::kTransferSyntaxUIDLossy) {
         return std::make_unique<jpeg2000_codec>(false);  // lossless = false (default lossy)
+    }
+
+    // HEVC/H.265 Main Profile (1.2.840.10008.1.2.4.107)
+    if (transfer_syntax_uid == hevc_codec::kTransferSyntaxUIDMain) {
+        return std::make_unique<hevc_codec>(false);  // main10 = false
+    }
+
+    // HEVC/H.265 Main 10 Profile (1.2.840.10008.1.2.4.108)
+    if (transfer_syntax_uid == hevc_codec::kTransferSyntaxUIDMain10) {
+        return std::make_unique<hevc_codec>(true);  // main10 = true
     }
 
     // HTJ2K Lossless Only (1.2.840.10008.1.2.4.201)

--- a/src/encoding/compression/hevc_codec.cpp
+++ b/src/encoding/compression/hevc_codec.cpp
@@ -1,0 +1,113 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pacs/encoding/compression/hevc_codec.hpp"
+#include <pacs/core/result.hpp>
+
+namespace pacs::encoding::compression {
+
+hevc_codec::hevc_codec(bool main10, int quality)
+    : main10_(main10),
+      quality_(quality) {}
+
+hevc_codec::~hevc_codec() = default;
+
+hevc_codec::hevc_codec(hevc_codec&&) noexcept = default;
+hevc_codec& hevc_codec::operator=(hevc_codec&&) noexcept = default;
+
+std::string_view hevc_codec::transfer_syntax_uid() const noexcept {
+    return main10_ ? kTransferSyntaxUIDMain10 : kTransferSyntaxUIDMain;
+}
+
+std::string_view hevc_codec::name() const noexcept {
+    return main10_ ? "HEVC/H.265 Main 10 Profile" : "HEVC/H.265 Main Profile";
+}
+
+bool hevc_codec::is_lossy() const noexcept {
+    return true;
+}
+
+bool hevc_codec::can_encode(const image_params& params) const noexcept {
+    if (params.width == 0 || params.height == 0) {
+        return false;
+    }
+
+    if (params.samples_per_pixel != 1 && params.samples_per_pixel != 3) {
+        return false;
+    }
+
+    if (main10_) {
+        // Main 10 Profile supports up to 10-bit
+        if (params.bits_stored < 1 || params.bits_stored > 10) {
+            return false;
+        }
+    } else {
+        // Main Profile supports up to 8-bit
+        if (params.bits_stored < 1 || params.bits_stored > 8) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool hevc_codec::can_decode(const image_params& params) const noexcept {
+    return can_encode(params);
+}
+
+bool hevc_codec::is_main10_profile() const noexcept {
+    return main10_;
+}
+
+int hevc_codec::quality() const noexcept {
+    return quality_;
+}
+
+// HEVC library not yet integrated -- return not-available errors
+
+codec_result hevc_codec::encode(
+    [[maybe_unused]] std::span<const uint8_t> pixel_data,
+    [[maybe_unused]] const image_params& params,
+    [[maybe_unused]] const compression_options& options) const {
+    return pacs::pacs_error<compression_result>(
+        pacs::error_codes::compression_error,
+        "HEVC codec not available: HEVC library not found at build time. "
+        "Build with PACS_WITH_HEVC=ON to enable.");
+}
+
+codec_result hevc_codec::decode(
+    [[maybe_unused]] std::span<const uint8_t> compressed_data,
+    [[maybe_unused]] const image_params& params) const {
+    return pacs::pacs_error<compression_result>(
+        pacs::error_codes::decompression_error,
+        "HEVC codec not available: HEVC library not found at build time. "
+        "Build with PACS_WITH_HEVC=ON to enable.");
+}
+
+}  // namespace pacs::encoding::compression

--- a/src/encoding/transfer_syntax.cpp
+++ b/src/encoding/transfer_syntax.cpp
@@ -57,7 +57,7 @@ struct ts_entry {
  * This table contains the standard Transfer Syntaxes defined in DICOM PS3.5.
  * Compression support will be added in later phases.
  */
-static constexpr std::array<ts_entry, 12> TS_REGISTRY = {{
+static constexpr std::array<ts_entry, 14> TS_REGISTRY = {{
     // Uncompressed Transfer Syntaxes (supported in Phase 1)
     {"1.2.840.10008.1.2",
      "Implicit VR Little Endian",
@@ -132,6 +132,19 @@ static constexpr std::array<ts_entry, 12> TS_REGISTRY = {{
 
     {"1.2.840.10008.1.2.4.203",
      "High-Throughput JPEG 2000 Image Compression",
+     byte_order::little_endian,
+     vr_encoding::explicit_vr,
+     true, false, true},
+
+    // HEVC/H.265 Transfer Syntaxes
+    {"1.2.840.10008.1.2.4.107",
+     "HEVC/H.265 Main Profile / Level 5.1",
+     byte_order::little_endian,
+     vr_encoding::explicit_vr,
+     true, false, true},
+
+    {"1.2.840.10008.1.2.4.108",
+     "HEVC/H.265 Main 10 Profile / Level 5.1",
      byte_order::little_endian,
      vr_encoding::explicit_vr,
      true, false, true},
@@ -233,6 +246,20 @@ const transfer_syntax transfer_syntax::htj2k_rpcl{
 const transfer_syntax transfer_syntax::htj2k_lossy{
     "1.2.840.10008.1.2.4.203",
     "High-Throughput JPEG 2000 Image Compression",
+    byte_order::little_endian,
+    vr_encoding::explicit_vr,
+    true, false, true};
+
+const transfer_syntax transfer_syntax::hevc_main{
+    "1.2.840.10008.1.2.4.107",
+    "HEVC/H.265 Main Profile / Level 5.1",
+    byte_order::little_endian,
+    vr_encoding::explicit_vr,
+    true, false, true};
+
+const transfer_syntax transfer_syntax::hevc_main10{
+    "1.2.840.10008.1.2.4.108",
+    "HEVC/H.265 Main 10 Profile / Level 5.1",
     byte_order::little_endian,
     vr_encoding::explicit_vr,
     true, false, true};

--- a/tests/encoding/compression/hevc_codec_test.cpp
+++ b/tests/encoding/compression/hevc_codec_test.cpp
@@ -1,0 +1,292 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "pacs/encoding/compression/hevc_codec.hpp"
+#include "pacs/encoding/compression/codec_factory.hpp"
+#include "pacs/encoding/compression/image_params.hpp"
+#include "pacs/encoding/transfer_syntax.hpp"
+
+#include <vector>
+
+using namespace pacs::encoding::compression;
+using namespace pacs::encoding;
+
+TEST_CASE("hevc_codec construction", "[encoding][compression][hevc]") {
+    SECTION("Default construction creates Main Profile codec") {
+        hevc_codec codec;
+
+        CHECK(codec.transfer_syntax_uid() == hevc_codec::kTransferSyntaxUIDMain);
+        CHECK(codec.name() == "HEVC/H.265 Main Profile");
+        CHECK(codec.is_lossy());
+        CHECK_FALSE(codec.is_main10_profile());
+        CHECK(codec.quality() == hevc_codec::kDefaultQuality);
+    }
+
+    SECTION("Main 10 Profile construction") {
+        hevc_codec codec(true);
+
+        CHECK(codec.transfer_syntax_uid() == hevc_codec::kTransferSyntaxUIDMain10);
+        CHECK(codec.name() == "HEVC/H.265 Main 10 Profile");
+        CHECK(codec.is_lossy());
+        CHECK(codec.is_main10_profile());
+    }
+
+    SECTION("Custom quality") {
+        hevc_codec codec(false, 18);
+
+        CHECK(codec.quality() == 18);
+    }
+
+    SECTION("Default quality matches constant") {
+        hevc_codec codec;
+
+        CHECK(codec.quality() == hevc_codec::kDefaultQuality);
+    }
+}
+
+TEST_CASE("hevc_codec transfer syntax UIDs", "[encoding][compression][hevc]") {
+    SECTION("UIDs match DICOM definitions") {
+        CHECK(hevc_codec::kTransferSyntaxUIDMain == "1.2.840.10008.1.2.4.107");
+        CHECK(hevc_codec::kTransferSyntaxUIDMain10 == "1.2.840.10008.1.2.4.108");
+    }
+
+    SECTION("UIDs are distinct") {
+        CHECK(hevc_codec::kTransferSyntaxUIDMain !=
+              hevc_codec::kTransferSyntaxUIDMain10);
+    }
+}
+
+TEST_CASE("hevc_codec is always lossy", "[encoding][compression][hevc]") {
+    SECTION("Main Profile is lossy") {
+        hevc_codec codec(false);
+        CHECK(codec.is_lossy());
+    }
+
+    SECTION("Main 10 Profile is lossy") {
+        hevc_codec codec(true);
+        CHECK(codec.is_lossy());
+    }
+}
+
+TEST_CASE("hevc_codec can_encode/can_decode", "[encoding][compression][hevc]") {
+    SECTION("Main Profile accepts 8-bit grayscale") {
+        hevc_codec codec(false);
+        image_params params;
+        params.width = 512;
+        params.height = 512;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.high_bit = 7;
+        params.samples_per_pixel = 1;
+
+        CHECK(codec.can_encode(params));
+        CHECK(codec.can_decode(params));
+    }
+
+    SECTION("Main Profile accepts 8-bit RGB") {
+        hevc_codec codec(false);
+        image_params params;
+        params.width = 256;
+        params.height = 256;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.high_bit = 7;
+        params.samples_per_pixel = 3;
+
+        CHECK(codec.can_encode(params));
+        CHECK(codec.can_decode(params));
+    }
+
+    SECTION("Main Profile rejects 10-bit") {
+        hevc_codec codec(false);
+        image_params params;
+        params.width = 256;
+        params.height = 256;
+        params.bits_allocated = 16;
+        params.bits_stored = 10;
+        params.high_bit = 9;
+        params.samples_per_pixel = 1;
+
+        CHECK_FALSE(codec.can_encode(params));
+    }
+
+    SECTION("Main 10 Profile accepts 10-bit grayscale") {
+        hevc_codec codec(true);
+        image_params params;
+        params.width = 256;
+        params.height = 256;
+        params.bits_allocated = 16;
+        params.bits_stored = 10;
+        params.high_bit = 9;
+        params.samples_per_pixel = 1;
+
+        CHECK(codec.can_encode(params));
+        CHECK(codec.can_decode(params));
+    }
+
+    SECTION("Main 10 Profile accepts 8-bit") {
+        hevc_codec codec(true);
+        image_params params;
+        params.width = 128;
+        params.height = 128;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.high_bit = 7;
+        params.samples_per_pixel = 1;
+
+        CHECK(codec.can_encode(params));
+    }
+
+    SECTION("Main 10 Profile rejects 16-bit") {
+        hevc_codec codec(true);
+        image_params params;
+        params.width = 256;
+        params.height = 256;
+        params.bits_allocated = 16;
+        params.bits_stored = 16;
+        params.high_bit = 15;
+        params.samples_per_pixel = 1;
+
+        CHECK_FALSE(codec.can_encode(params));
+    }
+
+    SECTION("Zero dimensions rejected") {
+        hevc_codec codec;
+        image_params params;
+        params.width = 0;
+        params.height = 512;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.samples_per_pixel = 1;
+
+        CHECK_FALSE(codec.can_encode(params));
+
+        params.width = 512;
+        params.height = 0;
+        CHECK_FALSE(codec.can_encode(params));
+    }
+
+    SECTION("Unsupported samples_per_pixel rejected") {
+        hevc_codec codec;
+        image_params params;
+        params.width = 64;
+        params.height = 64;
+        params.bits_allocated = 8;
+        params.bits_stored = 8;
+        params.samples_per_pixel = 4;
+
+        CHECK_FALSE(codec.can_encode(params));
+    }
+}
+
+TEST_CASE("hevc_codec encode/decode returns not-available error",
+          "[encoding][compression][hevc]") {
+    hevc_codec codec;
+    std::vector<uint8_t> data(64 * 64);
+    image_params params;
+    params.width = 64;
+    params.height = 64;
+    params.bits_allocated = 8;
+    params.bits_stored = 8;
+    params.high_bit = 7;
+    params.samples_per_pixel = 1;
+
+    SECTION("Encode returns error with not-available message") {
+        auto result = codec.encode(data, params);
+        REQUIRE_FALSE(result.is_ok());
+        CHECK_THAT(result.error().message,
+                   Catch::Matchers::ContainsSubstring("not available"));
+    }
+
+    SECTION("Decode returns error with not-available message") {
+        auto result = codec.decode(data, params);
+        REQUIRE_FALSE(result.is_ok());
+        CHECK_THAT(result.error().message,
+                   Catch::Matchers::ContainsSubstring("not available"));
+    }
+}
+
+TEST_CASE("hevc_codec move semantics", "[encoding][compression][hevc]") {
+    SECTION("Move construction preserves state") {
+        hevc_codec original(true, 18);
+        hevc_codec moved(std::move(original));
+
+        CHECK(moved.is_main10_profile());
+        CHECK(moved.quality() == 18);
+        CHECK(moved.transfer_syntax_uid() == hevc_codec::kTransferSyntaxUIDMain10);
+    }
+
+    SECTION("Move assignment preserves state") {
+        hevc_codec original(true);
+        hevc_codec target;
+        target = std::move(original);
+
+        CHECK(target.is_main10_profile());
+        CHECK(target.transfer_syntax_uid() == hevc_codec::kTransferSyntaxUIDMain10);
+    }
+}
+
+TEST_CASE("codec_factory HEVC support", "[encoding][compression][hevc]") {
+    SECTION("Factory recognizes HEVC Main Profile UID") {
+        CHECK(codec_factory::is_supported("1.2.840.10008.1.2.4.107"));
+
+        auto codec = codec_factory::create("1.2.840.10008.1.2.4.107");
+        REQUIRE(codec != nullptr);
+        CHECK(codec->transfer_syntax_uid() == "1.2.840.10008.1.2.4.107");
+        CHECK(codec->is_lossy());
+    }
+
+    SECTION("Factory recognizes HEVC Main 10 Profile UID") {
+        CHECK(codec_factory::is_supported("1.2.840.10008.1.2.4.108"));
+
+        auto codec = codec_factory::create("1.2.840.10008.1.2.4.108");
+        REQUIRE(codec != nullptr);
+        CHECK(codec->transfer_syntax_uid() == "1.2.840.10008.1.2.4.108");
+        CHECK(codec->is_lossy());
+    }
+
+    SECTION("HEVC UIDs appear in supported transfer syntaxes list") {
+        auto supported = codec_factory::supported_transfer_syntaxes();
+
+        bool found_main = false;
+        bool found_main10 = false;
+
+        for (const auto& uid : supported) {
+            if (uid == "1.2.840.10008.1.2.4.107") found_main = true;
+            if (uid == "1.2.840.10008.1.2.4.108") found_main10 = true;
+        }
+
+        CHECK(found_main);
+        CHECK(found_main10);
+    }
+}
+
+TEST_CASE("HEVC transfer syntax registry", "[encoding][compression][hevc]") {
+    SECTION("HEVC Main Profile is registered") {
+        auto ts = find_transfer_syntax("1.2.840.10008.1.2.4.107");
+        REQUIRE(ts.has_value());
+        CHECK(ts->is_valid());
+        CHECK(ts->is_supported());
+        CHECK(ts->is_encapsulated());
+        CHECK_FALSE(ts->is_deflated());
+        CHECK(ts->name() == "HEVC/H.265 Main Profile / Level 5.1");
+    }
+
+    SECTION("HEVC Main 10 Profile is registered") {
+        auto ts = find_transfer_syntax("1.2.840.10008.1.2.4.108");
+        REQUIRE(ts.has_value());
+        CHECK(ts->is_valid());
+        CHECK(ts->is_supported());
+        CHECK(ts->is_encapsulated());
+        CHECK_FALSE(ts->is_deflated());
+        CHECK(ts->name() == "HEVC/H.265 Main 10 Profile / Level 5.1");
+    }
+
+    SECTION("Static instances are available") {
+        CHECK(transfer_syntax::hevc_main.uid() == "1.2.840.10008.1.2.4.107");
+        CHECK(transfer_syntax::hevc_main10.uid() == "1.2.840.10008.1.2.4.108");
+        CHECK(transfer_syntax::hevc_main.is_encapsulated());
+        CHECK(transfer_syntax::hevc_main10.is_encapsulated());
+    }
+}

--- a/tests/encoding/transfer_syntax_test.cpp
+++ b/tests/encoding/transfer_syntax_test.cpp
@@ -209,8 +209,8 @@ TEST_CASE("transfer_syntax support enumeration", "[encoding][transfer_syntax]") 
     SECTION("supported_transfer_syntaxes returns only supported ones") {
         auto supported = supported_transfer_syntaxes();
 
-        // Uncompressed (3) + JPEG Baseline (1) + RLE Lossless (1) + HTJ2K (3)
-        CHECK(supported.size() == 8);
+        // Uncompressed (3) + JPEG Baseline (1) + RLE Lossless (1) + HTJ2K (3) + HEVC (2)
+        CHECK(supported.size() == 10);
 
         for (const auto& ts : supported) {
             CHECK(ts.is_supported());


### PR DESCRIPTION
Closes #845

## Summary
- Register HEVC/H.265 Main Profile (`1.2.840.10008.1.2.4.107`) and Main 10 Profile (`1.2.840.10008.1.2.4.108`) transfer syntaxes
- Add `hevc_codec` class following existing codec pattern (htj2k_codec reference)
- Register in transfer syntax registry, codec factory, and static instances
- Encode/decode stubbed pending HEVC library integration (`PACS_WITH_HEVC` build option)

## Key Design Decisions
- **Main Profile**: 8-bit video (cine MRI, US clips, XA sequences)
- **Main 10 Profile**: up to 10-bit video (HDR medical imaging)
- **Always lossy**: HEVC is inherently lossy compression for video sequences
- **CRF quality**: Configurable Constant Rate Factor (0-51, default 23)

## Test Plan
- [x] 8 test cases with 63 assertions covering:
  - Construction (Main/Main 10, custom quality)
  - Transfer syntax UID verification
  - Lossy flag always true
  - Capability checks (bit depth per profile, dimensions, samples_per_pixel)
  - Encode/decode not-available error messages
  - Move semantics
  - Codec factory integration
  - Transfer syntax registry and static instances
- [x] All 203 encoding tests pass (15640 assertions)