### PR TITLE
feat(web): add DICOMweb Storage Commitment REST endpoints (Sup 234)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1428,6 +1428,7 @@ if(TARGET Crow::Crow)
         src/web/endpoints/key_image_endpoints.cpp
         src/web/endpoints/viewer_state_endpoints.cpp
         src/web/endpoints/wado_uri_endpoints.cpp
+        src/web/endpoints/storage_commitment_endpoints.cpp
         src/web/auth/jwt_validator.cpp
         src/web/auth/jwks_provider.cpp
         src/web/auth/oauth2_middleware.cpp
@@ -2075,6 +2076,7 @@ if(PACS_BUILD_TESTS)
             tests/web/key_image_endpoints_test.cpp
             tests/web/viewer_state_endpoints_test.cpp
             tests/web/wado_uri_endpoints_test.cpp
+            tests/web/storage_commitment_endpoints_test.cpp
             tests/web/auth/jwt_validator_test.cpp
             tests/web/auth/oauth2_middleware_test.cpp
         )

--- a/include/pacs/web/endpoints/storage_commitment_endpoints.hpp
+++ b/include/pacs/web/endpoints/storage_commitment_endpoints.hpp
@@ -1,0 +1,201 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file storage_commitment_endpoints.hpp
+ * @brief DICOMweb Storage Commitment REST endpoints (Supplement 234)
+ *
+ * Provides RESTful API for requesting and polling storage commitment
+ * status, complementing the existing DIMSE-based Storage Commitment
+ * Push Model (N-ACTION/N-EVENT-REPORT).
+ *
+ * @see DICOM Supplement 234 -- DICOMweb Storage Commitment
+ * @see DICOM PS3.18 -- Web Services
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <chrono>
+#include <map>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "pacs/services/storage_commitment_types.hpp"
+
+namespace pacs::web {
+
+struct rest_server_context;
+
+namespace storage_commitment {
+
+/**
+ * @brief Transaction state for DICOMweb Storage Commitment
+ */
+enum class transaction_state {
+    pending,    ///< Commitment request received, verification in progress
+    success,    ///< All referenced instances verified present and intact
+    partial,    ///< Some instances verified, others failed
+    failure     ///< Commitment verification failed
+};
+
+/**
+ * @brief Convert transaction state to string
+ */
+[[nodiscard]] std::string_view to_string(transaction_state state) noexcept;
+
+/**
+ * @brief Parse transaction state from string
+ */
+[[nodiscard]] std::optional<transaction_state> parse_state(
+    std::string_view str) noexcept;
+
+/**
+ * @brief A storage commitment transaction record
+ */
+struct commitment_transaction {
+    /// Unique transaction identifier (DICOM UID format)
+    std::string transaction_uid;
+
+    /// Current state of the transaction
+    transaction_state state{transaction_state::pending};
+
+    /// SOP Instance references requested for commitment
+    std::vector<services::sop_reference> requested_references;
+
+    /// Successfully committed references (populated when verified)
+    std::vector<services::sop_reference> success_references;
+
+    /// Failed references with reasons (populated when verified)
+    std::vector<std::pair<services::sop_reference,
+                          services::commitment_failure_reason>> failed_references;
+
+    /// Study Instance UID (optional, for study-level commitment)
+    std::string study_instance_uid;
+
+    /// Timestamp when the commitment was requested
+    std::chrono::system_clock::time_point created_at;
+
+    /// Timestamp when verification completed
+    std::optional<std::chrono::system_clock::time_point> completed_at;
+};
+
+/**
+ * @brief In-memory store for commitment transactions
+ *
+ * Thread-safe storage for tracking DICOMweb commitment requests.
+ * In production, this would be backed by a persistent store.
+ */
+class transaction_store {
+public:
+    /**
+     * @brief Add a new transaction
+     * @param txn The transaction to store
+     */
+    void add(commitment_transaction txn);
+
+    /**
+     * @brief Find a transaction by its UID
+     * @param transaction_uid The transaction UID
+     * @return The transaction if found
+     */
+    [[nodiscard]] std::optional<commitment_transaction> find(
+        std::string_view transaction_uid) const;
+
+    /**
+     * @brief Update an existing transaction
+     * @param txn The updated transaction
+     * @return true if the transaction was found and updated
+     */
+    bool update(const commitment_transaction& txn);
+
+    /**
+     * @brief List all transactions (newest first)
+     * @param limit Maximum number to return (0 = unlimited)
+     * @return Vector of transactions
+     */
+    [[nodiscard]] std::vector<commitment_transaction> list(
+        size_t limit = 0) const;
+
+    /**
+     * @brief Get the number of stored transactions
+     */
+    [[nodiscard]] size_t size() const;
+
+private:
+    mutable std::mutex mutex_;
+    std::map<std::string, commitment_transaction, std::less<>> transactions_;
+};
+
+/**
+ * @brief Serialize a commitment transaction to DICOM JSON
+ * @param txn The transaction to serialize
+ * @return JSON string
+ */
+[[nodiscard]] std::string transaction_to_json(const commitment_transaction& txn);
+
+/**
+ * @brief Serialize a list of transactions to DICOM JSON array
+ * @param transactions The transactions to serialize
+ * @return JSON array string
+ */
+[[nodiscard]] std::string transactions_to_json(
+    const std::vector<commitment_transaction>& transactions);
+
+/**
+ * @brief Parse a commitment request from JSON body
+ * @param json_body The request body
+ * @param study_uid Optional study UID from URL path
+ * @return Parsed references, or empty on error
+ */
+struct parse_result {
+    std::vector<services::sop_reference> references;
+    std::string error_message;
+    bool valid{false};
+};
+
+[[nodiscard]] parse_result parse_commitment_request(
+    std::string_view json_body,
+    std::string_view study_uid = "");
+
+}  // namespace storage_commitment
+
+namespace endpoints {
+
+// Internal function - implementation in cpp file
+// Registers storage commitment endpoints with the Crow app
+// Called from rest_server.cpp
+
+}  // namespace endpoints
+
+}  // namespace pacs::web

--- a/src/web/endpoints/storage_commitment_endpoints.cpp
+++ b/src/web/endpoints/storage_commitment_endpoints.cpp
@@ -1,0 +1,609 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file storage_commitment_endpoints.cpp
+ * @brief DICOMweb Storage Commitment REST endpoint implementation
+ *
+ * @see DICOM Supplement 234 -- DICOMweb Storage Commitment
+ * @see DICOM PS3.18 -- Web Services
+ */
+
+// IMPORTANT: Include Crow FIRST before any PACS headers to avoid forward
+// declaration conflicts
+#include "crow.h"
+
+// Workaround for Windows: DELETE is defined as a macro in <winnt.h>
+// which conflicts with crow::HTTPMethod::DELETE
+#ifdef DELETE
+#undef DELETE
+#endif
+
+#include "pacs/storage/index_database.hpp"
+#include "pacs/web/auth/oauth2_middleware.hpp"
+#include "pacs/web/endpoints/storage_commitment_endpoints.hpp"
+#include "pacs/web/endpoints/system_endpoints.hpp"
+#include "pacs/web/rest_config.hpp"
+#include "pacs/web/rest_types.hpp"
+
+#include <chrono>
+#include <random>
+#include <sstream>
+#include <string>
+
+namespace pacs::web {
+
+namespace storage_commitment {
+
+// ============================================================================
+// transaction_state helpers
+// ============================================================================
+
+std::string_view to_string(transaction_state state) noexcept {
+    switch (state) {
+        case transaction_state::pending: return "PENDING";
+        case transaction_state::success: return "SUCCESS";
+        case transaction_state::partial: return "PARTIAL";
+        case transaction_state::failure: return "FAILURE";
+    }
+    return "UNKNOWN";
+}
+
+std::optional<transaction_state> parse_state(std::string_view str) noexcept {
+    if (str == "PENDING") return transaction_state::pending;
+    if (str == "SUCCESS") return transaction_state::success;
+    if (str == "PARTIAL") return transaction_state::partial;
+    if (str == "FAILURE") return transaction_state::failure;
+    return std::nullopt;
+}
+
+// ============================================================================
+// transaction_store
+// ============================================================================
+
+void transaction_store::add(commitment_transaction txn) {
+    std::lock_guard lock(mutex_);
+    auto uid = txn.transaction_uid;
+    transactions_.emplace(std::move(uid), std::move(txn));
+}
+
+std::optional<commitment_transaction> transaction_store::find(
+    std::string_view transaction_uid) const {
+    std::lock_guard lock(mutex_);
+    auto it = transactions_.find(transaction_uid);
+    if (it != transactions_.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
+bool transaction_store::update(const commitment_transaction& txn) {
+    std::lock_guard lock(mutex_);
+    auto it = transactions_.find(txn.transaction_uid);
+    if (it != transactions_.end()) {
+        it->second = txn;
+        return true;
+    }
+    return false;
+}
+
+std::vector<commitment_transaction> transaction_store::list(size_t limit) const {
+    std::lock_guard lock(mutex_);
+    std::vector<commitment_transaction> result;
+    result.reserve(limit == 0 ? transactions_.size()
+                              : std::min(limit, transactions_.size()));
+
+    for (auto it = transactions_.rbegin(); it != transactions_.rend(); ++it) {
+        if (limit > 0 && result.size() >= limit) break;
+        result.push_back(it->second);
+    }
+    return result;
+}
+
+size_t transaction_store::size() const {
+    std::lock_guard lock(mutex_);
+    return transactions_.size();
+}
+
+// ============================================================================
+// JSON serialization
+// ============================================================================
+
+namespace {
+
+std::string format_timestamp(std::chrono::system_clock::time_point tp) {
+    auto time_t = std::chrono::system_clock::to_time_t(tp);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &time_t);
+#else
+    gmtime_r(&time_t, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return buf;
+}
+
+std::string sop_reference_to_json(const services::sop_reference& ref) {
+    return R"({"sopClassUID":")" + json_escape(ref.sop_class_uid) +
+           R"(","sopInstanceUID":")" + json_escape(ref.sop_instance_uid) + R"("})";
+}
+
+std::string failed_reference_to_json(
+    const std::pair<services::sop_reference,
+                    services::commitment_failure_reason>& entry) {
+    return R"({"sopClassUID":")" + json_escape(entry.first.sop_class_uid) +
+           R"(","sopInstanceUID":")" + json_escape(entry.first.sop_instance_uid) +
+           R"(","failureReason":")" +
+           std::string(services::to_string(entry.second)) + R"("})";
+}
+
+}  // namespace
+
+std::string transaction_to_json(const commitment_transaction& txn) {
+    std::ostringstream ss;
+    ss << R"({"transactionUID":")" << json_escape(txn.transaction_uid) << R"(",)";
+    ss << R"("state":")" << to_string(txn.state) << R"(",)";
+
+    if (!txn.study_instance_uid.empty()) {
+        ss << R"("studyInstanceUID":")" << json_escape(txn.study_instance_uid) << R"(",)";
+    }
+
+    ss << R"("createdAt":")" << format_timestamp(txn.created_at) << R"(",)";
+
+    if (txn.completed_at.has_value()) {
+        ss << R"("completedAt":")" << format_timestamp(*txn.completed_at) << R"(",)";
+    }
+
+    // Requested references
+    ss << R"("requestedReferences":[)";
+    for (size_t i = 0; i < txn.requested_references.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << sop_reference_to_json(txn.requested_references[i]);
+    }
+    ss << "],";
+
+    // Success references
+    ss << R"("successReferences":[)";
+    for (size_t i = 0; i < txn.success_references.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << sop_reference_to_json(txn.success_references[i]);
+    }
+    ss << "],";
+
+    // Failed references
+    ss << R"("failedReferences":[)";
+    for (size_t i = 0; i < txn.failed_references.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << failed_reference_to_json(txn.failed_references[i]);
+    }
+    ss << "]}";
+
+    return ss.str();
+}
+
+std::string transactions_to_json(
+    const std::vector<commitment_transaction>& transactions) {
+    std::ostringstream ss;
+    ss << "[";
+    for (size_t i = 0; i < transactions.size(); ++i) {
+        if (i > 0) ss << ",";
+        ss << transaction_to_json(transactions[i]);
+    }
+    ss << "]";
+    return ss.str();
+}
+
+// ============================================================================
+// Request parsing
+// ============================================================================
+
+namespace {
+
+// Simple JSON string extraction (finds "key":"value" pairs)
+std::string extract_json_string(std::string_view json, std::string_view key) {
+    auto key_pattern = std::string("\"") + std::string(key) + "\"";
+    auto pos = json.find(key_pattern);
+    if (pos == std::string_view::npos) return {};
+
+    pos = json.find('"', pos + key_pattern.size());
+    if (pos == std::string_view::npos) return {};
+    pos++; // skip opening quote
+
+    auto end = json.find('"', pos);
+    if (end == std::string_view::npos) return {};
+
+    return std::string(json.substr(pos, end - pos));
+}
+
+}  // namespace
+
+parse_result parse_commitment_request(
+    std::string_view json_body,
+    std::string_view study_uid) {
+
+    parse_result result;
+
+    if (json_body.empty()) {
+        result.error_message = "Request body is empty";
+        return result;
+    }
+
+    // Look for referencedSOPSequence array
+    auto seq_pos = json_body.find("\"referencedSOPSequence\"");
+    if (seq_pos == std::string_view::npos) {
+        result.error_message = "Missing referencedSOPSequence in request body";
+        return result;
+    }
+
+    // Find the array start
+    auto arr_start = json_body.find('[', seq_pos);
+    if (arr_start == std::string_view::npos) {
+        result.error_message = "Invalid referencedSOPSequence format";
+        return result;
+    }
+
+    // Find matching array end
+    size_t depth = 0;
+    size_t arr_end = std::string_view::npos;
+    for (size_t i = arr_start; i < json_body.size(); ++i) {
+        if (json_body[i] == '[') ++depth;
+        else if (json_body[i] == ']') {
+            --depth;
+            if (depth == 0) {
+                arr_end = i;
+                break;
+            }
+        }
+    }
+
+    if (arr_end == std::string_view::npos) {
+        result.error_message = "Unterminated referencedSOPSequence array";
+        return result;
+    }
+
+    // Parse individual items in the array
+    auto array_content = json_body.substr(arr_start + 1, arr_end - arr_start - 1);
+
+    // Find each object in the array
+    size_t pos = 0;
+    while (pos < array_content.size()) {
+        auto obj_start = array_content.find('{', pos);
+        if (obj_start == std::string_view::npos) break;
+
+        size_t obj_depth = 0;
+        size_t obj_end = std::string_view::npos;
+        for (size_t i = obj_start; i < array_content.size(); ++i) {
+            if (array_content[i] == '{') ++obj_depth;
+            else if (array_content[i] == '}') {
+                --obj_depth;
+                if (obj_depth == 0) {
+                    obj_end = i;
+                    break;
+                }
+            }
+        }
+
+        if (obj_end == std::string_view::npos) break;
+
+        auto obj = array_content.substr(obj_start, obj_end - obj_start + 1);
+        auto sop_class = extract_json_string(obj, "sopClassUID");
+        auto sop_instance = extract_json_string(obj, "sopInstanceUID");
+
+        if (sop_instance.empty()) {
+            result.error_message = "Missing sopInstanceUID in reference";
+            return result;
+        }
+
+        result.references.push_back({std::move(sop_class), std::move(sop_instance)});
+        pos = obj_end + 1;
+    }
+
+    if (result.references.empty()) {
+        result.error_message = "No valid SOP references found in request";
+        return result;
+    }
+
+    // Ignore study_uid parameter (used for context only)
+    (void)study_uid;
+
+    result.valid = true;
+    return result;
+}
+
+}  // namespace storage_commitment
+
+// ============================================================================
+// Endpoint Registration
+// ============================================================================
+
+namespace endpoints {
+
+namespace {
+
+void add_cors_headers(crow::response& res, const rest_server_context& ctx) {
+    if (ctx.config != nullptr && !ctx.config->cors_allowed_origins.empty()) {
+        res.add_header("Access-Control-Allow-Origin",
+                       ctx.config->cors_allowed_origins);
+    }
+}
+
+bool check_storage_commitment_auth(
+    const std::shared_ptr<rest_server_context>& ctx,
+    const crow::request& req,
+    crow::response& res,
+    const std::vector<std::string>& required_scopes) {
+    if (ctx->oauth2 && ctx->oauth2->enabled()) {
+        auto user_ctx = ctx->oauth2->authenticate(req, res);
+        if (!user_ctx) return false;
+
+        if (!required_scopes.empty()) {
+            return ctx->oauth2->require_any_scope(
+                ctx->oauth2->last_claims(), res, required_scopes);
+        }
+        return true;
+    }
+    return true;
+}
+
+std::string generate_transaction_uid() {
+    // Generate a unique transaction UID using timestamp + random
+    auto now = std::chrono::system_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                  now.time_since_epoch())
+                  .count();
+
+    static thread_local std::mt19937 gen(std::random_device{}());
+    std::uniform_int_distribution<uint32_t> dist(1, 999999);
+
+    std::ostringstream ss;
+    ss << "2.25." << ms << "." << dist(gen);
+    return ss.str();
+}
+
+void verify_instances_async(
+    std::shared_ptr<rest_server_context> ctx,
+    std::shared_ptr<storage_commitment::transaction_store> store,
+    std::string transaction_uid) {
+
+    auto txn_opt = store->find(transaction_uid);
+    if (!txn_opt) return;
+
+    auto txn = *txn_opt;
+
+    for (const auto& ref : txn.requested_references) {
+        if (!ctx->database) {
+            txn.failed_references.emplace_back(
+                ref, services::commitment_failure_reason::processing_failure);
+            continue;
+        }
+
+        auto instance = ctx->database->find_instance(ref.sop_instance_uid);
+        if (instance.has_value()) {
+            txn.success_references.push_back(ref);
+        } else {
+            txn.failed_references.emplace_back(
+                ref, services::commitment_failure_reason::no_such_object_instance);
+        }
+    }
+
+    txn.completed_at = std::chrono::system_clock::now();
+
+    if (txn.failed_references.empty()) {
+        txn.state = storage_commitment::transaction_state::success;
+    } else if (txn.success_references.empty()) {
+        txn.state = storage_commitment::transaction_state::failure;
+    } else {
+        txn.state = storage_commitment::transaction_state::partial;
+    }
+
+    store->update(txn);
+}
+
+}  // namespace
+
+void register_storage_commitment_endpoints_impl(
+    crow::SimpleApp& app,
+    std::shared_ptr<rest_server_context> ctx) {
+
+    // Shared transaction store for all requests
+    auto store = std::make_shared<storage_commitment::transaction_store>();
+
+    // POST /dicomweb/storage-commitments
+    // Request storage commitment for a list of SOP Instances
+    CROW_ROUTE(app, "/dicomweb/storage-commitments")
+        .methods(crow::HTTPMethod::POST)(
+            [ctx, store](const crow::request& req) {
+                crow::response res;
+                res.add_header("Content-Type", "application/dicom+json");
+                add_cors_headers(res, *ctx);
+
+                if (!check_storage_commitment_auth(
+                        ctx, req, res, {"dicomweb.write"})) {
+                    return res;
+                }
+
+                if (!ctx->database) {
+                    res.code = 503;
+                    res.body = make_error_json(
+                        "DATABASE_UNAVAILABLE",
+                        "Storage service is not available");
+                    return res;
+                }
+
+                auto parsed = storage_commitment::parse_commitment_request(
+                    req.body);
+
+                if (!parsed.valid) {
+                    res.code = 400;
+                    res.body = make_error_json(
+                        "INVALID_REQUEST", parsed.error_message);
+                    return res;
+                }
+
+                // Create transaction
+                storage_commitment::commitment_transaction txn;
+                txn.transaction_uid = generate_transaction_uid();
+                txn.state = storage_commitment::transaction_state::pending;
+                txn.requested_references = std::move(parsed.references);
+                txn.created_at = std::chrono::system_clock::now();
+
+                store->add(txn);
+
+                // Verify instances synchronously for simplicity
+                // (async with thread pool in production)
+                verify_instances_async(ctx, store, txn.transaction_uid);
+
+                auto result = store->find(txn.transaction_uid);
+                res.code = 202;  // Accepted
+                res.add_header("Content-Location",
+                               "/dicomweb/storage-commitments/" +
+                                   txn.transaction_uid);
+                res.body = storage_commitment::transaction_to_json(*result);
+                return res;
+            });
+
+    // POST /dicomweb/studies/{studyUID}/commitment
+    // Request storage commitment for a study
+    CROW_ROUTE(app, "/dicomweb/studies/<string>/commitment")
+        .methods(crow::HTTPMethod::POST)(
+            [ctx, store](const crow::request& req,
+                         const std::string& study_uid) {
+                crow::response res;
+                res.add_header("Content-Type", "application/dicom+json");
+                add_cors_headers(res, *ctx);
+
+                if (!check_storage_commitment_auth(
+                        ctx, req, res, {"dicomweb.write"})) {
+                    return res;
+                }
+
+                if (!ctx->database) {
+                    res.code = 503;
+                    res.body = make_error_json(
+                        "DATABASE_UNAVAILABLE",
+                        "Storage service is not available");
+                    return res;
+                }
+
+                auto parsed = storage_commitment::parse_commitment_request(
+                    req.body, study_uid);
+
+                if (!parsed.valid) {
+                    res.code = 400;
+                    res.body = make_error_json(
+                        "INVALID_REQUEST", parsed.error_message);
+                    return res;
+                }
+
+                storage_commitment::commitment_transaction txn;
+                txn.transaction_uid = generate_transaction_uid();
+                txn.state = storage_commitment::transaction_state::pending;
+                txn.requested_references = std::move(parsed.references);
+                txn.study_instance_uid = study_uid;
+                txn.created_at = std::chrono::system_clock::now();
+
+                store->add(txn);
+                verify_instances_async(ctx, store, txn.transaction_uid);
+
+                auto result = store->find(txn.transaction_uid);
+                res.code = 202;
+                res.add_header("Content-Location",
+                               "/dicomweb/storage-commitments/" +
+                                   txn.transaction_uid);
+                res.body = storage_commitment::transaction_to_json(*result);
+                return res;
+            });
+
+    // GET /dicomweb/storage-commitments/{transactionUID}
+    // Check commitment status
+    CROW_ROUTE(app, "/dicomweb/storage-commitments/<string>")
+        .methods(crow::HTTPMethod::GET)(
+            [ctx, store](const crow::request& req,
+                         const std::string& transaction_uid) {
+                crow::response res;
+                res.add_header("Content-Type", "application/dicom+json");
+                add_cors_headers(res, *ctx);
+
+                if (!check_storage_commitment_auth(
+                        ctx, req, res, {"dicomweb.read"})) {
+                    return res;
+                }
+
+                auto txn = store->find(transaction_uid);
+                if (!txn) {
+                    res.code = 404;
+                    res.body = make_error_json(
+                        "NOT_FOUND",
+                        "Transaction not found: " + transaction_uid);
+                    return res;
+                }
+
+                res.code = 200;
+                res.body = storage_commitment::transaction_to_json(*txn);
+                return res;
+            });
+
+    // GET /dicomweb/storage-commitments
+    // List all commitment transactions
+    CROW_ROUTE(app, "/dicomweb/storage-commitments")
+        .methods(crow::HTTPMethod::GET)(
+            [ctx, store](const crow::request& req) {
+                crow::response res;
+                res.add_header("Content-Type", "application/dicom+json");
+                add_cors_headers(res, *ctx);
+
+                if (!check_storage_commitment_auth(
+                        ctx, req, res, {"dicomweb.read"})) {
+                    return res;
+                }
+
+                size_t limit = 100;
+                auto limit_param = req.url_params.get("limit");
+                if (limit_param != nullptr) {
+                    try {
+                        int val = std::stoi(limit_param);
+                        if (val > 0) {
+                            limit = static_cast<size_t>(val);
+                        }
+                    } catch (...) {
+                        // Use default
+                    }
+                }
+
+                auto transactions = store->list(limit);
+                res.code = 200;
+                res.body = storage_commitment::transactions_to_json(transactions);
+                return res;
+            });
+}
+
+}  // namespace endpoints
+
+}  // namespace pacs::web

--- a/src/web/rest_server.cpp
+++ b/src/web/rest_server.cpp
@@ -114,6 +114,8 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
                                           std::shared_ptr<rest_server_context> ctx);
 void register_wado_uri_endpoints_impl(crow::SimpleApp &app,
                                       std::shared_ptr<rest_server_context> ctx);
+void register_storage_commitment_endpoints_impl(
+    crow::SimpleApp &app, std::shared_ptr<rest_server_context> ctx);
 #ifdef PACS_WITH_DATABASE_SYSTEM
 void register_metrics_endpoints_impl(crow::SimpleApp &app,
                                      std::shared_ptr<rest_server_context> ctx);
@@ -287,6 +289,7 @@ void rest_server::start_async() {
     endpoints::register_key_image_endpoints_impl(app, impl_->context);
     endpoints::register_viewer_state_endpoints_impl(app, impl_->context);
     endpoints::register_wado_uri_endpoints_impl(app, impl_->context);
+    endpoints::register_storage_commitment_endpoints_impl(app, impl_->context);
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
     endpoints::register_metrics_endpoints_impl(app, impl_->context);

--- a/tests/web/storage_commitment_endpoints_test.cpp
+++ b/tests/web/storage_commitment_endpoints_test.cpp
@@ -1,0 +1,363 @@
+/**
+ * @file storage_commitment_endpoints_test.cpp
+ * @brief Unit tests for DICOMweb Storage Commitment endpoints (Supplement 234)
+ *
+ * Tests the utility functions and data structures for storage commitment
+ * REST API. Route handler testing requires integration test setup.
+ *
+ * @see DICOM Supplement 234 -- DICOMweb Storage Commitment
+ */
+
+#include <catch2/catch_test_macros.hpp>
+
+#include "pacs/web/endpoints/storage_commitment_endpoints.hpp"
+
+using namespace pacs::web::storage_commitment;
+using namespace pacs::services;
+
+// ============================================================================
+// transaction_state tests
+// ============================================================================
+
+TEST_CASE("transaction_state to_string", "[web][storage-commitment]") {
+    CHECK(to_string(transaction_state::pending) == "PENDING");
+    CHECK(to_string(transaction_state::success) == "SUCCESS");
+    CHECK(to_string(transaction_state::partial) == "PARTIAL");
+    CHECK(to_string(transaction_state::failure) == "FAILURE");
+}
+
+TEST_CASE("transaction_state parse_state", "[web][storage-commitment]") {
+    SECTION("Valid states") {
+        auto pending = parse_state("PENDING");
+        REQUIRE(pending.has_value());
+        CHECK(*pending == transaction_state::pending);
+
+        auto success = parse_state("SUCCESS");
+        REQUIRE(success.has_value());
+        CHECK(*success == transaction_state::success);
+
+        auto partial = parse_state("PARTIAL");
+        REQUIRE(partial.has_value());
+        CHECK(*partial == transaction_state::partial);
+
+        auto failure = parse_state("FAILURE");
+        REQUIRE(failure.has_value());
+        CHECK(*failure == transaction_state::failure);
+    }
+
+    SECTION("Invalid states") {
+        CHECK_FALSE(parse_state("invalid").has_value());
+        CHECK_FALSE(parse_state("").has_value());
+        CHECK_FALSE(parse_state("pending").has_value());  // case-sensitive
+    }
+}
+
+// ============================================================================
+// transaction_store tests
+// ============================================================================
+
+TEST_CASE("transaction_store operations", "[web][storage-commitment]") {
+    transaction_store store;
+
+    SECTION("Empty store") {
+        CHECK(store.size() == 0);
+        CHECK_FALSE(store.find("1.2.3").has_value());
+        CHECK(store.list().empty());
+    }
+
+    SECTION("Add and find transaction") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.1234";
+        txn.state = transaction_state::pending;
+        txn.created_at = std::chrono::system_clock::now();
+
+        store.add(txn);
+
+        CHECK(store.size() == 1);
+        auto found = store.find("2.25.1234");
+        REQUIRE(found.has_value());
+        CHECK(found->transaction_uid == "2.25.1234");
+        CHECK(found->state == transaction_state::pending);
+    }
+
+    SECTION("Find nonexistent transaction") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.1234";
+        txn.state = transaction_state::pending;
+        txn.created_at = std::chrono::system_clock::now();
+
+        store.add(txn);
+
+        CHECK_FALSE(store.find("2.25.9999").has_value());
+    }
+
+    SECTION("Update transaction") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.5678";
+        txn.state = transaction_state::pending;
+        txn.created_at = std::chrono::system_clock::now();
+
+        store.add(txn);
+
+        txn.state = transaction_state::success;
+        txn.completed_at = std::chrono::system_clock::now();
+        CHECK(store.update(txn));
+
+        auto found = store.find("2.25.5678");
+        REQUIRE(found.has_value());
+        CHECK(found->state == transaction_state::success);
+        CHECK(found->completed_at.has_value());
+    }
+
+    SECTION("Update nonexistent transaction") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.9999";
+        txn.state = transaction_state::success;
+
+        CHECK_FALSE(store.update(txn));
+    }
+
+    SECTION("List transactions") {
+        for (int i = 0; i < 5; ++i) {
+            commitment_transaction txn;
+            txn.transaction_uid = "2.25." + std::to_string(i);
+            txn.state = transaction_state::pending;
+            txn.created_at = std::chrono::system_clock::now();
+            store.add(txn);
+        }
+
+        CHECK(store.size() == 5);
+
+        auto all = store.list();
+        CHECK(all.size() == 5);
+
+        auto limited = store.list(3);
+        CHECK(limited.size() == 3);
+    }
+}
+
+// ============================================================================
+// JSON serialization tests
+// ============================================================================
+
+TEST_CASE("transaction_to_json", "[web][storage-commitment]") {
+    SECTION("Pending transaction") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.1234";
+        txn.state = transaction_state::pending;
+        txn.created_at = std::chrono::system_clock::now();
+        txn.requested_references.push_back(
+            {"1.2.840.10008.5.1.4.1.1.2", "1.2.3.4.5"});
+
+        auto json = transaction_to_json(txn);
+
+        CHECK(json.find("\"transactionUID\":\"2.25.1234\"") != std::string::npos);
+        CHECK(json.find("\"state\":\"PENDING\"") != std::string::npos);
+        CHECK(json.find("\"requestedReferences\":[") != std::string::npos);
+        CHECK(json.find("\"sopInstanceUID\":\"1.2.3.4.5\"") != std::string::npos);
+        CHECK(json.find("\"successReferences\":[]") != std::string::npos);
+        CHECK(json.find("\"failedReferences\":[]") != std::string::npos);
+    }
+
+    SECTION("Completed transaction with successes") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.5678";
+        txn.state = transaction_state::success;
+        txn.created_at = std::chrono::system_clock::now();
+        txn.completed_at = std::chrono::system_clock::now();
+        txn.requested_references.push_back(
+            {"1.2.840.10008.5.1.4.1.1.2", "1.2.3.4.5"});
+        txn.success_references.push_back(
+            {"1.2.840.10008.5.1.4.1.1.2", "1.2.3.4.5"});
+
+        auto json = transaction_to_json(txn);
+
+        CHECK(json.find("\"state\":\"SUCCESS\"") != std::string::npos);
+        CHECK(json.find("\"completedAt\"") != std::string::npos);
+        CHECK(json.find("\"successReferences\":[{") != std::string::npos);
+    }
+
+    SECTION("Partial transaction with failures") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.9999";
+        txn.state = transaction_state::partial;
+        txn.created_at = std::chrono::system_clock::now();
+        txn.completed_at = std::chrono::system_clock::now();
+
+        txn.requested_references.push_back(
+            {"1.2.840.10008.5.1.4.1.1.2", "1.2.3.4.5"});
+        txn.requested_references.push_back(
+            {"1.2.840.10008.5.1.4.1.1.2", "6.7.8.9.10"});
+
+        txn.success_references.push_back(
+            {"1.2.840.10008.5.1.4.1.1.2", "1.2.3.4.5"});
+        txn.failed_references.emplace_back(
+            sop_reference{"1.2.840.10008.5.1.4.1.1.2", "6.7.8.9.10"},
+            commitment_failure_reason::no_such_object_instance);
+
+        auto json = transaction_to_json(txn);
+
+        CHECK(json.find("\"state\":\"PARTIAL\"") != std::string::npos);
+        CHECK(json.find("\"failedReferences\":[{") != std::string::npos);
+        CHECK(json.find("\"failureReason\"") != std::string::npos);
+        CHECK(json.find("No such object instance") != std::string::npos);
+    }
+
+    SECTION("Transaction with study UID") {
+        commitment_transaction txn;
+        txn.transaction_uid = "2.25.1111";
+        txn.state = transaction_state::pending;
+        txn.study_instance_uid = "1.2.840.10008.9.9.9";
+        txn.created_at = std::chrono::system_clock::now();
+
+        auto json = transaction_to_json(txn);
+
+        CHECK(json.find("\"studyInstanceUID\":\"1.2.840.10008.9.9.9\"") !=
+              std::string::npos);
+    }
+}
+
+TEST_CASE("transactions_to_json", "[web][storage-commitment]") {
+    SECTION("Empty list") {
+        std::vector<commitment_transaction> empty;
+        CHECK(transactions_to_json(empty) == "[]");
+    }
+
+    SECTION("Multiple transactions") {
+        std::vector<commitment_transaction> txns;
+
+        commitment_transaction t1;
+        t1.transaction_uid = "2.25.1";
+        t1.state = transaction_state::success;
+        t1.created_at = std::chrono::system_clock::now();
+        txns.push_back(t1);
+
+        commitment_transaction t2;
+        t2.transaction_uid = "2.25.2";
+        t2.state = transaction_state::pending;
+        t2.created_at = std::chrono::system_clock::now();
+        txns.push_back(t2);
+
+        auto json = transactions_to_json(txns);
+        CHECK(json.front() == '[');
+        CHECK(json.back() == ']');
+        CHECK(json.find("\"2.25.1\"") != std::string::npos);
+        CHECK(json.find("\"2.25.2\"") != std::string::npos);
+    }
+}
+
+// ============================================================================
+// Request parsing tests
+// ============================================================================
+
+TEST_CASE("parse_commitment_request", "[web][storage-commitment]") {
+    SECTION("Valid request with references") {
+        std::string body = R"({
+            "referencedSOPSequence": [
+                {
+                    "sopClassUID": "1.2.840.10008.5.1.4.1.1.2",
+                    "sopInstanceUID": "1.2.3.4.5"
+                },
+                {
+                    "sopClassUID": "1.2.840.10008.5.1.4.1.1.2",
+                    "sopInstanceUID": "6.7.8.9.10"
+                }
+            ]
+        })";
+
+        auto result = parse_commitment_request(body);
+
+        REQUIRE(result.valid);
+        REQUIRE(result.references.size() == 2);
+        CHECK(result.references[0].sop_class_uid == "1.2.840.10008.5.1.4.1.1.2");
+        CHECK(result.references[0].sop_instance_uid == "1.2.3.4.5");
+        CHECK(result.references[1].sop_instance_uid == "6.7.8.9.10");
+    }
+
+    SECTION("Single reference") {
+        std::string body = R"({
+            "referencedSOPSequence": [
+                {"sopClassUID": "1.2.3", "sopInstanceUID": "4.5.6"}
+            ]
+        })";
+
+        auto result = parse_commitment_request(body);
+
+        REQUIRE(result.valid);
+        CHECK(result.references.size() == 1);
+    }
+
+    SECTION("Empty body") {
+        auto result = parse_commitment_request("");
+
+        CHECK_FALSE(result.valid);
+        CHECK_FALSE(result.error_message.empty());
+    }
+
+    SECTION("Missing referencedSOPSequence") {
+        auto result = parse_commitment_request(R"({"other": "data"})");
+
+        CHECK_FALSE(result.valid);
+        CHECK(result.error_message.find("referencedSOPSequence") !=
+              std::string::npos);
+    }
+
+    SECTION("Empty references array") {
+        auto result = parse_commitment_request(
+            R"({"referencedSOPSequence": []})");
+
+        CHECK_FALSE(result.valid);
+    }
+
+    SECTION("Missing sopInstanceUID") {
+        auto result = parse_commitment_request(
+            R"({"referencedSOPSequence": [{"sopClassUID": "1.2.3"}]})");
+
+        CHECK_FALSE(result.valid);
+        CHECK(result.error_message.find("sopInstanceUID") != std::string::npos);
+    }
+
+    SECTION("Reference with sopInstanceUID only (no sopClassUID)") {
+        auto result = parse_commitment_request(
+            R"({"referencedSOPSequence": [{"sopInstanceUID": "1.2.3"}]})");
+
+        REQUIRE(result.valid);
+        CHECK(result.references.size() == 1);
+        CHECK(result.references[0].sop_instance_uid == "1.2.3");
+        CHECK(result.references[0].sop_class_uid.empty());
+    }
+
+    SECTION("Study UID parameter is accepted") {
+        std::string body = R"({
+            "referencedSOPSequence": [
+                {"sopClassUID": "1.2.3", "sopInstanceUID": "4.5.6"}
+            ]
+        })";
+
+        auto result = parse_commitment_request(body, "1.2.840.study.1");
+
+        REQUIRE(result.valid);
+        CHECK(result.references.size() == 1);
+    }
+}
+
+// ============================================================================
+// commitment_failure_reason integration tests
+// ============================================================================
+
+TEST_CASE("commitment_failure_reason to_string integration",
+          "[web][storage-commitment]") {
+    CHECK(pacs::services::to_string(commitment_failure_reason::processing_failure) ==
+          "Processing failure");
+    CHECK(pacs::services::to_string(commitment_failure_reason::no_such_object_instance) ==
+          "No such object instance");
+    CHECK(pacs::services::to_string(commitment_failure_reason::resource_limitation) ==
+          "Resource limitation");
+    CHECK(pacs::services::to_string(
+              commitment_failure_reason::referenced_sop_class_not_supported) ==
+          "Referenced SOP Class not supported");
+    CHECK(pacs::services::to_string(commitment_failure_reason::class_instance_conflict) ==
+          "Class/Instance conflict");
+    CHECK(pacs::services::to_string(commitment_failure_reason::duplicate_transaction_uid) ==
+          "Duplicate Transaction UID");
+}


### PR DESCRIPTION
Closes #853

## Summary
- Add DICOMweb Storage Commitment REST API (Supplement 234) with four endpoints:
  - `POST /dicomweb/storage-commitments` - Request commitment for SOP instances
  - `POST /dicomweb/studies/{uid}/commitment` - Study-level commitment request
  - `GET /dicomweb/storage-commitments/{uid}` - Poll transaction status
  - `GET /dicomweb/storage-commitments` - List all transactions
- Transaction states: PENDING, SUCCESS, PARTIAL, FAILURE
- Thread-safe in-memory transaction store
- DICOM JSON response format per PS3.18
- OAuth 2.0 scope-based authentication support
- Reuses existing `storage_commitment_types.hpp` data structures

## Test Plan
- [x] Unit tests for transaction_state serialization/parsing (76 assertions in 7 test cases)
- [x] Transaction store CRUD operations
- [x] JSON serialization for all transaction states
- [x] Request body parsing with various valid/invalid inputs
- [x] Failure reason integration from existing DIMSE types
- [x] pacs_web library builds successfully