### PR TITLE
feat(security): add BCP 195 TLS policy profiles for DICOM PS3.15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1149,6 +1149,7 @@ set(PACS_SECURITY_SOURCES
     src/security/atna_syslog_transport.cpp
     src/security/atna_service_auditor.cpp
     src/security/atna_config.cpp
+    src/security/tls_policy.cpp
 )
 
 # Digital signature sources (requires OpenSSL - Issue #191)
@@ -1953,6 +1954,7 @@ if(PACS_BUILD_TESTS)
         tests/security/atna_syslog_transport_test.cpp
         tests/security/atna_service_auditor_test.cpp
         tests/security/atna_config_test.cpp
+        tests/security/tls_policy_test.cpp
     )
 
     # Add digital signature tests if OpenSSL is available (Issue #191)

--- a/include/pacs/security/tls_policy.hpp
+++ b/include/pacs/security/tls_policy.hpp
@@ -1,0 +1,258 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+/**
+ * @file tls_policy.hpp
+ * @brief TLS security policy for BCP 195 compliance (DICOM PS3.15)
+ *
+ * Defines TLS policy profiles that enforce cipher suite restrictions,
+ * protocol version requirements, and certificate constraints as
+ * specified by BCP 195 (RFC 9325) and DICOM PS3.15.
+ *
+ * @see DICOM PS3.15 -- Security and System Management Profiles
+ * @see RFC 9325 -- Recommendations for Secure Use of TLS and DTLS
+ * @see RFC 8446 -- TLS 1.3
+ * @see RFC 8996 -- Deprecating TLS 1.0 and TLS 1.1
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace pacs::security {
+
+/**
+ * @brief TLS policy profile levels
+ *
+ * Predefined security profiles aligned with DICOM PS3.15 and BCP 195.
+ */
+enum class tls_profile {
+    /// BCP 195 basic profile: TLS 1.2 minimum, standard cipher suites
+    bcp195_basic,
+
+    /// BCP 195 non-downgrading profile: TLS 1.2+ with no downgrade
+    /// This is the DICOM PS3.15 recommended profile
+    bcp195_non_downgrading,
+
+    /// Extended profile: TLS 1.3 only, strictest cipher suites
+    bcp195_extended
+};
+
+/**
+ * @brief Convert TLS profile to string
+ */
+[[nodiscard]] std::string_view to_string(tls_profile profile) noexcept;
+
+/**
+ * @brief Parse TLS profile from string
+ */
+[[nodiscard]] std::optional<tls_profile> parse_tls_profile(
+    std::string_view str) noexcept;
+
+/**
+ * @brief TLS cipher suite specification
+ */
+struct cipher_suite_spec {
+    /// TLS 1.3 cipher suites (OpenSSL ciphersuites string format)
+    std::string tls13_ciphers;
+
+    /// TLS 1.2 cipher suites (OpenSSL cipher string format)
+    std::string tls12_ciphers;
+};
+
+/**
+ * @brief Certificate validation constraints
+ */
+struct certificate_constraints {
+    /// Minimum RSA key size in bits
+    uint16_t min_rsa_key_bits{2048};
+
+    /// Minimum ECDSA curve size (P-256 = 256, P-384 = 384)
+    uint16_t min_ecdsa_curve_bits{256};
+
+    /// Maximum certificate chain depth
+    uint8_t max_chain_depth{5};
+
+    /// Require peer certificate verification
+    bool require_peer_verification{true};
+};
+
+/**
+ * @brief TLS security policy configuration
+ *
+ * Encapsulates all TLS settings for a given security profile.
+ * Use the factory methods to create standard profiles.
+ */
+class tls_policy {
+public:
+    /**
+     * @brief Create a BCP 195 basic profile policy
+     *
+     * - Minimum TLS 1.2
+     * - Standard BCP 195 cipher suites
+     * - RSA >= 2048, ECDSA >= P-256
+     */
+    [[nodiscard]] static tls_policy bcp195_basic_profile();
+
+    /**
+     * @brief Create a BCP 195 non-downgrading profile policy
+     *
+     * - Minimum TLS 1.2, prefers TLS 1.3
+     * - No protocol downgrade allowed
+     * - Only BCP 195-compliant cipher suites
+     * - RSA >= 2048, ECDSA >= P-256
+     *
+     * This is the recommended DICOM PS3.15 profile.
+     */
+    [[nodiscard]] static tls_policy bcp195_non_downgrading_profile();
+
+    /**
+     * @brief Create an extended profile (TLS 1.3 only)
+     *
+     * - TLS 1.3 only
+     * - Strictest cipher suites
+     * - RSA >= 3072, ECDSA >= P-256
+     */
+    [[nodiscard]] static tls_policy bcp195_extended_profile();
+
+    /**
+     * @brief Create a policy from a named profile
+     */
+    [[nodiscard]] static tls_policy from_profile(tls_profile profile);
+
+    /// @name Policy Properties
+    /// @{
+
+    [[nodiscard]] tls_profile profile() const noexcept;
+    [[nodiscard]] std::string_view profile_name() const noexcept;
+
+    [[nodiscard]] uint16_t min_protocol_version() const noexcept;
+    [[nodiscard]] uint16_t max_protocol_version() const noexcept;
+
+    [[nodiscard]] bool non_downgrading() const noexcept;
+
+    [[nodiscard]] const cipher_suite_spec& cipher_suites() const noexcept;
+    [[nodiscard]] const certificate_constraints& cert_constraints() const noexcept;
+
+    /// @}
+
+    /// @name Validation
+    /// @{
+
+    /**
+     * @brief Check if a TLS version is allowed by this policy
+     * @param version OpenSSL version constant (e.g., TLS1_2_VERSION)
+     */
+    [[nodiscard]] bool is_version_allowed(uint16_t version) const noexcept;
+
+    /**
+     * @brief Check if an RSA key size meets minimum requirements
+     * @param bits RSA key size in bits
+     */
+    [[nodiscard]] bool is_rsa_key_acceptable(uint16_t bits) const noexcept;
+
+    /**
+     * @brief Check if an ECDSA curve size meets minimum requirements
+     * @param bits ECDSA curve size in bits
+     */
+    [[nodiscard]] bool is_ecdsa_key_acceptable(uint16_t bits) const noexcept;
+
+    /**
+     * @brief Get the TLS 1.3 cipher suites string for OpenSSL
+     */
+    [[nodiscard]] std::string_view tls13_ciphersuites() const noexcept;
+
+    /**
+     * @brief Get the TLS 1.2 cipher suites string for OpenSSL
+     */
+    [[nodiscard]] std::string_view tls12_ciphersuites() const noexcept;
+
+    /// @}
+
+    /// @name Predefined Cipher Suite Strings
+    /// @{
+
+    /// TLS 1.3 required cipher suites (BCP 195)
+    static constexpr std::string_view kTls13Required =
+        "TLS_AES_256_GCM_SHA384:"
+        "TLS_AES_128_GCM_SHA256:"
+        "TLS_CHACHA20_POLY1305_SHA256";
+
+    /// TLS 1.3 strict cipher suites (extended profile)
+    static constexpr std::string_view kTls13Strict =
+        "TLS_AES_256_GCM_SHA384:"
+        "TLS_CHACHA20_POLY1305_SHA256";
+
+    /// TLS 1.2 BCP 195 recommended cipher suites
+    static constexpr std::string_view kTls12Recommended =
+        "ECDHE-ECDSA-AES256-GCM-SHA384:"
+        "ECDHE-RSA-AES256-GCM-SHA384:"
+        "ECDHE-ECDSA-CHACHA20-POLY1305:"
+        "ECDHE-RSA-CHACHA20-POLY1305:"
+        "ECDHE-ECDSA-AES128-GCM-SHA256:"
+        "ECDHE-RSA-AES128-GCM-SHA256";
+
+    /// @}
+
+    /// @name Protocol Version Constants
+    /// @{
+
+    /// OpenSSL TLS version constants for reference
+    static constexpr uint16_t kTls10Version = 0x0301;
+    static constexpr uint16_t kTls11Version = 0x0302;
+    static constexpr uint16_t kTls12Version = 0x0303;
+    static constexpr uint16_t kTls13Version = 0x0304;
+
+    /// @}
+
+private:
+    tls_policy(tls_profile prof, uint16_t min_ver, uint16_t max_ver,
+               bool non_downgrade, cipher_suite_spec ciphers,
+               certificate_constraints certs);
+
+    tls_profile profile_;
+    uint16_t min_version_;
+    uint16_t max_version_;
+    bool non_downgrading_;
+    cipher_suite_spec ciphers_;
+    certificate_constraints cert_constraints_;
+};
+
+/**
+ * @brief Get a list of all available TLS profiles
+ */
+[[nodiscard]] std::vector<tls_profile> available_tls_profiles();
+
+}  // namespace pacs::security

--- a/src/security/tls_policy.cpp
+++ b/src/security/tls_policy.cpp
@@ -1,0 +1,183 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+//    list of conditions and the following disclaimer.
+//
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+//    this list of conditions and the following disclaimer in the documentation
+//    and/or other materials provided with the distribution.
+//
+// 3. Neither the name of the copyright holder nor the names of its
+//    contributors may be used to endorse or promote products derived from
+//    this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pacs/security/tls_policy.hpp"
+
+namespace pacs::security {
+
+// ============================================================================
+// tls_profile string conversion
+// ============================================================================
+
+std::string_view to_string(tls_profile profile) noexcept {
+    switch (profile) {
+        case tls_profile::bcp195_basic:
+            return "BCP195-Basic";
+        case tls_profile::bcp195_non_downgrading:
+            return "BCP195-NonDowngrading";
+        case tls_profile::bcp195_extended:
+            return "BCP195-Extended";
+    }
+    return "Unknown";
+}
+
+std::optional<tls_profile> parse_tls_profile(std::string_view str) noexcept {
+    if (str == "BCP195-Basic" || str == "basic")
+        return tls_profile::bcp195_basic;
+    if (str == "BCP195-NonDowngrading" || str == "non-downgrading")
+        return tls_profile::bcp195_non_downgrading;
+    if (str == "BCP195-Extended" || str == "extended")
+        return tls_profile::bcp195_extended;
+    return std::nullopt;
+}
+
+// ============================================================================
+// tls_policy private constructor
+// ============================================================================
+
+tls_policy::tls_policy(tls_profile prof, uint16_t min_ver, uint16_t max_ver,
+                       bool non_downgrade, cipher_suite_spec ciphers,
+                       certificate_constraints certs)
+    : profile_(prof),
+      min_version_(min_ver),
+      max_version_(max_ver),
+      non_downgrading_(non_downgrade),
+      ciphers_(std::move(ciphers)),
+      cert_constraints_(std::move(certs)) {}
+
+// ============================================================================
+// Factory methods
+// ============================================================================
+
+tls_policy tls_policy::bcp195_basic_profile() {
+    return {tls_profile::bcp195_basic,
+            kTls12Version,
+            kTls13Version,
+            false,
+            {std::string(kTls13Required), std::string(kTls12Recommended)},
+            {2048, 256, 5, true}};
+}
+
+tls_policy tls_policy::bcp195_non_downgrading_profile() {
+    return {tls_profile::bcp195_non_downgrading,
+            kTls12Version,
+            kTls13Version,
+            true,
+            {std::string(kTls13Required), std::string(kTls12Recommended)},
+            {2048, 256, 5, true}};
+}
+
+tls_policy tls_policy::bcp195_extended_profile() {
+    return {tls_profile::bcp195_extended,
+            kTls13Version,
+            kTls13Version,
+            true,
+            {std::string(kTls13Strict), ""},
+            {3072, 256, 4, true}};
+}
+
+tls_policy tls_policy::from_profile(tls_profile profile) {
+    switch (profile) {
+        case tls_profile::bcp195_basic:
+            return bcp195_basic_profile();
+        case tls_profile::bcp195_non_downgrading:
+            return bcp195_non_downgrading_profile();
+        case tls_profile::bcp195_extended:
+            return bcp195_extended_profile();
+    }
+    return bcp195_non_downgrading_profile();
+}
+
+// ============================================================================
+// Property accessors
+// ============================================================================
+
+tls_profile tls_policy::profile() const noexcept {
+    return profile_;
+}
+
+std::string_view tls_policy::profile_name() const noexcept {
+    return to_string(profile_);
+}
+
+uint16_t tls_policy::min_protocol_version() const noexcept {
+    return min_version_;
+}
+
+uint16_t tls_policy::max_protocol_version() const noexcept {
+    return max_version_;
+}
+
+bool tls_policy::non_downgrading() const noexcept {
+    return non_downgrading_;
+}
+
+const cipher_suite_spec& tls_policy::cipher_suites() const noexcept {
+    return ciphers_;
+}
+
+const certificate_constraints& tls_policy::cert_constraints() const noexcept {
+    return cert_constraints_;
+}
+
+// ============================================================================
+// Validation
+// ============================================================================
+
+bool tls_policy::is_version_allowed(uint16_t version) const noexcept {
+    return version >= min_version_ && version <= max_version_;
+}
+
+bool tls_policy::is_rsa_key_acceptable(uint16_t bits) const noexcept {
+    return bits >= cert_constraints_.min_rsa_key_bits;
+}
+
+bool tls_policy::is_ecdsa_key_acceptable(uint16_t bits) const noexcept {
+    return bits >= cert_constraints_.min_ecdsa_curve_bits;
+}
+
+std::string_view tls_policy::tls13_ciphersuites() const noexcept {
+    return ciphers_.tls13_ciphers;
+}
+
+std::string_view tls_policy::tls12_ciphersuites() const noexcept {
+    return ciphers_.tls12_ciphers;
+}
+
+// ============================================================================
+// Utility functions
+// ============================================================================
+
+std::vector<tls_profile> available_tls_profiles() {
+    return {tls_profile::bcp195_basic,
+            tls_profile::bcp195_non_downgrading,
+            tls_profile::bcp195_extended};
+}
+
+}  // namespace pacs::security

--- a/tests/security/tls_policy_test.cpp
+++ b/tests/security/tls_policy_test.cpp
@@ -1,0 +1,309 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "pacs/security/tls_policy.hpp"
+
+using namespace pacs::security;
+
+// ============================================================================
+// tls_profile enum tests
+// ============================================================================
+
+TEST_CASE("tls_profile to_string", "[security][tls]") {
+    CHECK(to_string(tls_profile::bcp195_basic) == "BCP195-Basic");
+    CHECK(to_string(tls_profile::bcp195_non_downgrading) == "BCP195-NonDowngrading");
+    CHECK(to_string(tls_profile::bcp195_extended) == "BCP195-Extended");
+}
+
+TEST_CASE("tls_profile parse_tls_profile", "[security][tls]") {
+    SECTION("Full names") {
+        auto basic = parse_tls_profile("BCP195-Basic");
+        REQUIRE(basic.has_value());
+        CHECK(*basic == tls_profile::bcp195_basic);
+
+        auto nd = parse_tls_profile("BCP195-NonDowngrading");
+        REQUIRE(nd.has_value());
+        CHECK(*nd == tls_profile::bcp195_non_downgrading);
+
+        auto ext = parse_tls_profile("BCP195-Extended");
+        REQUIRE(ext.has_value());
+        CHECK(*ext == tls_profile::bcp195_extended);
+    }
+
+    SECTION("Short names") {
+        auto basic = parse_tls_profile("basic");
+        REQUIRE(basic.has_value());
+        CHECK(*basic == tls_profile::bcp195_basic);
+
+        auto nd = parse_tls_profile("non-downgrading");
+        REQUIRE(nd.has_value());
+        CHECK(*nd == tls_profile::bcp195_non_downgrading);
+
+        auto ext = parse_tls_profile("extended");
+        REQUIRE(ext.has_value());
+        CHECK(*ext == tls_profile::bcp195_extended);
+    }
+
+    SECTION("Invalid names") {
+        CHECK_FALSE(parse_tls_profile("invalid").has_value());
+        CHECK_FALSE(parse_tls_profile("").has_value());
+        CHECK_FALSE(parse_tls_profile("BASIC").has_value());
+    }
+}
+
+// ============================================================================
+// BCP 195 Basic Profile tests
+// ============================================================================
+
+TEST_CASE("tls_policy BCP 195 basic profile", "[security][tls]") {
+    auto policy = tls_policy::bcp195_basic_profile();
+
+    SECTION("Profile properties") {
+        CHECK(policy.profile() == tls_profile::bcp195_basic);
+        CHECK(policy.profile_name() == "BCP195-Basic");
+        CHECK_FALSE(policy.non_downgrading());
+    }
+
+    SECTION("Protocol version requirements") {
+        CHECK(policy.min_protocol_version() == tls_policy::kTls12Version);
+        CHECK(policy.max_protocol_version() == tls_policy::kTls13Version);
+
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls10Version));
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls11Version));
+        CHECK(policy.is_version_allowed(tls_policy::kTls12Version));
+        CHECK(policy.is_version_allowed(tls_policy::kTls13Version));
+    }
+
+    SECTION("Cipher suites are configured") {
+        CHECK_FALSE(policy.tls13_ciphersuites().empty());
+        CHECK_FALSE(policy.tls12_ciphersuites().empty());
+
+        // Must contain required TLS 1.3 ciphers
+        auto tls13 = policy.tls13_ciphersuites();
+        CHECK(tls13.find("TLS_AES_256_GCM_SHA384") != std::string_view::npos);
+        CHECK(tls13.find("TLS_AES_128_GCM_SHA256") != std::string_view::npos);
+
+        // Must contain ECDHE-based TLS 1.2 ciphers
+        auto tls12 = policy.tls12_ciphersuites();
+        CHECK(tls12.find("ECDHE") != std::string_view::npos);
+        CHECK(tls12.find("GCM") != std::string_view::npos);
+    }
+
+    SECTION("Certificate constraints") {
+        CHECK(policy.cert_constraints().min_rsa_key_bits == 2048);
+        CHECK(policy.cert_constraints().min_ecdsa_curve_bits == 256);
+        CHECK(policy.cert_constraints().require_peer_verification);
+
+        CHECK(policy.is_rsa_key_acceptable(2048));
+        CHECK(policy.is_rsa_key_acceptable(4096));
+        CHECK_FALSE(policy.is_rsa_key_acceptable(1024));
+
+        CHECK(policy.is_ecdsa_key_acceptable(256));
+        CHECK(policy.is_ecdsa_key_acceptable(384));
+        CHECK_FALSE(policy.is_ecdsa_key_acceptable(128));
+    }
+}
+
+// ============================================================================
+// BCP 195 Non-Downgrading Profile tests
+// ============================================================================
+
+TEST_CASE("tls_policy BCP 195 non-downgrading profile", "[security][tls]") {
+    auto policy = tls_policy::bcp195_non_downgrading_profile();
+
+    SECTION("Profile properties") {
+        CHECK(policy.profile() == tls_profile::bcp195_non_downgrading);
+        CHECK(policy.profile_name() == "BCP195-NonDowngrading");
+        CHECK(policy.non_downgrading());
+    }
+
+    SECTION("Protocol version requirements") {
+        CHECK(policy.min_protocol_version() == tls_policy::kTls12Version);
+        CHECK(policy.max_protocol_version() == tls_policy::kTls13Version);
+
+        // TLS 1.0 and 1.1 must be rejected
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls10Version));
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls11Version));
+
+        // TLS 1.2 and 1.3 must be accepted
+        CHECK(policy.is_version_allowed(tls_policy::kTls12Version));
+        CHECK(policy.is_version_allowed(tls_policy::kTls13Version));
+    }
+
+    SECTION("Non-downgrading flag is set") {
+        CHECK(policy.non_downgrading());
+    }
+
+    SECTION("Cipher suites match BCP 195 requirements") {
+        auto tls13 = policy.tls13_ciphersuites();
+        CHECK(tls13.find("TLS_AES_256_GCM_SHA384") != std::string_view::npos);
+        CHECK(tls13.find("TLS_AES_128_GCM_SHA256") != std::string_view::npos);
+        CHECK(tls13.find("TLS_CHACHA20_POLY1305_SHA256") != std::string_view::npos);
+
+        auto tls12 = policy.tls12_ciphersuites();
+        CHECK(tls12.find("ECDHE-ECDSA-AES256-GCM-SHA384") != std::string_view::npos);
+        CHECK(tls12.find("ECDHE-RSA-AES256-GCM-SHA384") != std::string_view::npos);
+        CHECK(tls12.find("ECDHE-RSA-AES128-GCM-SHA256") != std::string_view::npos);
+    }
+
+    SECTION("Certificate constraints match DICOM PS3.15") {
+        CHECK(policy.cert_constraints().min_rsa_key_bits == 2048);
+        CHECK(policy.cert_constraints().min_ecdsa_curve_bits == 256);
+        CHECK(policy.cert_constraints().max_chain_depth == 5);
+    }
+}
+
+// ============================================================================
+// BCP 195 Extended Profile tests
+// ============================================================================
+
+TEST_CASE("tls_policy BCP 195 extended profile", "[security][tls]") {
+    auto policy = tls_policy::bcp195_extended_profile();
+
+    SECTION("Profile properties") {
+        CHECK(policy.profile() == tls_profile::bcp195_extended);
+        CHECK(policy.profile_name() == "BCP195-Extended");
+        CHECK(policy.non_downgrading());
+    }
+
+    SECTION("TLS 1.3 only") {
+        CHECK(policy.min_protocol_version() == tls_policy::kTls13Version);
+        CHECK(policy.max_protocol_version() == tls_policy::kTls13Version);
+
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls10Version));
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls11Version));
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls12Version));
+        CHECK(policy.is_version_allowed(tls_policy::kTls13Version));
+    }
+
+    SECTION("Strict cipher suites") {
+        auto tls13 = policy.tls13_ciphersuites();
+        CHECK(tls13.find("TLS_AES_256_GCM_SHA384") != std::string_view::npos);
+        CHECK(tls13.find("TLS_CHACHA20_POLY1305_SHA256") != std::string_view::npos);
+
+        // No TLS 1.2 ciphers in extended profile
+        CHECK(policy.tls12_ciphersuites().empty());
+    }
+
+    SECTION("Stricter certificate requirements") {
+        CHECK(policy.cert_constraints().min_rsa_key_bits == 3072);
+        CHECK(policy.cert_constraints().min_ecdsa_curve_bits == 256);
+        CHECK(policy.cert_constraints().max_chain_depth == 4);
+
+        CHECK_FALSE(policy.is_rsa_key_acceptable(2048));
+        CHECK(policy.is_rsa_key_acceptable(3072));
+        CHECK(policy.is_rsa_key_acceptable(4096));
+    }
+}
+
+// ============================================================================
+// from_profile factory method
+// ============================================================================
+
+TEST_CASE("tls_policy from_profile", "[security][tls]") {
+    SECTION("Basic profile") {
+        auto policy = tls_policy::from_profile(tls_profile::bcp195_basic);
+        CHECK(policy.profile() == tls_profile::bcp195_basic);
+        CHECK_FALSE(policy.non_downgrading());
+    }
+
+    SECTION("Non-downgrading profile") {
+        auto policy = tls_policy::from_profile(tls_profile::bcp195_non_downgrading);
+        CHECK(policy.profile() == tls_profile::bcp195_non_downgrading);
+        CHECK(policy.non_downgrading());
+    }
+
+    SECTION("Extended profile") {
+        auto policy = tls_policy::from_profile(tls_profile::bcp195_extended);
+        CHECK(policy.profile() == tls_profile::bcp195_extended);
+        CHECK(policy.min_protocol_version() == tls_policy::kTls13Version);
+    }
+}
+
+// ============================================================================
+// Protocol version constants
+// ============================================================================
+
+TEST_CASE("tls_policy protocol version constants", "[security][tls]") {
+    // Verify constants match OpenSSL TLS version encoding
+    CHECK(tls_policy::kTls10Version == 0x0301);
+    CHECK(tls_policy::kTls11Version == 0x0302);
+    CHECK(tls_policy::kTls12Version == 0x0303);
+    CHECK(tls_policy::kTls13Version == 0x0304);
+
+    // Verify ordering
+    CHECK(tls_policy::kTls10Version < tls_policy::kTls11Version);
+    CHECK(tls_policy::kTls11Version < tls_policy::kTls12Version);
+    CHECK(tls_policy::kTls12Version < tls_policy::kTls13Version);
+}
+
+// ============================================================================
+// Cipher suite constants
+// ============================================================================
+
+TEST_CASE("tls_policy cipher suite constants", "[security][tls]") {
+    SECTION("TLS 1.3 required ciphers") {
+        auto ciphers = tls_policy::kTls13Required;
+        CHECK(ciphers.find("TLS_AES_256_GCM_SHA384") != std::string_view::npos);
+        CHECK(ciphers.find("TLS_AES_128_GCM_SHA256") != std::string_view::npos);
+        CHECK(ciphers.find("TLS_CHACHA20_POLY1305_SHA256") != std::string_view::npos);
+    }
+
+    SECTION("TLS 1.3 strict ciphers") {
+        auto ciphers = tls_policy::kTls13Strict;
+        CHECK(ciphers.find("TLS_AES_256_GCM_SHA384") != std::string_view::npos);
+        // AES-128 not in strict profile
+        CHECK(ciphers.find("TLS_AES_128_GCM_SHA256") == std::string_view::npos);
+    }
+
+    SECTION("TLS 1.2 recommended ciphers use ECDHE only") {
+        auto ciphers = tls_policy::kTls12Recommended;
+        // All entries must use ECDHE (forward secrecy)
+        CHECK(ciphers.find("ECDHE") != std::string_view::npos);
+        // No DHE-only (non-ECDHE) or RSA-only key exchange
+        CHECK(ciphers.find(":DHE-RSA-AES") == std::string_view::npos);
+        // All must use GCM (AEAD)
+        CHECK(ciphers.find("GCM") != std::string_view::npos);
+        // No CBC mode
+        CHECK(ciphers.find("CBC") == std::string_view::npos);
+    }
+}
+
+// ============================================================================
+// available_tls_profiles
+// ============================================================================
+
+TEST_CASE("available_tls_profiles", "[security][tls]") {
+    auto profiles = available_tls_profiles();
+
+    CHECK(profiles.size() == 3);
+    CHECK(profiles[0] == tls_profile::bcp195_basic);
+    CHECK(profiles[1] == tls_profile::bcp195_non_downgrading);
+    CHECK(profiles[2] == tls_profile::bcp195_extended);
+}
+
+// ============================================================================
+// Version rejection tests (BCP 195 compliance)
+// ============================================================================
+
+TEST_CASE("All profiles reject TLS 1.0 and 1.1", "[security][tls]") {
+    auto profiles = available_tls_profiles();
+
+    for (auto prof : profiles) {
+        auto policy = tls_policy::from_profile(prof);
+
+        INFO("Profile: " << to_string(prof));
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls10Version));
+        CHECK_FALSE(policy.is_version_allowed(tls_policy::kTls11Version));
+    }
+}
+
+TEST_CASE("All profiles require peer verification", "[security][tls]") {
+    auto profiles = available_tls_profiles();
+
+    for (auto prof : profiles) {
+        auto policy = tls_policy::from_profile(prof);
+
+        INFO("Profile: " << to_string(prof));
+        CHECK(policy.cert_constraints().require_peer_verification);
+    }
+}


### PR DESCRIPTION
Closes #854

## Summary
- Add `tls_policy` class with three BCP 195 security profiles:
  - **Basic** (`bcp195_basic`): TLS 1.2 minimum, BCP 195 cipher suites, RSA >= 2048
  - **Non-Downgrading** (`bcp195_non_downgrading`): TLS 1.2+ with downgrade prevention (DICOM PS3.15 recommended)
  - **Extended** (`bcp195_extended`): TLS 1.3 only, strict ciphers, RSA >= 3072
- Predefined cipher suite constants for TLS 1.2 and 1.3 (ECDHE + GCM/ChaCha20 only)
- Certificate constraints: minimum RSA/ECDSA key sizes, chain depth, peer verification
- Protocol version validation rejecting TLS 1.0/1.1 per RFC 8996
- Profile string parsing for configuration files

## Test Plan
- [x] All TLS policy tests pass (114 assertions in 11 test cases)
- [x] Profile serialization/parsing (full and short names)
- [x] All profiles reject TLS 1.0 and 1.1
- [x] All profiles require peer verification
- [x] Basic/Non-Downgrading accept TLS 1.2 and 1.3
- [x] Extended accepts TLS 1.3 only
- [x] Certificate key size validation for RSA and ECDSA
- [x] Cipher suite strings contain only approved algorithms
- [x] Protocol version constant ordering verified