### PR TITLE
feat(deps): pin Crow web framework to v1.3.1 release tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -726,14 +726,15 @@ endif()
 FetchContent_Declare(
     Crow
     GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
-    GIT_TAG master  # Use master for ASIO 1.30+ compatibility (io_context vs io_service)
+    GIT_TAG v1.3.1  # Pinned release; compatible with ASIO 1.30+ io_context (IEC 62304 §8.1.2)
+    GIT_SHALLOW TRUE
 )
 set(CROW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
 set(CROW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
 set(CROW_ENABLE_SSL OFF CACHE BOOL "" FORCE)
 set(CROW_ENABLE_COMPRESSION OFF CACHE BOOL "" FORCE)
 FetchContent_MakeAvailable(Crow)
-message(STATUS "  [OK] Crow (master) fetched")
+message(STATUS "  [OK] Crow (v1.3.1) fetched")
 
 ##################################################
 # Dependency Chain Validation


### PR DESCRIPTION
## Summary
- Pin Crow web framework from floating `master` to `v1.3.1` release tag
- Add `GIT_SHALLOW TRUE` for faster CI fetches
- Ensures IEC 62304 §8.1.2 SOUP traceability with reproducible builds

Closes #877

## What Changed

| File | Change |
|------|--------|
| `CMakeLists.txt` | `GIT_TAG master` -> `GIT_TAG v1.3.1`, add `GIT_SHALLOW TRUE` |

## Why v1.3.1
- Latest stable Crow release
- Compatible with ASIO 1.30+ `io_context` (verified from Crow changelog)
- Original comment noted `master` was needed for ASIO 1.30+ compatibility, which is satisfied by v1.3.1

## Test Plan
- [x] CI builds pass on all platforms (Ubuntu, macOS, Windows)
- [x] REST API / DICOMweb endpoints work correctly
- [x] Crow HTTP server starts and responds to requests