### PR TITLE
Define canonical PACS storage repository sets

### DIFF
--- a/docs/adr/ADR-002-pacs-storage-port-segmentation.md
+++ b/docs/adr/ADR-002-pacs-storage-port-segmentation.md
@@ -1,0 +1,149 @@
+# ADR-002: Define PACS Storage Port Segmentation
+
+> **Status:** Accepted
+> **Date:** 2026-03-09
+> **Decision Makers:** pacs_system core team
+> **Related Issues:** [#891](https://github.com/kcenon/pacs_system/issues/891), [#892](https://github.com/kcenon/pacs_system/issues/892), #893, #894, #896, #897
+
+---
+
+## Context
+
+The PACS storage layer currently mixes three different shapes of persistence access:
+
+1. Canonical split repositories already backed by `pacs_database_adapter`
+2. Aggregate compatibility repositories that bundle multiple persistence concerns
+3. Large mixed storage classes such as `index_database` that still own several PACS persistence ports
+
+This makes it difficult for higher-level PACS services to depend on a stable repository-set contract and obscures which persistence responsibilities belong to PACS versus `database_system`.
+
+---
+
+## Decision
+
+We will standardize PACS storage around two explicit contracts:
+
+1. A **canonical repository-set contract** for higher-level PACS wiring
+2. A **compatibility repository-set contract** used only during incremental migration away from aggregate repositories
+
+The canonical contract is exposed through `repository_factory::canonical_repositories()` and is grouped by PACS-owned persistence ports. Aggregate repositories remain available through `repository_factory::compatibility_repositories()` until the migration phases complete.
+
+`database_system` remains an infrastructure dependency only. PACS owns the port model, repository boundaries, and persistence semantics.
+
+---
+
+## Port Inventory
+
+| Domain | PACS storage port | Primary contract | Current implementation | Compatibility adapter | Ownership |
+|--------|-------------------|------------------|------------------------|-----------------------|-----------|
+| Metadata | patient metadata | `index_database` | `index_database` patient APIs | None | PACS domain |
+| Metadata | study metadata | `index_database` | `index_database` study APIs | None | PACS domain |
+| Metadata | series metadata | `index_database` | `index_database` series APIs | None | PACS domain |
+| Metadata | instance metadata | `index_database` | `index_database` instance APIs | None | PACS domain |
+| Lifecycle | audit trail | `index_database` | `index_database` audit APIs | None | PACS domain |
+| Lifecycle | modality worklist | `index_database` | `index_database` worklist APIs | None | PACS domain |
+| Lifecycle | UPS workitems | `index_database` | `index_database` UPS APIs | None | PACS domain |
+| Lifecycle | schema migration history | `index_database` / `migration_runner` | `index_database`, `migration_runner` | None | PACS domain |
+| Lifecycle | storage commitment | `commitment_repository` | `commitment_repository` | None | PACS domain |
+| Client state | sync configuration | `sync_config_repository` | `sync_config_repository` | `sync_repository` | PACS domain |
+| Client state | sync conflicts | `sync_conflict_repository` | `sync_conflict_repository` | `sync_repository` | PACS domain |
+| Client state | sync history | `sync_history_repository` | `sync_history_repository` | `sync_repository` | PACS domain |
+| Client state | viewer state records | `viewer_state_record_repository` | `viewer_state_record_repository` | `viewer_state_repository` | PACS domain |
+| Client state | recent studies | `recent_study_repository` | `recent_study_repository` | `viewer_state_repository` | PACS domain |
+| Client state | prefetch rules | `prefetch_rule_repository` | `prefetch_rule_repository` | `prefetch_repository` | PACS domain |
+| Client state | prefetch history | `prefetch_history_repository` | `prefetch_history_repository` | `prefetch_repository` | PACS domain |
+| Client state | jobs | `job_repository` | `job_repository` | None | PACS domain |
+| Client state | routing rules | `routing_repository` | `routing_repository` | None | PACS domain |
+| Client state | remote nodes | `node_repository` | `node_repository` | None | PACS domain |
+| Client state | annotations | `annotation_repository` | `annotation_repository` | None | PACS domain |
+| Client state | key images | `key_image_repository` | `key_image_repository` | None | PACS domain |
+| Client state | measurements | `measurement_repository` | `measurement_repository` | None | PACS domain |
+
+---
+
+## Canonical Repository Set
+
+Higher-level PACS services should depend on the following canonical repository groups:
+
+- `sync_repository_set`
+  - `sync_config_repository`
+  - `sync_conflict_repository`
+  - `sync_history_repository`
+- `viewer_state_repository_set`
+  - `viewer_state_record_repository`
+  - `recent_study_repository`
+- `prefetch_repository_set`
+  - `prefetch_rule_repository`
+  - `prefetch_history_repository`
+- standalone canonical repositories
+  - `job_repository`
+  - `routing_repository`
+  - `node_repository`
+  - `annotation_repository`
+  - `key_image_repository`
+  - `measurement_repository`
+  - `commitment_repository`
+
+Aggregate repositories are classified as compatibility-only:
+
+- `sync_repository`
+- `viewer_state_repository`
+- `prefetch_repository`
+
+These compatibility repositories may remain temporarily for migration windows, but new service wiring must not introduce new dependencies on them.
+
+---
+
+## Ownership Boundary
+
+### PACS owns
+
+- Port names and repository segmentation
+- Entity-specific persistence semantics
+- Compatibility adapters required during PACS-internal migration
+- Rules about which higher layers may depend on which repositories
+
+### `database_system` owns
+
+- Connection management
+- Transactions and unit-of-work primitives
+- Backend selection
+- Query building and low-level execution helpers
+
+PACS higher layers must not depend on raw SQL execution helpers or backend-specific APIs directly.
+
+---
+
+## Allowed Exceptions
+
+Raw SQL or native-backend seams are allowed only for the following categories:
+
+1. DDL and schema migrations in `migration_runner`
+2. Explicitly documented metadata/lifecycle seams that still live inside `index_database` until later decomposition phases
+3. Backend bootstrap and infrastructure-only code that does not encode PACS domain semantics
+
+These exceptions do **not** permit higher-level PACS services or repositories to construct new ad hoc SQL strings outside documented storage boundaries.
+
+---
+
+## Consequences
+
+### Positive
+
+1. Higher-level services can target a stable PACS-owned repository-set contract
+2. Aggregate repositories are clearly marked as migration shims instead of primary contracts
+3. Later phases can replace `index_database` internals without changing the port map
+4. PACS/domain ownership is separated more cleanly from `database_system` infrastructure responsibilities
+
+### Tradeoffs
+
+1. The metadata and lifecycle domains still rely on `index_database` until later phases
+2. Compatibility adapters remain temporarily to preserve incremental delivery
+
+---
+
+## Follow-up Work
+
+1. #893 will replace raw adapter access with PACS session and unit-of-work boundaries
+2. #894 will move more wiring to repository-set contracts
+3. #896 and #897 will split `index_database` and remove legacy fallback paths

--- a/include/pacs/storage/repository_factory.hpp
+++ b/include/pacs/storage/repository_factory.hpp
@@ -57,11 +57,75 @@ class annotation_repository;
 class routing_repository;
 class node_repository;
 class sync_repository;
+class sync_config_repository;
+class sync_conflict_repository;
+class sync_history_repository;
 class key_image_repository;
 class measurement_repository;
 class viewer_state_repository;
+class viewer_state_record_repository;
+class recent_study_repository;
 class prefetch_repository;
+class prefetch_rule_repository;
+class prefetch_history_repository;
 class commitment_repository;
+
+/**
+ * @brief Canonical sync repository set for higher-level PACS wiring
+ */
+struct sync_repository_set {
+    std::shared_ptr<sync_config_repository> configs;
+    std::shared_ptr<sync_conflict_repository> conflicts;
+    std::shared_ptr<sync_history_repository> history;
+};
+
+/**
+ * @brief Canonical viewer-state repository set for higher-level PACS wiring
+ */
+struct viewer_state_repository_set {
+    std::shared_ptr<viewer_state_record_repository> records;
+    std::shared_ptr<recent_study_repository> recent_studies;
+};
+
+/**
+ * @brief Canonical prefetch repository set for higher-level PACS wiring
+ */
+struct prefetch_repository_set {
+    std::shared_ptr<prefetch_rule_repository> rules;
+    std::shared_ptr<prefetch_history_repository> history;
+};
+
+/**
+ * @brief Canonical PACS repository-set contract for higher-level service wiring
+ *
+ * This contract exposes the split repositories that own PACS persistence
+ * semantics. Higher-level services should prefer this set over aggregate
+ * compatibility repositories.
+ */
+struct canonical_repository_set {
+    std::shared_ptr<job_repository> jobs;
+    std::shared_ptr<annotation_repository> annotations;
+    std::shared_ptr<routing_repository> routing_rules;
+    std::shared_ptr<node_repository> nodes;
+    sync_repository_set sync;
+    std::shared_ptr<key_image_repository> key_images;
+    std::shared_ptr<measurement_repository> measurements;
+    viewer_state_repository_set viewer_state;
+    prefetch_repository_set prefetch;
+    std::shared_ptr<commitment_repository> commitments;
+};
+
+/**
+ * @brief Compatibility repository contract kept for incremental migration
+ *
+ * These aggregate repositories remain available while higher layers are moved
+ * to canonical split repository sets.
+ */
+struct compatibility_repository_set {
+    std::shared_ptr<sync_repository> sync_states;
+    std::shared_ptr<viewer_state_repository> viewer_states;
+    std::shared_ptr<prefetch_repository> prefetch_queue;
+};
 
 /**
  * @brief Factory for creating repository instances with shared database
@@ -161,11 +225,31 @@ public:
     [[nodiscard]] auto nodes() -> std::shared_ptr<node_repository>;
 
     /**
-     * @brief Get or create sync repository
+     * @brief Get or create aggregate sync repository
      *
+     * Compatibility-only contract. Prefer sync_configs(), sync_conflicts(),
+     * and sync_history() for new higher-level wiring.
      * @return Shared pointer to sync repository
      */
     [[nodiscard]] auto sync_states() -> std::shared_ptr<sync_repository>;
+
+    /**
+     * @brief Get or create canonical sync config repository
+     */
+    [[nodiscard]] auto sync_configs()
+        -> std::shared_ptr<sync_config_repository>;
+
+    /**
+     * @brief Get or create canonical sync conflict repository
+     */
+    [[nodiscard]] auto sync_conflicts()
+        -> std::shared_ptr<sync_conflict_repository>;
+
+    /**
+     * @brief Get or create canonical sync history repository
+     */
+    [[nodiscard]] auto sync_history()
+        -> std::shared_ptr<sync_history_repository>;
 
     /**
      * @brief Get or create key image repository
@@ -183,20 +267,48 @@ public:
         -> std::shared_ptr<measurement_repository>;
 
     /**
-     * @brief Get or create viewer state repository
+     * @brief Get or create aggregate viewer state repository
      *
+     * Compatibility-only contract. Prefer viewer_state_records() and
+     * recent_studies() for new higher-level wiring.
      * @return Shared pointer to viewer state repository
      */
     [[nodiscard]] auto viewer_states()
         -> std::shared_ptr<viewer_state_repository>;
 
     /**
-     * @brief Get or create prefetch repository
+     * @brief Get or create canonical viewer state record repository
+     */
+    [[nodiscard]] auto viewer_state_records()
+        -> std::shared_ptr<viewer_state_record_repository>;
+
+    /**
+     * @brief Get or create canonical recent study repository
+     */
+    [[nodiscard]] auto recent_studies()
+        -> std::shared_ptr<recent_study_repository>;
+
+    /**
+     * @brief Get or create aggregate prefetch repository
      *
+     * Compatibility-only contract. Prefer prefetch_rules() and
+     * prefetch_history() for new higher-level wiring.
      * @return Shared pointer to prefetch repository
      */
     [[nodiscard]] auto prefetch_queue()
         -> std::shared_ptr<prefetch_repository>;
+
+    /**
+     * @brief Get or create canonical prefetch rule repository
+     */
+    [[nodiscard]] auto prefetch_rules()
+        -> std::shared_ptr<prefetch_rule_repository>;
+
+    /**
+     * @brief Get or create canonical prefetch history repository
+     */
+    [[nodiscard]] auto prefetch_history()
+        -> std::shared_ptr<prefetch_history_repository>;
 
     /**
      * @brief Get or create commitment repository
@@ -205,6 +317,17 @@ public:
      */
     [[nodiscard]] auto commitments()
         -> std::shared_ptr<commitment_repository>;
+
+    /**
+     * @brief Get canonical repository set for higher-level service wiring
+     */
+    [[nodiscard]] auto canonical_repositories() -> canonical_repository_set;
+
+    /**
+     * @brief Get compatibility-only aggregate repository set
+     */
+    [[nodiscard]] auto compatibility_repositories()
+        -> compatibility_repository_set;
 
     /**
      * @brief Get the database adapter
@@ -223,10 +346,17 @@ private:
     std::shared_ptr<routing_repository> routing_rules_;
     std::shared_ptr<node_repository> nodes_;
     std::shared_ptr<sync_repository> sync_states_;
+    std::shared_ptr<sync_config_repository> sync_configs_;
+    std::shared_ptr<sync_conflict_repository> sync_conflicts_;
+    std::shared_ptr<sync_history_repository> sync_history_;
     std::shared_ptr<key_image_repository> key_images_;
     std::shared_ptr<measurement_repository> measurements_;
     std::shared_ptr<viewer_state_repository> viewer_states_;
+    std::shared_ptr<viewer_state_record_repository> viewer_state_records_;
+    std::shared_ptr<recent_study_repository> recent_studies_;
     std::shared_ptr<prefetch_repository> prefetch_queue_;
+    std::shared_ptr<prefetch_rule_repository> prefetch_rules_;
+    std::shared_ptr<prefetch_history_repository> prefetch_history_;
     std::shared_ptr<commitment_repository> commitments_;
 };
 

--- a/src/storage/repository_factory.cpp
+++ b/src/storage/repository_factory.cpp
@@ -51,9 +51,16 @@
 #include "pacs/storage/key_image_repository.hpp"
 #include "pacs/storage/measurement_repository.hpp"
 #include "pacs/storage/node_repository.hpp"
+#include "pacs/storage/prefetch_history_repository.hpp"
 #include "pacs/storage/prefetch_repository.hpp"
+#include "pacs/storage/prefetch_rule_repository.hpp"
 #include "pacs/storage/routing_repository.hpp"
+#include "pacs/storage/recent_study_repository.hpp"
+#include "pacs/storage/sync_config_repository.hpp"
+#include "pacs/storage/sync_conflict_repository.hpp"
+#include "pacs/storage/sync_history_repository.hpp"
 #include "pacs/storage/sync_repository.hpp"
+#include "pacs/storage/viewer_state_record_repository.hpp"
 #include "pacs/storage/viewer_state_repository.hpp"
 
 namespace pacs::storage {
@@ -99,6 +106,30 @@ auto repository_factory::sync_states() -> std::shared_ptr<sync_repository> {
     return sync_states_;
 }
 
+auto repository_factory::sync_configs()
+    -> std::shared_ptr<sync_config_repository> {
+    if (!sync_configs_) {
+        sync_configs_ = std::make_shared<sync_config_repository>(db_);
+    }
+    return sync_configs_;
+}
+
+auto repository_factory::sync_conflicts()
+    -> std::shared_ptr<sync_conflict_repository> {
+    if (!sync_conflicts_) {
+        sync_conflicts_ = std::make_shared<sync_conflict_repository>(db_);
+    }
+    return sync_conflicts_;
+}
+
+auto repository_factory::sync_history()
+    -> std::shared_ptr<sync_history_repository> {
+    if (!sync_history_) {
+        sync_history_ = std::make_shared<sync_history_repository>(db_);
+    }
+    return sync_history_;
+}
+
 auto repository_factory::key_images()
     -> std::shared_ptr<key_image_repository> {
     if (!key_images_) {
@@ -123,6 +154,23 @@ auto repository_factory::viewer_states()
     return viewer_states_;
 }
 
+auto repository_factory::viewer_state_records()
+    -> std::shared_ptr<viewer_state_record_repository> {
+    if (!viewer_state_records_) {
+        viewer_state_records_ =
+            std::make_shared<viewer_state_record_repository>(db_);
+    }
+    return viewer_state_records_;
+}
+
+auto repository_factory::recent_studies()
+    -> std::shared_ptr<recent_study_repository> {
+    if (!recent_studies_) {
+        recent_studies_ = std::make_shared<recent_study_repository>(db_);
+    }
+    return recent_studies_;
+}
+
 auto repository_factory::prefetch_queue()
     -> std::shared_ptr<prefetch_repository> {
     if (!prefetch_queue_) {
@@ -131,12 +179,65 @@ auto repository_factory::prefetch_queue()
     return prefetch_queue_;
 }
 
+auto repository_factory::prefetch_rules()
+    -> std::shared_ptr<prefetch_rule_repository> {
+    if (!prefetch_rules_) {
+        prefetch_rules_ = std::make_shared<prefetch_rule_repository>(db_);
+    }
+    return prefetch_rules_;
+}
+
+auto repository_factory::prefetch_history()
+    -> std::shared_ptr<prefetch_history_repository> {
+    if (!prefetch_history_) {
+        prefetch_history_ = std::make_shared<prefetch_history_repository>(db_);
+    }
+    return prefetch_history_;
+}
+
 auto repository_factory::commitments()
     -> std::shared_ptr<commitment_repository> {
     if (!commitments_) {
         commitments_ = std::make_shared<commitment_repository>(db_);
     }
     return commitments_;
+}
+
+auto repository_factory::canonical_repositories() -> canonical_repository_set {
+    return {
+        .jobs = jobs(),
+        .annotations = annotations(),
+        .routing_rules = routing_rules(),
+        .nodes = nodes(),
+        .sync =
+            {
+                .configs = sync_configs(),
+                .conflicts = sync_conflicts(),
+                .history = sync_history(),
+            },
+        .key_images = key_images(),
+        .measurements = measurements(),
+        .viewer_state =
+            {
+                .records = viewer_state_records(),
+                .recent_studies = recent_studies(),
+            },
+        .prefetch =
+            {
+                .rules = prefetch_rules(),
+                .history = prefetch_history(),
+            },
+        .commitments = commitments(),
+    };
+}
+
+auto repository_factory::compatibility_repositories()
+    -> compatibility_repository_set {
+    return {
+        .sync_states = sync_states(),
+        .viewer_states = viewer_states(),
+        .prefetch_queue = prefetch_queue(),
+    };
 }
 
 auto repository_factory::db() const

--- a/tests/storage/repository_factory_test.cpp
+++ b/tests/storage/repository_factory_test.cpp
@@ -2,8 +2,8 @@
  * @file repository_factory_test.cpp
  * @brief Unit tests for repository_factory class
  *
- * Verifies that all 10 repositories are lazily initialized and return
- * valid (non-null) instances from the factory.
+ * Verifies that canonical and compatibility repositories are lazily
+ * initialized and return valid (non-null) instances from the factory.
  *
  * @see Issue #716 - Complete repository_factory migration
  */
@@ -75,7 +75,7 @@ TEST_CASE("repository_factory returns shared db adapter",
 // All repositories return non-null
 // ============================================================================
 
-TEST_CASE("repository_factory returns non-null for all repositories",
+TEST_CASE("repository_factory returns non-null for canonical and compatibility repositories",
           "[storage][repository_factory]") {
     if (!is_sqlite_backend_supported()) {
         SUCCEED("Skipped: SQLite backend not supported");
@@ -89,10 +89,19 @@ TEST_CASE("repository_factory returns non-null for all repositories",
     SECTION("routing_rules") { CHECK(factory.routing_rules() != nullptr); }
     SECTION("nodes") { CHECK(factory.nodes() != nullptr); }
     SECTION("sync_states") { CHECK(factory.sync_states() != nullptr); }
+    SECTION("sync_configs") { CHECK(factory.sync_configs() != nullptr); }
+    SECTION("sync_conflicts") { CHECK(factory.sync_conflicts() != nullptr); }
+    SECTION("sync_history") { CHECK(factory.sync_history() != nullptr); }
     SECTION("key_images") { CHECK(factory.key_images() != nullptr); }
     SECTION("measurements") { CHECK(factory.measurements() != nullptr); }
     SECTION("viewer_states") { CHECK(factory.viewer_states() != nullptr); }
+    SECTION("viewer_state_records") {
+        CHECK(factory.viewer_state_records() != nullptr);
+    }
+    SECTION("recent_studies") { CHECK(factory.recent_studies() != nullptr); }
     SECTION("prefetch_queue") { CHECK(factory.prefetch_queue() != nullptr); }
+    SECTION("prefetch_rules") { CHECK(factory.prefetch_rules() != nullptr); }
+    SECTION("prefetch_history") { CHECK(factory.prefetch_history() != nullptr); }
     SECTION("commitments") { CHECK(factory.commitments() != nullptr); }
 }
 
@@ -139,9 +148,39 @@ TEST_CASE("repository_factory caches instances on repeated calls",
         CHECK(first == second);
     }
 
+    SECTION("sync_configs returns same pointer") {
+        auto first = factory.sync_configs();
+        auto second = factory.sync_configs();
+        CHECK(first == second);
+    }
+
+    SECTION("sync_conflicts returns same pointer") {
+        auto first = factory.sync_conflicts();
+        auto second = factory.sync_conflicts();
+        CHECK(first == second);
+    }
+
+    SECTION("sync_history returns same pointer") {
+        auto first = factory.sync_history();
+        auto second = factory.sync_history();
+        CHECK(first == second);
+    }
+
     SECTION("viewer_states returns same pointer") {
         auto first = factory.viewer_states();
         auto second = factory.viewer_states();
+        CHECK(first == second);
+    }
+
+    SECTION("viewer_state_records returns same pointer") {
+        auto first = factory.viewer_state_records();
+        auto second = factory.viewer_state_records();
+        CHECK(first == second);
+    }
+
+    SECTION("recent_studies returns same pointer") {
+        auto first = factory.recent_studies();
+        auto second = factory.recent_studies();
         CHECK(first == second);
     }
 
@@ -150,6 +189,49 @@ TEST_CASE("repository_factory caches instances on repeated calls",
         auto second = factory.prefetch_queue();
         CHECK(first == second);
     }
+
+    SECTION("prefetch_rules returns same pointer") {
+        auto first = factory.prefetch_rules();
+        auto second = factory.prefetch_rules();
+        CHECK(first == second);
+    }
+
+    SECTION("prefetch_history returns same pointer") {
+        auto first = factory.prefetch_history();
+        auto second = factory.prefetch_history();
+        CHECK(first == second);
+    }
+}
+
+TEST_CASE("repository_factory returns structured canonical and compatibility sets",
+          "[storage][repository_factory]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+    test_database tdb;
+    repository_factory factory(tdb.get());
+
+    const auto canonical = factory.canonical_repositories();
+    CHECK(canonical.jobs == factory.jobs());
+    CHECK(canonical.annotations == factory.annotations());
+    CHECK(canonical.routing_rules == factory.routing_rules());
+    CHECK(canonical.nodes == factory.nodes());
+    CHECK(canonical.sync.configs == factory.sync_configs());
+    CHECK(canonical.sync.conflicts == factory.sync_conflicts());
+    CHECK(canonical.sync.history == factory.sync_history());
+    CHECK(canonical.key_images == factory.key_images());
+    CHECK(canonical.measurements == factory.measurements());
+    CHECK(canonical.viewer_state.records == factory.viewer_state_records());
+    CHECK(canonical.viewer_state.recent_studies == factory.recent_studies());
+    CHECK(canonical.prefetch.rules == factory.prefetch_rules());
+    CHECK(canonical.prefetch.history == factory.prefetch_history());
+    CHECK(canonical.commitments == factory.commitments());
+
+    const auto compatibility = factory.compatibility_repositories();
+    CHECK(compatibility.sync_states == factory.sync_states());
+    CHECK(compatibility.viewer_states == factory.viewer_states());
+    CHECK(compatibility.prefetch_queue == factory.prefetch_queue());
 }
 
 #endif  // PACS_WITH_DATABASE_SYSTEM


### PR DESCRIPTION
## Summary
- add canonical split repository accessors and structured repository-set contracts to `repository_factory`
- keep aggregate sync/viewer/prefetch repositories as compatibility-only contracts for incremental migration
- document the PACS storage port inventory, ownership boundary, and allowed exceptions in ADR-002

## Verification
- `python3` syntax-only compile check for `src/storage/repository_factory.cpp`
- `python3` syntax-only compile check for `tests/storage/repository_factory_test.cpp`
- `ctest --test-dir build -R repository_factory --output-on-failure` (executed against the existing build tree before rebuild)

## Notes
- A full `cmake --build build --target storage_tests -j4` rebuild was blocked in the sandbox because `thread_system` attempted to fetch `simdutf` from GitHub during CMake regeneration.

Closes #892