### PR TITLE
feat(storage): add PACS session and unit-of-work boundary

### DIFF
--- a/include/pacs/storage/base_repository.hpp
+++ b/include/pacs/storage/base_repository.hpp
@@ -419,6 +419,11 @@ protected:
     [[nodiscard]] auto query_builder() -> database::query_builder;
 
     /**
+     * @brief Open a PACS storage session for repository work
+     */
+    [[nodiscard]] auto storage_session() -> pacs_storage_session;
+
+    /**
      * @brief Get the database adapter
      *
      * @return Shared pointer to database adapter

--- a/include/pacs/storage/base_repository_impl.hpp
+++ b/include/pacs/storage/base_repository_impl.hpp
@@ -76,7 +76,8 @@ auto base_repository<Entity, PrimaryKey>::find_by_id(PrimaryKey id)
             -1, "Database not connected", "storage"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto storage = storage_session();
+    auto builder = storage.create_query_builder();
     auto columns = select_columns();
 
     if (columns.empty() || (columns.size() == 1 && columns[0] == "*")) {
@@ -103,7 +104,7 @@ auto base_repository<Entity, PrimaryKey>::find_by_id(PrimaryKey id)
     builder.limit(1);
 
     auto query = builder.build();
-    auto result = db_->select(query);
+    auto result = storage.select(query);
 
     if (result.is_err()) {
         return Result<Entity>(result.error());
@@ -139,7 +140,8 @@ auto base_repository<Entity, PrimaryKey>::find_all(
             -1, "Database not connected", "storage"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto storage = storage_session();
+    auto builder = storage.create_query_builder();
     auto columns = select_columns();
 
     if (columns.empty() || (columns.size() == 1 && columns[0] == "*")) {
@@ -155,7 +157,7 @@ auto base_repository<Entity, PrimaryKey>::find_all(
     }
 
     auto query = builder.build();
-    auto result = db_->select(query);
+    auto result = storage.select(query);
 
     if (result.is_err()) {
         return list_result_type(result.error());
@@ -186,7 +188,8 @@ auto base_repository<Entity, PrimaryKey>::find_where(
             -1, "Database not connected", "storage"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto storage = storage_session();
+    auto builder = storage.create_query_builder();
     auto columns = select_columns();
 
     if (columns.empty() || (columns.size() == 1 && columns[0] == "*")) {
@@ -198,7 +201,7 @@ auto base_repository<Entity, PrimaryKey>::find_where(
     builder.from(table_name_).where(column, op, value);
 
     auto query = builder.build();
-    auto result = db_->select(query);
+    auto result = storage.select(query);
 
     if (result.is_err()) {
         return list_result_type(result.error());
@@ -227,7 +230,8 @@ auto base_repository<Entity, PrimaryKey>::exists(PrimaryKey id)
             -1, "Database not connected", "storage"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto storage = storage_session();
+    auto builder = storage.create_query_builder();
 
     // Convert primary key to database_value
     database_value pk_value;
@@ -246,7 +250,7 @@ auto base_repository<Entity, PrimaryKey>::exists(PrimaryKey id)
         .where(pk_column_, "=", pk_value);
 
     auto query = builder.build();
-    auto result = db_->select(query);
+    auto result = storage.select(query);
 
     if (result.is_err()) {
         return Result<bool>(result.error());
@@ -273,11 +277,12 @@ auto base_repository<Entity, PrimaryKey>::count() -> Result<size_t> {
             -1, "Database not connected", "storage"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto storage = storage_session();
+    auto builder = storage.create_query_builder();
     builder.select({"COUNT(*) as count"}).from(table_name_);
 
     auto query = builder.build();
-    auto result = db_->select(query);
+    auto result = storage.select(query);
 
     if (result.is_err()) {
         return Result<size_t>(result.error());
@@ -325,18 +330,19 @@ auto base_repository<Entity, PrimaryKey>::insert(const Entity& entity)
 
     try {
         auto row = entity_to_row(entity);
-        auto builder = db_->create_query_builder();
+        auto storage = storage_session();
+        auto builder = storage.create_query_builder();
         builder.insert_into(table_name_).values(row);
 
         auto query = builder.build();
-        auto result = db_->insert(query);
+        auto result = storage.insert(query);
 
         if (result.is_err()) {
             return Result<PrimaryKey>(result.error());
         }
 
         // Get the last insert rowid
-        auto rowid = db_->last_insert_rowid();
+        auto rowid = storage.last_insert_rowid();
 
         if constexpr (std::is_integral_v<PrimaryKey>) {
             return Result<PrimaryKey>(static_cast<PrimaryKey>(rowid));
@@ -371,7 +377,8 @@ auto base_repository<Entity, PrimaryKey>::update(const Entity& entity)
         auto row = entity_to_row(entity);
         auto pk = get_pk(entity);
 
-        auto builder = db_->create_query_builder();
+        auto storage = storage_session();
+        auto builder = storage.create_query_builder();
         builder.update(table_name_).set(row);
 
         // Convert primary key to database_value
@@ -389,7 +396,7 @@ auto base_repository<Entity, PrimaryKey>::update(const Entity& entity)
         builder.where(pk_column_, "=", pk_value);
 
         auto query = builder.build();
-        auto result = db_->update(query);
+        auto result = storage.update(query);
 
         if (result.is_err()) {
             return VoidResult(result.error());
@@ -416,7 +423,8 @@ auto base_repository<Entity, PrimaryKey>::remove(PrimaryKey id)
             -1, "Database not connected", "storage"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto storage = storage_session();
+    auto builder = storage.create_query_builder();
 
     // Convert primary key to database_value
     database_value pk_value;
@@ -433,7 +441,7 @@ auto base_repository<Entity, PrimaryKey>::remove(PrimaryKey id)
     builder.delete_from(table_name_).where(pk_column_, "=", pk_value);
 
     auto query = builder.build();
-    auto result = db_->remove(query);
+    auto result = storage.remove(query);
 
     if (result.is_err()) {
         return VoidResult(result.error());
@@ -457,11 +465,12 @@ auto base_repository<Entity, PrimaryKey>::remove_where(
             -1, "Database not connected", "storage"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto storage = storage_session();
+    auto builder = storage.create_query_builder();
     builder.delete_from(table_name_).where(column, op, value);
 
     auto query = builder.build();
-    auto result = db_->remove(query);
+    auto result = storage.remove(query);
 
     if (result.is_err()) {
         return Result<size_t>(result.error());
@@ -485,19 +494,24 @@ auto base_repository<Entity, PrimaryKey>::insert_batch(
     std::vector<PrimaryKey> ids;
     ids.reserve(entities.size());
 
-    auto tx_result = db_->transaction([&]() -> VoidResult {
-        for (const auto& entity : entities) {
-            auto insert_result = insert(entity);
-            if (insert_result.is_err()) {
-                return VoidResult(insert_result.error());
-            }
-            ids.push_back(insert_result.value());
-        }
-        return kcenon::common::ok();
-    });
+    auto uow_result = db_->begin_unit_of_work();
+    if (uow_result.is_err()) {
+        return Result<std::vector<PrimaryKey>>(uow_result.error());
+    }
 
-    if (tx_result.is_err()) {
-        return Result<std::vector<PrimaryKey>>(tx_result.error());
+    auto uow = std::move(uow_result.value());
+    for (const auto& entity : entities) {
+        auto insert_result = insert(entity);
+        if (insert_result.is_err()) {
+            (void)uow.rollback();
+            return Result<std::vector<PrimaryKey>>(insert_result.error());
+        }
+        ids.push_back(insert_result.value());
+    }
+
+    auto commit_result = uow.commit();
+    if (commit_result.is_err()) {
+        return Result<std::vector<PrimaryKey>>(commit_result.error());
     }
 
     return Result<std::vector<PrimaryKey>>(std::move(ids));
@@ -513,7 +527,33 @@ auto base_repository<Entity, PrimaryKey>::in_transaction(Func&& func)
             -1, "Database not connected", "storage"});
     }
 
-    return db_->transaction(std::forward<Func>(func));
+    auto uow_result = db_->begin_unit_of_work();
+    if (uow_result.is_err()) {
+        using ResultType = std::invoke_result_t<Func>;
+        return ResultType(uow_result.error());
+    }
+
+    auto uow = std::move(uow_result.value());
+    try {
+        auto result = std::forward<Func>(func)();
+        if (result.is_err()) {
+            (void)uow.rollback();
+            return result;
+        }
+
+        auto commit_result = uow.commit();
+        if (commit_result.is_err()) {
+            using ResultType = std::invoke_result_t<Func>;
+            return ResultType(commit_result.error());
+        }
+
+        return result;
+    } catch (const std::exception& e) {
+        (void)uow.rollback();
+        using ResultType = std::invoke_result_t<Func>;
+        return ResultType(kcenon::common::error_info{
+            -1, std::string("Transaction failed: ") + e.what(), "storage"});
+    }
 }
 
 // =============================================================================
@@ -529,7 +569,13 @@ auto base_repository<Entity, PrimaryKey>::select_columns() const
 template <typename Entity, typename PrimaryKey>
 auto base_repository<Entity, PrimaryKey>::query_builder()
     -> database::query_builder {
-    return db_->create_query_builder();
+    return storage_session().create_query_builder();
+}
+
+template <typename Entity, typename PrimaryKey>
+auto base_repository<Entity, PrimaryKey>::storage_session()
+    -> pacs_storage_session {
+    return db_->open_session();
 }
 
 template <typename Entity, typename PrimaryKey>

--- a/include/pacs/storage/pacs_database_adapter.hpp
+++ b/include/pacs/storage/pacs_database_adapter.hpp
@@ -127,6 +127,63 @@ struct database_result {
 
 // Forward declaration
 class scoped_transaction;
+class pacs_database_adapter;
+class pacs_unit_of_work;
+
+/**
+ * @brief PACS storage session over the unified database adapter
+ *
+ * Repositories should prefer this narrow session boundary instead of calling
+ * raw mutator methods directly on pacs_database_adapter.
+ */
+class pacs_storage_session {
+public:
+    explicit pacs_storage_session(pacs_database_adapter& adapter) noexcept;
+
+    [[nodiscard]] auto create_query_builder() const -> database::query_builder;
+    [[nodiscard]] auto select(const std::string& query)
+        -> Result<database_result>;
+    [[nodiscard]] auto insert(const std::string& query) -> Result<uint64_t>;
+    [[nodiscard]] auto update(const std::string& query) -> Result<uint64_t>;
+    [[nodiscard]] auto remove(const std::string& query) -> Result<uint64_t>;
+    [[nodiscard]] auto execute(const std::string& query) -> VoidResult;
+    [[nodiscard]] auto last_insert_rowid() const -> int64_t;
+    [[nodiscard]] auto begin_unit_of_work() -> Result<pacs_unit_of_work>;
+
+private:
+    pacs_database_adapter* adapter_{nullptr};
+};
+
+/**
+ * @brief PACS unit-of-work wrapper that owns transaction lifetime
+ */
+class pacs_unit_of_work {
+public:
+    pacs_unit_of_work() = default;
+    pacs_unit_of_work(pacs_database_adapter& adapter, bool active) noexcept;
+    ~pacs_unit_of_work();
+
+    pacs_unit_of_work(const pacs_unit_of_work&) = delete;
+    auto operator=(const pacs_unit_of_work&) -> pacs_unit_of_work& = delete;
+    pacs_unit_of_work(pacs_unit_of_work&& other) noexcept;
+    auto operator=(pacs_unit_of_work&& other) noexcept -> pacs_unit_of_work&;
+
+    [[nodiscard]] auto create_query_builder() const -> database::query_builder;
+    [[nodiscard]] auto select(const std::string& query)
+        -> Result<database_result>;
+    [[nodiscard]] auto insert(const std::string& query) -> Result<uint64_t>;
+    [[nodiscard]] auto update(const std::string& query) -> Result<uint64_t>;
+    [[nodiscard]] auto remove(const std::string& query) -> Result<uint64_t>;
+    [[nodiscard]] auto execute(const std::string& query) -> VoidResult;
+    [[nodiscard]] auto last_insert_rowid() const -> int64_t;
+    [[nodiscard]] auto commit() -> VoidResult;
+    [[nodiscard]] auto rollback() -> VoidResult;
+    [[nodiscard]] auto is_active() const noexcept -> bool;
+
+private:
+    pacs_database_adapter* adapter_{nullptr};
+    bool active_{false};
+};
 
 /**
  * @brief Unified database adapter for PACS system
@@ -237,6 +294,20 @@ public:
      */
     [[nodiscard]] auto is_connected() const noexcept -> bool;
 
+    /**
+     * @brief Open a PACS storage session over the connected database
+     *
+     * Repository code should use this boundary for query execution and query
+     * builder access.
+     */
+    [[nodiscard]] auto open_session() -> pacs_storage_session;
+    [[nodiscard]] auto open_session() const -> pacs_storage_session;
+
+    /**
+     * @brief Begin a PACS unit of work that owns a transaction lifecycle
+     */
+    [[nodiscard]] auto begin_unit_of_work() -> Result<pacs_unit_of_work>;
+
     // ========================================================================
     // Query Builder Factory
     // ========================================================================
@@ -278,6 +349,8 @@ public:
     /**
      * @brief Execute an INSERT query
      *
+     * Compatibility path. Prefer open_session() for repository runtime code.
+     *
      * @param query SQL INSERT statement
      * @return Result containing number of inserted rows or error
      */
@@ -285,6 +358,8 @@ public:
 
     /**
      * @brief Execute an UPDATE query
+     *
+     * Compatibility path. Prefer open_session() for repository runtime code.
      *
      * @param query SQL UPDATE statement
      * @return Result containing number of updated rows or error
@@ -294,6 +369,8 @@ public:
     /**
      * @brief Execute a DELETE query
      *
+     * Compatibility path. Prefer open_session() for repository runtime code.
+     *
      * @param query SQL DELETE statement
      * @return Result containing number of deleted rows or error
      */
@@ -302,7 +379,8 @@ public:
     /**
      * @brief Execute raw SQL (DDL, PRAGMA, etc.)
      *
-     * Use for schema changes, PRAGMA statements, and other non-CRUD operations.
+     * Infrastructure escape hatch for schema changes, PRAGMA statements, and
+     * other explicitly documented non-CRUD operations.
      *
      * @param query SQL statement to execute
      * @return Success or error result
@@ -409,6 +487,22 @@ public:
     [[nodiscard]] auto last_error() const -> std::string;
 
 private:
+    friend class pacs_storage_session;
+    friend class pacs_unit_of_work;
+
+    [[nodiscard]] auto run_select(const std::string& query)
+        -> Result<database_result>;
+    [[nodiscard]] auto run_insert(const std::string& query)
+        -> Result<uint64_t>;
+    [[nodiscard]] auto run_update(const std::string& query)
+        -> Result<uint64_t>;
+    [[nodiscard]] auto run_remove(const std::string& query)
+        -> Result<uint64_t>;
+    [[nodiscard]] auto run_execute(const std::string& query) -> VoidResult;
+    [[nodiscard]] auto begin_transaction_internal() -> VoidResult;
+    [[nodiscard]] auto commit_internal() -> VoidResult;
+    [[nodiscard]] auto rollback_internal() -> VoidResult;
+
     struct impl;
     std::unique_ptr<impl> impl_;
 };

--- a/src/storage/annotation_repository.cpp
+++ b/src/storage/annotation_repository.cpp
@@ -182,7 +182,7 @@ auto annotation_repository::find_by_pk(int64_t pk) -> result_type {
         .where("pk", "=", pk)
         .limit(1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return result_type(result.error());
     }
@@ -276,7 +276,7 @@ auto annotation_repository::search(const annotation_query& query)
         }
     }
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -308,7 +308,7 @@ auto annotation_repository::update_annotation(const annotation_record& record)
         .set("updated_at", now_str)
         .where("annotation_id", "=", record.annotation_id);
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -378,7 +378,7 @@ auto annotation_repository::count_matching(const annotation_query& query)
         builder.where(condition.value());
     }
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/commitment_repository.cpp
+++ b/src/storage/commitment_repository.cpp
@@ -68,7 +68,7 @@ auto commitment_repository::record_request(
             -1, "Database not connected", "storage"});
     }
 
-    return db()->transaction([&]() -> VoidResult {
+    return in_transaction([&]() -> VoidResult {
         commitment_record record;
         record.transaction_uid = transaction_uid;
         record.requesting_ae = requesting_ae;
@@ -94,7 +94,7 @@ auto commitment_repository::update_result(
             -1, "Database not connected", "storage"});
     }
 
-    return db()->transaction([&]() -> VoidResult {
+    return in_transaction([&]() -> VoidResult {
         // Determine overall status
         commitment_status new_status;
         if (result.failed_references.empty() &&
@@ -122,7 +122,7 @@ auto commitment_repository::update_result(
             std::to_string(result.failed_references.size()) +
             " WHERE transaction_uid = '" + transaction_uid + "'";
 
-        auto exec_result = db()->execute(sql);
+        auto exec_result = storage_session().execute(sql);
         if (exec_result.is_err()) {
             return VoidResult(exec_result.error());
         }
@@ -133,7 +133,7 @@ auto commitment_repository::update_result(
                 "UPDATE commitment_references SET status = 'success'"
                 " WHERE transaction_uid = '" + transaction_uid +
                 "' AND sop_instance_uid = '" + ref.sop_instance_uid + "'";
-            auto ref_result = db()->execute(ref_sql);
+            auto ref_result = storage_session().execute(ref_sql);
             if (ref_result.is_err()) {
                 return VoidResult(ref_result.error());
             }
@@ -147,7 +147,7 @@ auto commitment_repository::update_result(
                 std::to_string(static_cast<uint16_t>(reason)) +
                 " WHERE transaction_uid = '" + transaction_uid +
                 "' AND sop_instance_uid = '" + ref.sop_instance_uid + "'";
-            auto ref_result = db()->execute(ref_sql);
+            auto ref_result = storage_session().execute(ref_sql);
             if (ref_result.is_err()) {
                 return VoidResult(ref_result.error());
             }
@@ -187,7 +187,7 @@ auto commitment_repository::get_references(
         .from("commitment_references")
         .where("transaction_uid", "=", transaction_uid);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<std::vector<commitment_reference_record>>(result.error());
     }
@@ -237,7 +237,7 @@ auto commitment_repository::cleanup_old_transactions(
         "WHERE status IN ('success', 'failed', 'partial') "
         "AND completion_time < '" + cutoff_str + "')";
 
-    auto ref_result = db()->execute(ref_sql);
+    auto ref_result = storage_session().execute(ref_sql);
     if (ref_result.is_err()) {
         return Result<size_t>(ref_result.error());
     }
@@ -248,7 +248,7 @@ auto commitment_repository::cleanup_old_transactions(
         "WHERE status IN ('success', 'failed', 'partial') "
         "AND completion_time < '" + cutoff_str + "'";
 
-    auto count_result = db()->select(count_sql);
+    auto count_result = storage_session().select(count_sql);
     size_t deleted_count = 0;
     if (count_result.is_ok() && !count_result.value().empty()) {
         deleted_count = std::stoull(count_result.value()[0].at("cnt"));
@@ -260,7 +260,7 @@ auto commitment_repository::cleanup_old_transactions(
         "WHERE status IN ('success', 'failed', 'partial') "
         "AND completion_time < '" + cutoff_str + "'";
 
-    auto result = db()->execute(sql);
+    auto result = storage_session().execute(sql);
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }
@@ -360,7 +360,7 @@ auto commitment_repository::insert_references(
             ref.sop_class_uid + "', '" +
             ref.sop_instance_uid + "', 'pending')";
 
-        auto result = db()->execute(sql);
+        auto result = storage_session().execute(sql);
         if (result.is_err()) {
             return VoidResult(result.error());
         }

--- a/src/storage/job_repository.cpp
+++ b/src/storage/job_repository.cpp
@@ -268,7 +268,7 @@ auto job_repository::find_by_pk(int64_t pk) -> result_type {
         .where("pk", "=", pk)
         .limit(1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return result_type(result.error());
     }
@@ -337,7 +337,7 @@ auto job_repository::find_jobs(const job_query_options& options)
         }
     }
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -378,7 +378,7 @@ auto job_repository::find_pending_jobs(size_t limit) -> list_result_type {
         .order_by("created_at", database::sort_order::asc)
         .limit(limit);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -409,7 +409,7 @@ auto job_repository::find_by_node(std::string_view node_id) -> list_result_type 
         .where(source_cond || dest_cond)
         .order_by("created_at", database::sort_order::desc);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -448,7 +448,7 @@ auto job_repository::cleanup_old_jobs(std::chrono::hours max_age)
     auto builder = query_builder();
     builder.delete_from(table_name()).where(final_cond);
 
-    auto result = db()->remove(builder.build());
+    auto result = storage_session().remove(builder.build());
     if (result.is_err()) {
         return kcenon::common::make_error<size_t>(
             -1, result.error().message, "storage");
@@ -481,7 +481,7 @@ auto job_repository::update_status(std::string_view job_id,
 
     builder.where("job_id", "=", std::string(job_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -508,7 +508,7 @@ auto job_repository::update_progress(std::string_view job_id,
         .set("current_item_description", progress.current_item_description)
         .where("job_id", "=", std::string(job_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -530,7 +530,7 @@ auto job_repository::mark_started(std::string_view job_id) -> VoidResult {
         .set("started_at", now_str)
         .where("job_id", "=", std::string(job_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -552,7 +552,7 @@ auto job_repository::mark_completed(std::string_view job_id) -> VoidResult {
         .set("completed_at", now_str)
         .where("job_id", "=", std::string(job_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -586,7 +586,7 @@ auto job_repository::mark_failed(std::string_view job_id,
         .set("completed_at", now_str)
         .where("job_id", "=", std::string(job_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -612,7 +612,7 @@ auto job_repository::increment_retry(std::string_view job_id) -> VoidResult {
         .set("retry_count", static_cast<int64_t>(current_retry + 1))
         .where("job_id", "=", std::string(job_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -636,7 +636,7 @@ auto job_repository::count_by_status(client::job_status status)
         .from(table_name())
         .where("status", "=", std::string(client::to_string(status)));
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }
@@ -666,7 +666,7 @@ auto job_repository::count_completed_today() -> Result<size_t> {
 
     // Note: For date comparison, we use the date portion of completed_at
     // This requires database-specific handling - using LIKE for portability
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }
@@ -690,7 +690,7 @@ auto job_repository::count_failed_today() -> Result<size_t> {
         .from(table_name())
         .where("status", "=", std::string("failed"));
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/key_image_repository.cpp
+++ b/src/storage/key_image_repository.cpp
@@ -69,7 +69,7 @@ auto key_image_repository::find_by_pk(int64_t pk) -> result_type {
         .where("pk", "=", pk)
         .limit(1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return result_type(result.error());
     }
@@ -141,7 +141,7 @@ auto key_image_repository::search(const key_image_query& query)
         }
     }
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -167,7 +167,7 @@ auto key_image_repository::count_by_study(std::string_view study_uid)
         .from(table_name())
         .where("study_uid", "=", std::string(study_uid));
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/measurement_repository.cpp
+++ b/src/storage/measurement_repository.cpp
@@ -69,7 +69,7 @@ auto measurement_repository::find_by_pk(int64_t pk) -> result_type {
         .where("pk", "=", pk)
         .limit(1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return result_type(result.error());
     }
@@ -143,7 +143,7 @@ auto measurement_repository::search(const measurement_query& query)
         }
     }
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -201,7 +201,7 @@ auto measurement_repository::count(const measurement_query& query)
         builder.where(condition.value());
     }
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/node_repository.cpp
+++ b/src/storage/node_repository.cpp
@@ -115,7 +115,7 @@ auto node_repository::find_by_pk(int64_t pk) -> result_type {
         .where("pk", "=", pk)
         .limit(1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return result_type(result.error());
     }
@@ -139,7 +139,7 @@ auto node_repository::find_all_nodes() -> list_result_type {
         .from(table_name())
         .order_by("name", database::sort_order::asc);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -166,7 +166,7 @@ auto node_repository::find_by_status(client::node_status status)
         .where("status", "=", std::string(client::to_string(status)))
         .order_by("name", database::sort_order::asc);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -202,7 +202,7 @@ auto node_repository::update_status(
                    "last_error_message = '" + std::string(error_message) +
                    "', updated_at = CURRENT_TIMESTAMP "
                    "WHERE node_id = '" + std::string(node_id) + "'";
-        auto result = db()->execute(sql);
+        auto result = storage_session().execute(sql);
         if (result.is_err()) {
             return VoidResult(result.error());
         }
@@ -212,7 +212,7 @@ auto node_repository::update_status(
             .set("status", std::string(client::to_string(status)))
             .where("node_id", "=", std::string(node_id));
 
-        auto result = db()->execute(builder.build());
+        auto result = storage_session().execute(builder.build());
         if (result.is_err()) {
             return VoidResult(result.error());
         }
@@ -233,7 +233,7 @@ auto node_repository::update_last_verified(std::string_view node_id)
                "updated_at = CURRENT_TIMESTAMP WHERE node_id = '" +
                std::string(node_id) + "'";
 
-    auto result = db()->execute(sql);
+    auto result = storage_session().execute(sql);
     if (result.is_err()) {
         return VoidResult(result.error());
     }

--- a/src/storage/pacs_database_adapter.cpp
+++ b/src/storage/pacs_database_adapter.cpp
@@ -92,8 +92,6 @@ auto to_backend_type(database::database_types type)
     switch (type) {
         case database::database_types::postgres:
             return database::integrated::backend_type::postgres;
-        case database::database_types::mysql:
-            return database::integrated::backend_type::mysql;
         case database::database_types::sqlite:
             return database::integrated::backend_type::sqlite;
         case database::database_types::mongodb:
@@ -135,6 +133,145 @@ auto make_void_error(int code, const std::string& message,
 }
 
 }  // namespace
+
+// ============================================================================
+// pacs_storage_session Implementation
+// ============================================================================
+
+pacs_storage_session::pacs_storage_session(
+    pacs_database_adapter& adapter) noexcept
+    : adapter_(&adapter) {}
+
+auto pacs_storage_session::create_query_builder() const
+    -> database::query_builder {
+    return adapter_->create_query_builder();
+}
+
+auto pacs_storage_session::select(const std::string& query)
+    -> Result<database_result> {
+    return adapter_->run_select(query);
+}
+
+auto pacs_storage_session::insert(const std::string& query)
+    -> Result<uint64_t> {
+    return adapter_->run_insert(query);
+}
+
+auto pacs_storage_session::update(const std::string& query)
+    -> Result<uint64_t> {
+    return adapter_->run_update(query);
+}
+
+auto pacs_storage_session::remove(const std::string& query)
+    -> Result<uint64_t> {
+    return adapter_->run_remove(query);
+}
+
+auto pacs_storage_session::execute(const std::string& query) -> VoidResult {
+    return adapter_->run_execute(query);
+}
+
+auto pacs_storage_session::last_insert_rowid() const -> int64_t {
+    return adapter_->last_insert_rowid();
+}
+
+auto pacs_storage_session::begin_unit_of_work() -> Result<pacs_unit_of_work> {
+    return adapter_->begin_unit_of_work();
+}
+
+// ============================================================================
+// pacs_unit_of_work Implementation
+// ============================================================================
+
+pacs_unit_of_work::pacs_unit_of_work(
+    pacs_database_adapter& adapter, bool active) noexcept
+    : adapter_(&adapter), active_(active) {}
+
+pacs_unit_of_work::~pacs_unit_of_work() {
+    if (active_ && adapter_ != nullptr) {
+        (void)adapter_->rollback_internal();
+    }
+}
+
+pacs_unit_of_work::pacs_unit_of_work(pacs_unit_of_work&& other) noexcept
+    : adapter_(other.adapter_), active_(other.active_) {
+    other.adapter_ = nullptr;
+    other.active_ = false;
+}
+
+auto pacs_unit_of_work::operator=(pacs_unit_of_work&& other) noexcept
+    -> pacs_unit_of_work& {
+    if (this == &other) {
+        return *this;
+    }
+
+    if (active_ && adapter_ != nullptr) {
+        (void)adapter_->rollback_internal();
+    }
+
+    adapter_ = other.adapter_;
+    active_ = other.active_;
+    other.adapter_ = nullptr;
+    other.active_ = false;
+    return *this;
+}
+
+auto pacs_unit_of_work::create_query_builder() const -> database::query_builder {
+    return adapter_->create_query_builder();
+}
+
+auto pacs_unit_of_work::select(const std::string& query)
+    -> Result<database_result> {
+    return adapter_->run_select(query);
+}
+
+auto pacs_unit_of_work::insert(const std::string& query) -> Result<uint64_t> {
+    return adapter_->run_insert(query);
+}
+
+auto pacs_unit_of_work::update(const std::string& query) -> Result<uint64_t> {
+    return adapter_->run_update(query);
+}
+
+auto pacs_unit_of_work::remove(const std::string& query) -> Result<uint64_t> {
+    return adapter_->run_remove(query);
+}
+
+auto pacs_unit_of_work::execute(const std::string& query) -> VoidResult {
+    return adapter_->run_execute(query);
+}
+
+auto pacs_unit_of_work::last_insert_rowid() const -> int64_t {
+    return adapter_ != nullptr ? adapter_->last_insert_rowid() : 0;
+}
+
+auto pacs_unit_of_work::commit() -> VoidResult {
+    if (!active_ || adapter_ == nullptr) {
+        return make_void_error(-1, "Unit of work not active", "storage");
+    }
+
+    auto result = adapter_->commit_internal();
+    if (result.is_ok()) {
+        active_ = false;
+    }
+    return result;
+}
+
+auto pacs_unit_of_work::rollback() -> VoidResult {
+    if (!active_ || adapter_ == nullptr) {
+        return ok();
+    }
+
+    auto result = adapter_->rollback_internal();
+    if (result.is_ok()) {
+        active_ = false;
+    }
+    return result;
+}
+
+auto pacs_unit_of_work::is_active() const noexcept -> bool {
+    return active_;
+}
 
 // ============================================================================
 // Construction / Destruction
@@ -234,6 +371,26 @@ auto pacs_database_adapter::is_connected() const noexcept -> bool {
     return impl_ && impl_->db && impl_->db->is_connected();
 }
 
+auto pacs_database_adapter::open_session() -> pacs_storage_session {
+    return pacs_storage_session(*this);
+}
+
+auto pacs_database_adapter::open_session() const -> pacs_storage_session {
+    return pacs_storage_session(
+        const_cast<pacs_database_adapter&>(*this));
+}
+
+auto pacs_database_adapter::begin_unit_of_work()
+    -> Result<pacs_unit_of_work> {
+    auto result = begin_transaction_internal();
+    if (result.is_err()) {
+        return make_error<pacs_unit_of_work>(
+            result.error().code, result.error().message, result.error().module);
+    }
+
+    return Result<pacs_unit_of_work>::ok(pacs_unit_of_work(*this, true));
+}
+
 // ============================================================================
 // Query Builder Factory
 // ============================================================================
@@ -246,7 +403,7 @@ auto pacs_database_adapter::create_query_builder() -> database::query_builder {
 // CRUD Operations
 // ============================================================================
 
-auto pacs_database_adapter::select(const std::string& query)
+auto pacs_database_adapter::run_select(const std::string& query)
     -> Result<database_result> {
     if (!is_connected()) {
         return make_error<database_result>(
@@ -266,7 +423,7 @@ auto pacs_database_adapter::select(const std::string& query)
         convert_result(result.value()));
 }
 
-auto pacs_database_adapter::insert(const std::string& query)
+auto pacs_database_adapter::run_insert(const std::string& query)
     -> Result<uint64_t> {
     if (!is_connected()) {
         return make_error<uint64_t>(-1, "Not connected to database", "storage");
@@ -300,7 +457,7 @@ auto pacs_database_adapter::insert(const std::string& query)
         static_cast<uint64_t>(result.value()));
 }
 
-auto pacs_database_adapter::update(const std::string& query)
+auto pacs_database_adapter::run_update(const std::string& query)
     -> Result<uint64_t> {
     if (!is_connected()) {
         return make_error<uint64_t>(-1, "Not connected to database", "storage");
@@ -319,7 +476,7 @@ auto pacs_database_adapter::update(const std::string& query)
         static_cast<uint64_t>(result.value()));
 }
 
-auto pacs_database_adapter::remove(const std::string& query)
+auto pacs_database_adapter::run_remove(const std::string& query)
     -> Result<uint64_t> {
     if (!is_connected()) {
         return make_error<uint64_t>(-1, "Not connected to database", "storage");
@@ -338,7 +495,8 @@ auto pacs_database_adapter::remove(const std::string& query)
         static_cast<uint64_t>(result.value()));
 }
 
-auto pacs_database_adapter::execute(const std::string& query) -> VoidResult {
+auto pacs_database_adapter::run_execute(const std::string& query)
+    -> VoidResult {
     if (!is_connected()) {
         return make_void_error(-1, "Not connected to database", "storage");
     }
@@ -355,11 +513,35 @@ auto pacs_database_adapter::execute(const std::string& query) -> VoidResult {
     return ok();
 }
 
+auto pacs_database_adapter::select(const std::string& query)
+    -> Result<database_result> {
+    return run_select(query);
+}
+
+auto pacs_database_adapter::insert(const std::string& query)
+    -> Result<uint64_t> {
+    return run_insert(query);
+}
+
+auto pacs_database_adapter::update(const std::string& query)
+    -> Result<uint64_t> {
+    return run_update(query);
+}
+
+auto pacs_database_adapter::remove(const std::string& query)
+    -> Result<uint64_t> {
+    return run_remove(query);
+}
+
+auto pacs_database_adapter::execute(const std::string& query) -> VoidResult {
+    return run_execute(query);
+}
+
 // ============================================================================
 // Transaction Support
 // ============================================================================
 
-auto pacs_database_adapter::begin_transaction() -> VoidResult {
+auto pacs_database_adapter::begin_transaction_internal() -> VoidResult {
     if (!is_connected()) {
         return make_void_error(-1, "Not connected to database", "storage");
     }
@@ -383,7 +565,7 @@ auto pacs_database_adapter::begin_transaction() -> VoidResult {
     return ok();
 }
 
-auto pacs_database_adapter::commit() -> VoidResult {
+auto pacs_database_adapter::commit_internal() -> VoidResult {
     if (!is_connected()) {
         return make_void_error(-1, "Not connected to database", "storage");
     }
@@ -406,7 +588,7 @@ auto pacs_database_adapter::commit() -> VoidResult {
     return ok();
 }
 
-auto pacs_database_adapter::rollback() -> VoidResult {
+auto pacs_database_adapter::rollback_internal() -> VoidResult {
     if (!is_connected()) {
         return ok();  // No-op if not connected
     }
@@ -428,6 +610,18 @@ auto pacs_database_adapter::rollback() -> VoidResult {
     }
 
     return ok();
+}
+
+auto pacs_database_adapter::begin_transaction() -> VoidResult {
+    return begin_transaction_internal();
+}
+
+auto pacs_database_adapter::commit() -> VoidResult {
+    return commit_internal();
+}
+
+auto pacs_database_adapter::rollback() -> VoidResult {
+    return rollback_internal();
 }
 
 auto pacs_database_adapter::in_transaction() const noexcept -> bool {

--- a/src/storage/prefetch_history_repository.cpp
+++ b/src/storage/prefetch_history_repository.cpp
@@ -103,14 +103,14 @@ auto prefetch_history_repository::find_by_patient(
             -1, "Database not connected", "prefetch_history_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .where("patient_id", "=", std::string(patient_id))
         .order_by("prefetched_at", database::sort_order::desc)
         .limit(limit);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -137,14 +137,14 @@ auto prefetch_history_repository::find_by_rule(
             -1, "Database not connected", "prefetch_history_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .where("rule_id", "=", std::string(rule_id))
         .order_by("prefetched_at", database::sort_order::desc)
         .limit(limit);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -166,14 +166,14 @@ auto prefetch_history_repository::find_by_status(
             -1, "Database not connected", "prefetch_history_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .where("status", "=", std::string(status))
         .order_by("prefetched_at", database::sort_order::desc)
         .limit(limit);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -193,13 +193,13 @@ auto prefetch_history_repository::find_recent(size_t limit) -> list_result_type 
             -1, "Database not connected", "prefetch_history_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .order_by("prefetched_at", database::sort_order::desc)
         .limit(limit);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -225,7 +225,7 @@ auto prefetch_history_repository::update_status(
     sql << "UPDATE prefetch_history SET status = '" << status
         << "' WHERE pk = " << pk;
 
-    auto result = db()->update(sql.str());
+    auto result = storage_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -246,7 +246,7 @@ auto prefetch_history_repository::cleanup_old(std::chrono::hours max_age)
         WHERE prefetched_at < datetime('now', '-)"
         << max_age.count() << R"( hours'))";
 
-    auto result = db()->remove(sql.str());
+    auto result = storage_session().remove(sql.str());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/prefetch_repository.cpp
+++ b/src/storage/prefetch_repository.cpp
@@ -243,7 +243,7 @@ VoidResult prefetch_repository::initialize_tables() {
             -1, "Database not connected", "prefetch_repository"});
     }
 
-    auto result = db_->execute(R"(
+    auto result = db_->open_session().execute(R"(
         CREATE TABLE IF NOT EXISTS prefetch_rules (
             pk INTEGER PRIMARY KEY AUTOINCREMENT,
             rule_id TEXT UNIQUE NOT NULL,
@@ -271,7 +271,7 @@ VoidResult prefetch_repository::initialize_tables() {
         return result;
     }
 
-    result = db_->execute(R"(
+    result = db_->open_session().execute(R"(
         CREATE TABLE IF NOT EXISTS prefetch_history (
             pk INTEGER PRIMARY KEY AUTOINCREMENT,
             patient_id TEXT NOT NULL,
@@ -288,7 +288,7 @@ VoidResult prefetch_repository::initialize_tables() {
         return result;
     }
 
-    result = db_->execute(R"(
+    result = db_->open_session().execute(R"(
         CREATE INDEX IF NOT EXISTS idx_prefetch_history_patient ON prefetch_history(patient_id);
         CREATE INDEX IF NOT EXISTS idx_prefetch_history_study ON prefetch_history(study_uid);
         CREATE INDEX IF NOT EXISTS idx_prefetch_history_status ON prefetch_history(status);
@@ -378,7 +378,7 @@ VoidResult prefetch_repository::save_rule(const client::prefetch_rule& rule) {
             updated_at = CURRENT_TIMESTAMP
     )";
 
-    auto result = db_->insert(sql.str());
+    auto result = db_->open_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -399,7 +399,7 @@ std::optional<client::prefetch_rule> prefetch_repository::find_rule_by_id(
                triggered_count, studies_prefetched, last_triggered
         FROM prefetch_rules WHERE rule_id = ')" << rule_id << "'";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err() || result.value().empty()) {
         return std::nullopt;
     }
@@ -420,7 +420,7 @@ std::optional<client::prefetch_rule> prefetch_repository::find_rule_by_pk(
                triggered_count, studies_prefetched, last_triggered
         FROM prefetch_rules WHERE pk = )" << pk;
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err() || result.value().empty()) {
         return std::nullopt;
     }
@@ -454,7 +454,7 @@ std::vector<client::prefetch_rule> prefetch_repository::find_rules(
     sql << " ORDER BY created_at DESC";
     sql << " LIMIT " << options.limit << " OFFSET " << options.offset;
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err()) return rules;
 
     rules.reserve(result.value().size());
@@ -480,7 +480,7 @@ VoidResult prefetch_repository::remove_rule(std::string_view rule_id) {
     std::ostringstream sql;
     sql << "DELETE FROM prefetch_rules WHERE rule_id = '" << rule_id << "'";
 
-    auto result = db_->remove(sql.str());
+    auto result = db_->open_session().remove(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -494,7 +494,7 @@ bool prefetch_repository::rule_exists(std::string_view rule_id) const {
     std::ostringstream sql;
     sql << "SELECT 1 FROM prefetch_rules WHERE rule_id = '" << rule_id << "'";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     return result.is_ok() && !result.value().empty();
 }
 
@@ -515,7 +515,7 @@ VoidResult prefetch_repository::increment_triggered(std::string_view rule_id) {
             last_triggered = CURRENT_TIMESTAMP
         WHERE rule_id = ')" << rule_id << "'";
 
-    auto result = db_->update(sql.str());
+    auto result = db_->open_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -536,7 +536,7 @@ VoidResult prefetch_repository::increment_studies_prefetched(
             studies_prefetched = studies_prefetched + )" << count
         << " WHERE rule_id = '" << rule_id << "'";
 
-    auto result = db_->update(sql.str());
+    auto result = db_->open_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -557,7 +557,7 @@ VoidResult prefetch_repository::enable_rule(std::string_view rule_id) {
             updated_at = CURRENT_TIMESTAMP
         WHERE rule_id = ')" << rule_id << "'";
 
-    auto result = db_->update(sql.str());
+    auto result = db_->open_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -578,7 +578,7 @@ VoidResult prefetch_repository::disable_rule(std::string_view rule_id) {
             updated_at = CURRENT_TIMESTAMP
         WHERE rule_id = ')" << rule_id << "'";
 
-    auto result = db_->update(sql.str());
+    auto result = db_->open_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -620,7 +620,7 @@ VoidResult prefetch_repository::save_history(const client::prefetch_history& his
 
     sql << "'" << history.status << "')";
 
-    auto result = db_->insert(sql.str());
+    auto result = db_->open_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -654,7 +654,7 @@ std::vector<client::prefetch_history> prefetch_repository::find_history(
     sql << " ORDER BY prefetched_at DESC";
     sql << " LIMIT " << options.limit << " OFFSET " << options.offset;
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err()) return histories;
 
     histories.reserve(result.value().size());
@@ -673,14 +673,14 @@ bool prefetch_repository::is_study_prefetched(std::string_view study_uid) const 
         SELECT 1 FROM prefetch_history
         WHERE study_uid = ')" << study_uid << "' AND status IN ('completed', 'pending')";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     return result.is_ok() && !result.value().empty();
 }
 
 size_t prefetch_repository::count_completed_today() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select(R"(
+    auto result = db_->open_session().select(R"(
         SELECT COUNT(*) as count FROM prefetch_history
         WHERE status = 'completed'
         AND date(prefetched_at) = date('now')
@@ -693,7 +693,7 @@ size_t prefetch_repository::count_completed_today() const {
 size_t prefetch_repository::count_failed_today() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select(R"(
+    auto result = db_->open_session().select(R"(
         SELECT COUNT(*) as count FROM prefetch_history
         WHERE status = 'failed'
         AND date(prefetched_at) = date('now')
@@ -715,7 +715,7 @@ VoidResult prefetch_repository::update_history_status(
     sql << "UPDATE prefetch_history SET status = '" << status
         << "' WHERE study_uid = '" << study_uid << "'";
 
-    auto result = db_->update(sql.str());
+    auto result = db_->open_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -735,7 +735,7 @@ Result<size_t> prefetch_repository::cleanup_old_history(std::chrono::hours max_a
     std::ostringstream sql;
     sql << "DELETE FROM prefetch_history WHERE prefetched_at < '" << cutoff_str << "'";
 
-    auto result = db_->remove(sql.str());
+    auto result = db_->open_session().remove(sql.str());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }
@@ -750,7 +750,7 @@ Result<size_t> prefetch_repository::cleanup_old_history(std::chrono::hours max_a
 size_t prefetch_repository::rule_count() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select("SELECT COUNT(*) as count FROM prefetch_rules");
+    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM prefetch_rules");
     if (result.is_err() || result.value().empty()) return 0;
     return std::stoull(result.value()[0].at("count"));
 }
@@ -758,7 +758,7 @@ size_t prefetch_repository::rule_count() const {
 size_t prefetch_repository::enabled_rule_count() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select(
+    auto result = db_->open_session().select(
         "SELECT COUNT(*) as count FROM prefetch_rules WHERE enabled = 1");
     if (result.is_err() || result.value().empty()) return 0;
     return std::stoull(result.value()[0].at("count"));
@@ -767,7 +767,7 @@ size_t prefetch_repository::enabled_rule_count() const {
 size_t prefetch_repository::history_count() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select("SELECT COUNT(*) as count FROM prefetch_history");
+    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM prefetch_history");
     if (result.is_err() || result.value().empty()) return 0;
     return std::stoull(result.value()[0].at("count"));
 }

--- a/src/storage/prefetch_rule_repository.cpp
+++ b/src/storage/prefetch_rule_repository.cpp
@@ -120,7 +120,7 @@ auto prefetch_rule_repository::enable(std::string_view rule_id) -> VoidResult {
     sql << "UPDATE prefetch_rules SET enabled = 1 WHERE rule_id = '"
         << rule_id << "'";
 
-    auto result = db()->update(sql.str());
+    auto result = storage_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -138,7 +138,7 @@ auto prefetch_rule_repository::disable(std::string_view rule_id) -> VoidResult {
     sql << "UPDATE prefetch_rules SET enabled = 0 WHERE rule_id = '"
         << rule_id << "'";
 
-    auto result = db()->update(sql.str());
+    auto result = storage_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -161,7 +161,7 @@ auto prefetch_rule_repository::increment_triggered(std::string_view rule_id)
         WHERE rule_id = ')"
         << rule_id << "'";
 
-    auto result = db()->update(sql.str());
+    auto result = storage_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -181,7 +181,7 @@ auto prefetch_rule_repository::increment_studies_prefetched(
     sql << "UPDATE prefetch_rules SET studies_prefetched = studies_prefetched + "
         << count << " WHERE rule_id = '" << rule_id << "'";
 
-    auto result = db()->update(sql.str());
+    auto result = storage_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }

--- a/src/storage/recent_study_repository.cpp
+++ b/src/storage/recent_study_repository.cpp
@@ -138,7 +138,7 @@ auto recent_study_repository::record_access(
             accessed_at = excluded.accessed_at
     )";
 
-    auto result = db()->insert(sql.str());
+    auto result = storage_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -154,7 +154,7 @@ auto recent_study_repository::find_by_user(
             -1, "Database not connected", "recent_study_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .where("user_id", "=", std::string(user_id))
@@ -163,7 +163,7 @@ auto recent_study_repository::find_by_user(
         .limit(limit);
 
     auto query = builder.build();
-    auto result = db()->select(query);
+    auto result = storage_session().select(query);
 
     if (result.is_err()) {
         return list_result_type(result.error());
@@ -201,13 +201,13 @@ auto recent_study_repository::count_for_user(std::string_view user_id)
             -1, "Database not connected", "recent_study_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select({"COUNT(*) as count"})
         .from(table_name())
         .where("user_id", "=", std::string(user_id));
 
     auto query = builder.build();
-    auto result = db()->select(query);
+    auto result = storage_session().select(query);
 
     if (result.is_err()) {
         return Result<size_t>(result.error());
@@ -241,13 +241,13 @@ auto recent_study_repository::was_recently_accessed(
     auto study_cond = database::query_condition(
         "study_uid", "=", std::string(study_uid));
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select({"COUNT(*) as count"})
         .from(table_name())
         .where(user_cond && study_cond);
 
     auto query = builder.build();
-    auto result = db()->select(query);
+    auto result = storage_session().select(query);
 
     if (result.is_err()) {
         return Result<bool>(result.error());

--- a/src/storage/routing_repository.cpp
+++ b/src/storage/routing_repository.cpp
@@ -353,7 +353,7 @@ auto routing_repository::find_by_pk(int64_t pk) -> result_type {
         .where("pk", "=", pk)
         .limit(1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return result_type(result.error());
     }
@@ -389,7 +389,7 @@ auto routing_repository::find_rules(const routing_rule_query_options& options)
 
     builder.limit(options.limit).offset(options.offset);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -426,7 +426,7 @@ auto routing_repository::update_priority(std::string_view rule_id, int priority)
         .set("priority", static_cast<int64_t>(priority))
         .where("rule_id", "=", std::string(rule_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -445,7 +445,7 @@ auto routing_repository::enable_rule(std::string_view rule_id) -> VoidResult {
         .set("enabled", static_cast<int64_t>(1))
         .where("rule_id", "=", std::string(rule_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -464,7 +464,7 @@ auto routing_repository::disable_rule(std::string_view rule_id) -> VoidResult {
         .set("enabled", static_cast<int64_t>(0))
         .where("rule_id", "=", std::string(rule_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -488,7 +488,7 @@ auto routing_repository::increment_triggered(std::string_view rule_id)
                "last_triggered = CURRENT_TIMESTAMP "
                "WHERE rule_id = '" + std::string(rule_id) + "'";
 
-    auto result = db()->execute(sql);
+    auto result = storage_session().execute(sql);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -507,7 +507,7 @@ auto routing_repository::increment_success(std::string_view rule_id)
                " SET success_count = success_count + 1 WHERE rule_id = '" +
                std::string(rule_id) + "'";
 
-    auto result = db()->execute(sql);
+    auto result = storage_session().execute(sql);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -526,7 +526,7 @@ auto routing_repository::increment_failure(std::string_view rule_id)
                " SET failure_count = failure_count + 1 WHERE rule_id = '" +
                std::string(rule_id) + "'";
 
-    auto result = db()->execute(sql);
+    auto result = storage_session().execute(sql);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -549,7 +549,7 @@ auto routing_repository::reset_statistics(std::string_view rule_id)
         .set("last_triggered", std::string{})
         .where("rule_id", "=", std::string(rule_id));
 
-    auto result = db()->execute(builder.build());
+    auto result = storage_session().execute(builder.build());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -568,7 +568,7 @@ auto routing_repository::count_enabled() -> Result<size_t> {
         .from(table_name())
         .where("enabled", "=", 1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/sync_config_repository.cpp
+++ b/src/storage/sync_config_repository.cpp
@@ -151,7 +151,7 @@ auto sync_config_repository::update_stats(
             << config_id << "'";
     }
 
-    auto result = db()->update(sql.str());
+    auto result = storage_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }

--- a/src/storage/sync_conflict_repository.cpp
+++ b/src/storage/sync_conflict_repository.cpp
@@ -127,7 +127,7 @@ auto sync_conflict_repository::resolve(
         WHERE study_uid = ')"
         << study_uid << "'";
 
-    auto result = db()->update(sql.str());
+    auto result = storage_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -148,7 +148,7 @@ auto sync_conflict_repository::cleanup_old(std::chrono::hours max_age)
         WHERE resolved = 1 AND resolved_at < datetime('now', '-)"
         << max_age.count() << R"( hours'))";
 
-    auto result = db()->remove(sql.str());
+    auto result = storage_session().remove(sql.str());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/sync_history_repository.cpp
+++ b/src/storage/sync_history_repository.cpp
@@ -103,14 +103,14 @@ auto sync_history_repository::find_by_config(
             -1, "Database not connected", "sync_history_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .where("config_id", "=", std::string(config_id))
         .order_by("started_at", database::sort_order::desc)
         .limit(limit);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return list_result_type(result.error());
     }
@@ -131,14 +131,14 @@ auto sync_history_repository::find_last_for_config(std::string_view config_id)
             -1, "Database not connected", "sync_history_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .where("config_id", "=", std::string(config_id))
         .order_by("started_at", database::sort_order::desc)
         .limit(1);
 
-    auto result = db()->select(builder.build());
+    auto result = storage_session().select(builder.build());
     if (result.is_err()) {
         return result_type(result.error());
     }
@@ -164,7 +164,7 @@ auto sync_history_repository::cleanup_old(std::chrono::hours max_age)
         WHERE started_at < datetime('now', '-)"
         << max_age.count() << R"( hours'))";
 
-    auto result = db()->remove(sql.str());
+    auto result = storage_session().remove(sql.str());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }

--- a/src/storage/sync_repository.cpp
+++ b/src/storage/sync_repository.cpp
@@ -192,7 +192,7 @@ VoidResult sync_repository::save_config(const client::sync_config& config) {
             -1, "Database not connected", "sync_repository"});
     }
 
-    auto builder = db_->create_query_builder();
+    auto builder = db_->open_session().create_query_builder();
     std::ostringstream sql;
     sql << R"(
         INSERT INTO sync_configs (
@@ -237,7 +237,7 @@ VoidResult sync_repository::save_config(const client::sync_config& config) {
             updated_at = datetime('now')
     )";
 
-    auto result = db_->insert(sql.str());
+    auto result = db_->open_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -258,7 +258,7 @@ std::optional<client::sync_config> sync_repository::find_config(
                total_syncs, studies_synced
         FROM sync_configs WHERE config_id = ')" << config_id << "'";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err() || result.value().empty()) {
         return std::nullopt;
     }
@@ -279,7 +279,7 @@ std::vector<client::sync_config> sync_repository::list_configs() const {
         FROM sync_configs ORDER BY name
     )";
 
-    auto result = db_->select(sql);
+    auto result = db_->open_session().select(sql);
     if (result.is_err()) return configs;
 
     configs.reserve(result.value().size());
@@ -303,7 +303,7 @@ std::vector<client::sync_config> sync_repository::list_enabled_configs() const {
         FROM sync_configs WHERE enabled = 1 ORDER BY name
     )";
 
-    auto result = db_->select(sql);
+    auto result = db_->open_session().select(sql);
     if (result.is_err()) return configs;
 
     configs.reserve(result.value().size());
@@ -323,7 +323,7 @@ VoidResult sync_repository::remove_config(std::string_view config_id) {
     std::ostringstream sql;
     sql << "DELETE FROM sync_configs WHERE config_id = '" << config_id << "'";
 
-    auto result = db_->remove(sql.str());
+    auto result = db_->open_session().remove(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -359,7 +359,7 @@ VoidResult sync_repository::update_config_stats(
             WHERE config_id = ')" << config_id << "'";
     }
 
-    auto result = db_->update(sql.str());
+    auto result = db_->open_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -417,7 +417,7 @@ VoidResult sync_repository::save_conflict(const client::sync_conflict& conflict)
             resolved_at = excluded.resolved_at
     )";
 
-    auto result = db_->insert(sql.str());
+    auto result = db_->open_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -437,7 +437,7 @@ std::optional<client::sync_conflict> sync_repository::find_conflict(
                resolved, resolution, detected_at, resolved_at
         FROM sync_conflicts WHERE study_uid = ')" << study_uid << "'";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err() || result.value().empty()) {
         return std::nullopt;
     }
@@ -458,7 +458,7 @@ std::vector<client::sync_conflict> sync_repository::list_conflicts(
                resolved, resolution, detected_at, resolved_at
         FROM sync_conflicts WHERE config_id = ')" << config_id << R"(' ORDER BY detected_at DESC)";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err()) return conflicts;
 
     conflicts.reserve(result.value().size());
@@ -481,7 +481,7 @@ std::vector<client::sync_conflict> sync_repository::list_unresolved_conflicts() 
         FROM sync_conflicts WHERE resolved = 0 ORDER BY detected_at DESC
     )";
 
-    auto result = db_->select(sql);
+    auto result = db_->open_session().select(sql);
     if (result.is_err()) return conflicts;
 
     conflicts.reserve(result.value().size());
@@ -508,7 +508,7 @@ VoidResult sync_repository::resolve_conflict(
             resolved_at = datetime('now')
         WHERE study_uid = ')" << study_uid << "' AND resolved = 0";
 
-    auto result = db_->update(sql.str());
+    auto result = db_->open_session().update(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -529,7 +529,7 @@ Result<size_t> sync_repository::cleanup_old_conflicts(std::chrono::hours max_age
     sql << "DELETE FROM sync_conflicts WHERE resolved = 1 AND resolved_at < '"
         << cutoff_str << "'";
 
-    auto result = db_->remove(sql.str());
+    auto result = db_->open_session().remove(sql.str());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }
@@ -564,7 +564,7 @@ VoidResult sync_repository::save_history(const client::sync_history& history) {
         << "'" << format_timestamp(history.started_at) << "', "
         << "'" << format_timestamp(history.completed_at) << "')";
 
-    auto result = db_->insert(sql.str());
+    auto result = db_->open_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -585,7 +585,7 @@ std::vector<client::sync_history> sync_repository::list_history(
         FROM sync_history WHERE config_id = ')" << config_id
         << "' ORDER BY started_at DESC LIMIT " << limit;
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err()) return histories;
 
     histories.reserve(result.value().size());
@@ -608,7 +608,7 @@ std::optional<client::sync_history> sync_repository::get_last_history(
         FROM sync_history WHERE config_id = ')" << config_id
         << "' ORDER BY started_at DESC LIMIT 1";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err() || result.value().empty()) {
         return std::nullopt;
     }
@@ -628,7 +628,7 @@ Result<size_t> sync_repository::cleanup_old_history(std::chrono::hours max_age) 
     std::ostringstream sql;
     sql << "DELETE FROM sync_history WHERE completed_at < '" << cutoff_str << "'";
 
-    auto result = db_->remove(sql.str());
+    auto result = db_->open_session().remove(sql.str());
     if (result.is_err()) {
         return Result<size_t>(result.error());
     }
@@ -643,7 +643,7 @@ Result<size_t> sync_repository::cleanup_old_history(std::chrono::hours max_age) 
 size_t sync_repository::count_configs() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select("SELECT COUNT(*) as count FROM sync_configs");
+    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM sync_configs");
     if (result.is_err() || result.value().empty()) return 0;
 
     return std::stoull(result.value()[0].at("count"));
@@ -652,7 +652,7 @@ size_t sync_repository::count_configs() const {
 size_t sync_repository::count_unresolved_conflicts() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select(
+    auto result = db_->open_session().select(
         "SELECT COUNT(*) as count FROM sync_conflicts WHERE resolved = 0");
     if (result.is_err() || result.value().empty()) return 0;
 
@@ -662,7 +662,7 @@ size_t sync_repository::count_unresolved_conflicts() const {
 size_t sync_repository::count_syncs_today() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select(R"(
+    auto result = db_->open_session().select(R"(
         SELECT COUNT(*) as count FROM sync_history
         WHERE date(completed_at) = date('now')
     )");

--- a/src/storage/viewer_state_record_repository.cpp
+++ b/src/storage/viewer_state_record_repository.cpp
@@ -140,14 +140,14 @@ auto viewer_state_record_repository::find_by_study_and_user(
     auto user_cond = database::query_condition(
         "user_id", "=", std::string(user_id));
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns())
         .from(table_name())
         .where(study_cond && user_cond)
         .order_by("updated_at", database::sort_order::desc);
 
     auto query = builder.build();
-    auto result = db()->select(query);
+    auto result = storage_session().select(query);
 
     if (result.is_err()) {
         return list_result_type(result.error());
@@ -176,7 +176,7 @@ auto viewer_state_record_repository::search(const viewer_state_query& query)
             -1, "Database not connected", "viewer_state_record_repository"});
     }
 
-    auto builder = db()->create_query_builder();
+    auto builder = storage_session().create_query_builder();
     builder.select(select_columns()).from(table_name());
 
     // Build condition based on query filters
@@ -211,7 +211,7 @@ auto viewer_state_record_repository::search(const viewer_state_query& query)
     }
 
     auto sql = builder.build();
-    auto result = db()->select(sql);
+    auto result = storage_session().select(sql);
 
     if (result.is_err()) {
         return list_result_type(result.error());

--- a/src/storage/viewer_state_repository.cpp
+++ b/src/storage/viewer_state_repository.cpp
@@ -159,7 +159,7 @@ VoidResult viewer_state_repository::save_state(const viewer_state_record& record
             updated_at = excluded.updated_at
     )";
 
-    auto result = db_->insert(sql.str());
+    auto result = db_->open_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -176,7 +176,7 @@ std::optional<viewer_state_record> viewer_state_repository::find_state_by_id(
         SELECT pk, state_id, study_uid, user_id, state_json, created_at, updated_at
         FROM viewer_states WHERE state_id = ')" << state_id << "'";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err() || result.value().empty()) {
         return std::nullopt;
     }
@@ -216,7 +216,7 @@ std::vector<viewer_state_record> viewer_state_repository::search_states(
         sql << " LIMIT " << query.limit << " OFFSET " << query.offset;
     }
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err()) return states;
 
     states.reserve(result.value().size());
@@ -236,7 +236,7 @@ VoidResult viewer_state_repository::remove_state(std::string_view state_id) {
     std::ostringstream sql;
     sql << "DELETE FROM viewer_states WHERE state_id = '" << state_id << "'";
 
-    auto result = db_->remove(sql.str());
+    auto result = db_->open_session().remove(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -247,7 +247,7 @@ VoidResult viewer_state_repository::remove_state(std::string_view state_id) {
 size_t viewer_state_repository::count_states() const {
     if (!db_ || !db_->is_connected()) return 0;
 
-    auto result = db_->select("SELECT COUNT(*) as count FROM viewer_states");
+    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM viewer_states");
     if (result.is_err() || result.value().empty()) return 0;
 
     return std::stoull(result.value()[0].at("count"));
@@ -275,7 +275,7 @@ VoidResult viewer_state_repository::record_study_access(
             accessed_at = excluded.accessed_at
     )";
 
-    auto result = db_->insert(sql.str());
+    auto result = db_->open_session().insert(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -297,7 +297,7 @@ std::vector<recent_study_record> viewer_state_repository::get_recent_studies(
         ORDER BY accessed_at DESC, pk DESC
         LIMIT )" << limit;
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err()) return studies;
 
     studies.reserve(result.value().size());
@@ -317,7 +317,7 @@ VoidResult viewer_state_repository::clear_recent_studies(std::string_view user_i
     std::ostringstream sql;
     sql << "DELETE FROM recent_studies WHERE user_id = '" << user_id << "'";
 
-    auto result = db_->remove(sql.str());
+    auto result = db_->open_session().remove(sql.str());
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -332,7 +332,7 @@ size_t viewer_state_repository::count_recent_studies(std::string_view user_id) c
     sql << "SELECT COUNT(*) as count FROM recent_studies WHERE user_id = '"
         << user_id << "'";
 
-    auto result = db_->select(sql.str());
+    auto result = db_->open_session().select(sql.str());
     if (result.is_err() || result.value().empty()) return 0;
 
     return std::stoull(result.value()[0].at("count"));

--- a/tests/storage/pacs_database_adapter_test.cpp
+++ b/tests/storage/pacs_database_adapter_test.cpp
@@ -96,12 +96,15 @@ TEST_CASE("pacs_database_adapter: construction and initial state",
 TEST_CASE("pacs_database_adapter: operations fail when not connected",
           "[storage][adapter][interface]") {
     pacs_database_adapter db(":memory:");
+    auto session = db.open_session();
 
     auto select_result = db.select("SELECT 1");
     CHECK(select_result.is_err());
+    CHECK(session.select("SELECT 1").is_err());
 
     auto insert_result = db.insert("INSERT INTO test VALUES (1)");
     CHECK(insert_result.is_err());
+    CHECK(session.insert("INSERT INTO test VALUES (1)").is_err());
 
     auto update_result = db.update("UPDATE test SET x = 1");
     CHECK(update_result.is_err());
@@ -111,6 +114,9 @@ TEST_CASE("pacs_database_adapter: operations fail when not connected",
 
     auto exec_result = db.execute("CREATE TABLE test (x INT)");
     CHECK(exec_result.is_err());
+
+    auto uow_result = db.begin_unit_of_work();
+    CHECK(uow_result.is_err());
 }
 
 TEST_CASE("pacs_database_adapter: transaction state when not connected",
@@ -441,6 +447,77 @@ TEST_CASE("pacs_database_adapter: transaction template function",
     auto check = db.select("SELECT COUNT(*) as cnt FROM patients");
     REQUIRE(check.is_ok());
     CHECK(check.value()[0].at("cnt") == "2");
+}
+
+TEST_CASE("pacs_database_adapter: session boundary executes queries",
+          "[storage][adapter][integration]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: " << SQLITE_NOT_SUPPORTED_MSG);
+        return;
+    }
+
+    pacs_database_adapter db(":memory:");
+    REQUIRE(db.connect().is_ok());
+
+    auto session = db.open_session();
+    REQUIRE(session.execute(
+                  "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT)")
+                .is_ok());
+
+    auto insert_result =
+        session.insert("INSERT INTO patients (name) VALUES ('Session User')");
+    REQUIRE(insert_result.is_ok());
+    CHECK(session.last_insert_rowid() == 1);
+
+    auto select_result = session.select("SELECT name FROM patients WHERE id = 1");
+    REQUIRE(select_result.is_ok());
+    REQUIRE_FALSE(select_result.value().empty());
+    CHECK(select_result.value()[0].at("name") == "Session User");
+}
+
+TEST_CASE("pacs_database_adapter: unit_of_work owns transaction lifecycle",
+          "[storage][adapter][integration]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: " << SQLITE_NOT_SUPPORTED_MSG);
+        return;
+    }
+
+    pacs_database_adapter db(":memory:");
+    REQUIRE(db.connect().is_ok());
+    REQUIRE(db.execute(
+                  "CREATE TABLE patients (id INTEGER PRIMARY KEY, name TEXT)")
+                .is_ok());
+
+    SECTION("commit persists changes") {
+        auto uow_result = db.begin_unit_of_work();
+        REQUIRE(uow_result.is_ok());
+
+        auto uow = std::move(uow_result.value());
+        REQUIRE(uow.insert("INSERT INTO patients (name) VALUES ('Committed')")
+                    .is_ok());
+        REQUIRE(uow.commit().is_ok());
+        CHECK_FALSE(uow.is_active());
+
+        auto check = db.select("SELECT COUNT(*) as cnt FROM patients");
+        REQUIRE(check.is_ok());
+        CHECK(check.value()[0].at("cnt") == "1");
+    }
+
+    SECTION("destructor rolls back uncommitted work") {
+        {
+            auto uow_result = db.begin_unit_of_work();
+            REQUIRE(uow_result.is_ok());
+
+            auto uow = std::move(uow_result.value());
+            REQUIRE(uow.insert("INSERT INTO patients (name) VALUES ('Rolled Back')")
+                        .is_ok());
+            CHECK(uow.is_active());
+        }
+
+        auto check = db.select("SELECT COUNT(*) as cnt FROM patients");
+        REQUIRE(check.is_ok());
+        CHECK(check.value()[0].at("cnt") == "0");
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
## Background

Issue #893 asks PACS storage code to stop treating `pacs_database_adapter` as a raw SQL facade and instead consume `database_system` through a narrower PACS-owned session and unit-of-work boundary.

Before this change, repositories primarily called string-based mutator APIs directly on `pacs_database_adapter`, and transaction ownership remained centered on the adapter itself rather than on an explicit PACS storage boundary.

## Problem

The previous adapter surface made it easy for repository code to depend directly on infrastructure details:

- repositories called `select/insert/update/remove/execute` directly on the adapter
- transaction ownership was exposed as adapter state instead of a PACS unit-of-work abstraction
- compatibility repositories such as `sync_repository`, `prefetch_repository`, and `viewer_state_repository` still bypassed the storage boundary entirely
- shared repository code in `base_repository` had no session abstraction to target

That made the PACS storage layer harder to segment cleanly from `database_system` and left Phase 2 of #891 incomplete.

## Approach

This PR introduces an explicit PACS session and unit-of-work layer on top of `pacs_database_adapter`, then migrates repository code to target that boundary.

The raw adapter methods remain available as compatibility paths during the migration window, but repository runtime code now prefers the PACS-owned session surface.

## Main Changes

- added `pacs_storage_session` and `pacs_unit_of_work` to `pacs_database_adapter`
- added `open_session()` and `begin_unit_of_work()` to centralize PACS-side query execution and transaction lifecycle handling
- moved adapter internals behind private `run_*` and transaction helper methods so the new boundary can reuse one execution path
- updated `base_repository` to use the PACS session surface for query builder access, reads, writes, and batch transaction flows
- migrated derived repositories that use the shared base path to `storage_session()` calls instead of direct adapter mutation helpers
- migrated compatibility repositories `sync_repository`, `prefetch_repository`, and `viewer_state_repository` to use the PACS session surface as well
- updated `commitment_repository` transaction flows to use repository-level unit-of-work handling
- added adapter tests for the new session boundary and explicit unit-of-work lifecycle behavior

## Verification

- `cmake --build /Users/raphaelshin/Sources/pacs_system/build --target storage_tests -j4`
- `./bin/storage_tests "[storage][adapter],[storage][repository]"`

Both commands completed successfully on March 10, 2026 (Asia/Seoul).

## Remaining Risks / Follow-up

- raw string-based adapter APIs are still present as compatibility paths for incremental migration, so follow-up work can tighten or formally deprecate those escape hatches further if desired
- `index_database` still has its own large mixed persistence responsibilities and remains the larger decomposition stream tracked separately under later phases of #891

## Issue Linkage

Refs #893
Part of #891
