### PR TITLE
feat(storage): wire split repository sets into PACS services

### DIFF
--- a/include/pacs/client/prefetch_manager.hpp
+++ b/include/pacs/client/prefetch_manager.hpp
@@ -64,6 +64,11 @@
 // Forward declarations
 namespace pacs::storage {
 class prefetch_repository;
+class prefetch_rule_repository;
+class prefetch_history_repository;
+#ifdef PACS_WITH_DATABASE_SYSTEM
+struct prefetch_repository_set;
+#endif
 }
 
 namespace pacs::services {
@@ -148,6 +153,24 @@ public:
         std::shared_ptr<services::worklist_scu> worklist_scu = nullptr,
         std::shared_ptr<di::ILogger> logger = nullptr);
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    /**
+     * @brief Construct a prefetch manager from split prefetch repositories
+     *
+     * @param repositories Canonical prefetch repository set (required)
+     * @param node_manager Remote node manager for DICOM operations (required)
+     * @param job_manager Job manager for async operations (required)
+     * @param worklist_scu Worklist SCU for MWL queries (optional)
+     * @param logger Logger instance (optional, defaults to NullLogger)
+     */
+    explicit prefetch_manager(
+        const storage::prefetch_repository_set& repositories,
+        std::shared_ptr<remote_node_manager> node_manager,
+        std::shared_ptr<job_manager> job_manager,
+        std::shared_ptr<services::worklist_scu> worklist_scu = nullptr,
+        std::shared_ptr<di::ILogger> logger = nullptr);
+#endif
+
     /**
      * @brief Construct with custom configuration
      *
@@ -165,6 +188,26 @@ public:
         std::shared_ptr<job_manager> job_manager,
         std::shared_ptr<services::worklist_scu> worklist_scu = nullptr,
         std::shared_ptr<di::ILogger> logger = nullptr);
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    /**
+     * @brief Construct with split repositories and custom configuration
+     *
+     * @param config Manager configuration
+     * @param repositories Canonical prefetch repository set (required)
+     * @param node_manager Remote node manager for DICOM operations (required)
+     * @param job_manager Job manager for async operations (required)
+     * @param worklist_scu Worklist SCU for MWL queries (optional)
+     * @param logger Logger instance (optional, defaults to NullLogger)
+     */
+    explicit prefetch_manager(
+        const prefetch_manager_config& config,
+        const storage::prefetch_repository_set& repositories,
+        std::shared_ptr<remote_node_manager> node_manager,
+        std::shared_ptr<job_manager> job_manager,
+        std::shared_ptr<services::worklist_scu> worklist_scu = nullptr,
+        std::shared_ptr<di::ILogger> logger = nullptr);
+#endif
 
     /**
      * @brief Destructor - stops scheduler and monitor if running

--- a/include/pacs/client/sync_manager.hpp
+++ b/include/pacs/client/sync_manager.hpp
@@ -57,6 +57,12 @@
 // Forward declarations
 namespace pacs::storage {
 class sync_repository;
+class sync_config_repository;
+class sync_conflict_repository;
+class sync_history_repository;
+#ifdef PACS_WITH_DATABASE_SYSTEM
+struct sync_repository_set;
+#endif
 }
 
 namespace pacs::services {
@@ -137,6 +143,24 @@ public:
         std::shared_ptr<services::query_scu> query_scu,
         std::shared_ptr<di::ILogger> logger = nullptr);
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    /**
+     * @brief Construct a sync manager from split sync repositories
+     *
+     * @param repositories Canonical sync repository set (required)
+     * @param node_manager Remote node manager (required)
+     * @param job_manager Job manager for async operations (required)
+     * @param query_scu Query SCU for study comparisons (required)
+     * @param logger Logger instance (optional)
+     */
+    explicit sync_manager(
+        const storage::sync_repository_set& repositories,
+        std::shared_ptr<remote_node_manager> node_manager,
+        std::shared_ptr<job_manager> job_manager,
+        std::shared_ptr<services::query_scu> query_scu,
+        std::shared_ptr<di::ILogger> logger = nullptr);
+#endif
+
     /**
      * @brief Construct a sync manager with custom configuration
      *
@@ -154,6 +178,26 @@ public:
         std::shared_ptr<job_manager> job_manager,
         std::shared_ptr<services::query_scu> query_scu,
         std::shared_ptr<di::ILogger> logger = nullptr);
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    /**
+     * @brief Construct a sync manager with split repositories and custom config
+     *
+     * @param config Manager configuration
+     * @param repositories Canonical sync repository set (required)
+     * @param node_manager Remote node manager (required)
+     * @param job_manager Job manager for async operations (required)
+     * @param query_scu Query SCU for study comparisons (required)
+     * @param logger Logger instance (optional)
+     */
+    explicit sync_manager(
+        const sync_manager_config& config,
+        const storage::sync_repository_set& repositories,
+        std::shared_ptr<remote_node_manager> node_manager,
+        std::shared_ptr<job_manager> job_manager,
+        std::shared_ptr<services::query_scu> query_scu,
+        std::shared_ptr<di::ILogger> logger = nullptr);
+#endif
 
     /**
      * @brief Destructor - stops scheduler if running

--- a/include/pacs/storage/prefetch_history_repository.hpp
+++ b/include/pacs/storage/prefetch_history_repository.hpp
@@ -71,6 +71,10 @@ public:
 
     [[nodiscard]] auto find_recent(size_t limit = 100) -> list_result_type;
 
+    [[nodiscard]] auto count_completed_today() -> Result<size_t>;
+
+    [[nodiscard]] auto count_failed_today() -> Result<size_t>;
+
     [[nodiscard]] auto update_status(
         int64_t pk,
         std::string_view status) -> VoidResult;
@@ -95,6 +99,9 @@ protected:
         -> std::vector<std::string> override;
 
 private:
+    [[nodiscard]] auto count_by_status_today(std::string_view status)
+        -> Result<size_t>;
+
     [[nodiscard]] auto parse_timestamp(const std::string& str) const
         -> std::chrono::system_clock::time_point;
 

--- a/src/client/prefetch_manager.cpp
+++ b/src/client/prefetch_manager.cpp
@@ -38,7 +38,10 @@
 #include "pacs/client/prefetch_manager.hpp"
 #include "pacs/client/job_manager.hpp"
 #include "pacs/client/remote_node_manager.hpp"
+#include "pacs/storage/prefetch_history_repository.hpp"
 #include "pacs/storage/prefetch_repository.hpp"
+#include "pacs/storage/prefetch_rule_repository.hpp"
+#include "pacs/storage/repository_factory.hpp"
 #include "pacs/services/worklist_scu.hpp"
 #include "pacs/core/dicom_dataset.hpp"
 #include "pacs/core/dicom_tag_constants.hpp"
@@ -144,6 +147,10 @@ struct prefetch_manager::impl {
 
     // Dependencies
     std::shared_ptr<storage::prefetch_repository> repo;
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    std::shared_ptr<storage::prefetch_rule_repository> rule_repo;
+    std::shared_ptr<storage::prefetch_history_repository> history_repo;
+#endif
     std::shared_ptr<remote_node_manager> node_manager;
     std::shared_ptr<job_manager> job_mgr;
     std::shared_ptr<services::worklist_scu> worklist_scu;
@@ -178,6 +185,19 @@ struct prefetch_manager::impl {
     // =========================================================================
 
     void load_rules_from_repo() {
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (rule_repo) {
+            auto loaded = rule_repo->find_enabled();
+            if (loaded.is_err()) {
+                return;
+            }
+
+            std::unique_lock lock(rules_mutex);
+            rules_cache = std::move(loaded.value());
+            return;
+        }
+        #endif
+
         if (!repo) return;
 
         std::unique_lock lock(rules_mutex);
@@ -185,6 +205,16 @@ struct prefetch_manager::impl {
     }
 
     void save_rule_to_repo(const prefetch_rule& rule) {
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (rule_repo) {
+            auto exists = rule_repo->exists(rule.rule_id);
+            if (exists.is_ok() && exists.value()) {
+                [[maybe_unused]] auto result = rule_repo->update(rule);
+            } else {
+                [[maybe_unused]] auto result = rule_repo->insert(rule);
+            }
+        } else
+        #endif
         if (repo) {
             [[maybe_unused]] auto result = repo->save_rule(rule);
         }
@@ -212,6 +242,20 @@ struct prefetch_manager::impl {
 
     bool is_study_local(std::string_view study_uid) const {
         // Check history for completed prefetch
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (history_repo) {
+            auto history = history_repo->find_by_study(study_uid);
+            if (history.is_err()) {
+                return false;
+            }
+
+            return std::any_of(history.value().begin(), history.value().end(),
+                [](const prefetch_history& entry) {
+                    return entry.status == "completed" || entry.status == "pending";
+                });
+        }
+        #endif
+
         if (repo) {
             return repo->is_study_prefetched(study_uid);
         }
@@ -247,7 +291,11 @@ struct prefetch_manager::impl {
         const std::string& source_node_id,
         const std::string& job_id,
         const std::string& status) {
+#ifdef PACS_WITH_DATABASE_SYSTEM
+        if (!repo && !history_repo) return;
+#else
         if (!repo) return;
+#endif
 
         prefetch_history history;
         history.patient_id = patient_id;
@@ -258,10 +306,28 @@ struct prefetch_manager::impl {
         history.status = status;
         history.prefetched_at = std::chrono::system_clock::now();
 
-        [[maybe_unused]] auto result = repo->save_history(history);
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (history_repo) {
+            [[maybe_unused]] auto result = history_repo->save(history);
+        } else
+        #endif
+        {
+            [[maybe_unused]] auto result = repo->save_history(history);
+        }
     }
 
     void increment_rule_stats(const std::string& rule_id, size_t studies) {
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (rule_repo) {
+            [[maybe_unused]] auto result1 = rule_repo->increment_triggered(rule_id);
+            if (studies > 0) {
+                [[maybe_unused]] auto result2 =
+                    rule_repo->increment_studies_prefetched(rule_id, studies);
+            }
+            return;
+        }
+        #endif
+
         if (!repo) return;
 
         [[maybe_unused]] auto result1 = repo->increment_triggered(rule_id);
@@ -356,6 +422,18 @@ prefetch_manager::prefetch_manager(
           std::move(worklist_scu),
           std::move(logger)) {}
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+prefetch_manager::prefetch_manager(
+    const storage::prefetch_repository_set& repositories,
+    std::shared_ptr<remote_node_manager> node_manager,
+    std::shared_ptr<job_manager> job_manager,
+    std::shared_ptr<services::worklist_scu> worklist_scu,
+    std::shared_ptr<di::ILogger> logger)
+    : prefetch_manager(prefetch_manager_config{}, repositories,
+                       std::move(node_manager), std::move(job_manager),
+                       std::move(worklist_scu), std::move(logger)) {}
+#endif
+
 prefetch_manager::prefetch_manager(
     const prefetch_manager_config& config,
     std::shared_ptr<storage::prefetch_repository> repo,
@@ -380,6 +458,27 @@ prefetch_manager::prefetch_manager(
     impl_->load_rules_from_repo();
 }
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+prefetch_manager::prefetch_manager(
+    const prefetch_manager_config& config,
+    const storage::prefetch_repository_set& repositories,
+    std::shared_ptr<remote_node_manager> node_manager,
+    std::shared_ptr<job_manager> job_manager,
+    std::shared_ptr<services::worklist_scu> worklist_scu,
+    std::shared_ptr<di::ILogger> logger)
+    : impl_(std::make_unique<impl>()) {
+    impl_->config = config;
+    impl_->rule_repo = repositories.rules;
+    impl_->history_repo = repositories.history;
+    impl_->node_manager = std::move(node_manager);
+    impl_->job_mgr = std::move(job_manager);
+    impl_->worklist_scu = std::move(worklist_scu);
+    impl_->logger = logger ? std::move(logger) : std::make_shared<di::NullLogger>();
+
+    impl_->load_rules_from_repo();
+}
+#endif
+
 prefetch_manager::~prefetch_manager() {
     stop_scheduler();
     stop_worklist_monitor();
@@ -396,6 +495,14 @@ pacs::VoidResult prefetch_manager::add_rule(const prefetch_rule& rule) {
     }
 
     // Save to repository
+    #ifdef PACS_WITH_DATABASE_SYSTEM
+    if (impl_->rule_repo) {
+        auto result = impl_->rule_repo->insert(new_rule);
+        if (result.is_err()) {
+            return VoidResult(result.error());
+        }
+    } else
+    #endif
     if (impl_->repo) {
         auto result = impl_->repo->save_rule(new_rule);
         if (result.is_err()) {
@@ -419,6 +526,14 @@ pacs::VoidResult prefetch_manager::update_rule(const prefetch_rule& rule) {
     }
 
     // Save to repository
+    #ifdef PACS_WITH_DATABASE_SYSTEM
+    if (impl_->rule_repo) {
+        auto result = impl_->rule_repo->update(rule);
+        if (result.is_err()) {
+            return VoidResult(result.error());
+        }
+    } else
+    #endif
     if (impl_->repo) {
         auto result = impl_->repo->save_rule(rule);
         if (result.is_err()) {
@@ -443,6 +558,14 @@ pacs::VoidResult prefetch_manager::update_rule(const prefetch_rule& rule) {
 
 pacs::VoidResult prefetch_manager::remove_rule(std::string_view rule_id) {
     // Remove from repository
+    #ifdef PACS_WITH_DATABASE_SYSTEM
+    if (impl_->rule_repo) {
+        auto result = impl_->rule_repo->remove(std::string(rule_id));
+        if (result.is_err()) {
+            return result;
+        }
+    } else
+    #endif
     if (impl_->repo) {
         auto result = impl_->repo->remove_rule(rule_id);
         if (result.is_err()) {
@@ -738,6 +861,12 @@ size_t prefetch_manager::pending_prefetches() const {
 }
 
 size_t prefetch_manager::completed_today() const {
+    #ifdef PACS_WITH_DATABASE_SYSTEM
+    if (impl_->history_repo) {
+        auto count = impl_->history_repo->count_completed_today();
+        return count.is_ok() ? count.value() : 0;
+    }
+    #endif
     if (impl_->repo) {
         return impl_->repo->count_completed_today();
     }
@@ -745,6 +874,12 @@ size_t prefetch_manager::completed_today() const {
 }
 
 size_t prefetch_manager::failed_today() const {
+    #ifdef PACS_WITH_DATABASE_SYSTEM
+    if (impl_->history_repo) {
+        auto count = impl_->history_repo->count_failed_today();
+        return count.is_ok() ? count.value() : 0;
+    }
+    #endif
     if (impl_->repo) {
         return impl_->repo->count_failed_today();
     }

--- a/src/client/sync_manager.cpp
+++ b/src/client/sync_manager.cpp
@@ -38,6 +38,10 @@
 #include "pacs/client/sync_manager.hpp"
 #include "pacs/client/job_manager.hpp"
 #include "pacs/client/remote_node_manager.hpp"
+#include "pacs/storage/repository_factory.hpp"
+#include "pacs/storage/sync_config_repository.hpp"
+#include "pacs/storage/sync_conflict_repository.hpp"
+#include "pacs/storage/sync_history_repository.hpp"
 #include "pacs/storage/sync_repository.hpp"
 #include "pacs/services/query_scu.hpp"
 #include "pacs/core/dicom_tag_constants.hpp"
@@ -102,6 +106,11 @@ struct sync_manager::impl {
 
     // Dependencies
     std::shared_ptr<storage::sync_repository> repo;
+#ifdef PACS_WITH_DATABASE_SYSTEM
+    std::shared_ptr<storage::sync_config_repository> config_repo;
+    std::shared_ptr<storage::sync_conflict_repository> conflict_repo;
+    std::shared_ptr<storage::sync_history_repository> history_repo;
+#endif
     std::shared_ptr<remote_node_manager> node_manager;
     std::shared_ptr<job_manager> job_mgr;
     std::shared_ptr<services::query_scu> query_scu;
@@ -167,6 +176,16 @@ struct sync_manager::impl {
             }
         }
 
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (config_repo) {
+            auto exists = config_repo->exists(cfg.config_id);
+            if (exists.is_ok() && exists.value()) {
+                [[maybe_unused]] auto result = config_repo->update(cfg);
+            } else {
+                [[maybe_unused]] auto result = config_repo->insert(cfg);
+            }
+        } else
+        #endif
         if (repo) {
             [[maybe_unused]] auto result = repo->save_config(cfg);
         }
@@ -198,6 +217,17 @@ struct sync_manager::impl {
             if (success) {
                 it->last_successful_sync = std::chrono::system_clock::now();
             }
+        }
+
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (config_repo) {
+            [[maybe_unused]] auto result =
+                config_repo->update_stats(config_id, success, studies_synced);
+        } else
+        #endif
+        if (repo) {
+            [[maybe_unused]] auto result =
+                repo->update_config_stats(config_id, success, studies_synced);
         }
     }
 
@@ -270,6 +300,16 @@ struct sync_manager::impl {
             }
         }
 
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (conflict_repo) {
+            auto exists = conflict_repo->exists(conflict.study_uid);
+            if (exists.is_ok() && exists.value()) {
+                [[maybe_unused]] auto result = conflict_repo->update(conflict);
+            } else {
+                [[maybe_unused]] auto result = conflict_repo->insert(conflict);
+            }
+        } else
+        #endif
         if (repo) {
             [[maybe_unused]] auto result = repo->save_conflict(conflict);
         }
@@ -415,17 +455,23 @@ struct sync_manager::impl {
         store_last_result(cfg.config_id, result);
 
         // Save history
+        sync_history history;
+        history.config_id = cfg.config_id;
+        history.job_id = result.job_id;
+        history.success = result.success;
+        history.studies_checked = result.studies_checked;
+        history.studies_synced = result.studies_synced;
+        history.conflicts_found = result.conflicts.size();
+        history.errors = result.errors;
+        history.started_at = result.started_at;
+        history.completed_at = result.completed_at;
+
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (history_repo) {
+            [[maybe_unused]] auto save_result = history_repo->save(history);
+        } else
+        #endif
         if (repo) {
-            sync_history history;
-            history.config_id = cfg.config_id;
-            history.job_id = result.job_id;
-            history.success = result.success;
-            history.studies_checked = result.studies_checked;
-            history.studies_synced = result.studies_synced;
-            history.conflicts_found = result.conflicts.size();
-            history.errors = result.errors;
-            history.started_at = result.started_at;
-            history.completed_at = result.completed_at;
             [[maybe_unused]] auto save_result = repo->save_history(history);
         }
 
@@ -636,6 +682,27 @@ struct sync_manager::impl {
     }
 
     void load_configs_from_repo() {
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (config_repo) {
+            auto loaded = config_repo->find_all();
+            if (loaded.is_err()) {
+                return;
+            }
+
+            {
+                std::unique_lock lock(configs_mutex);
+                configs = std::move(loaded.value());
+            }
+
+            if (logger && !configs.empty()) {
+                logger->info_fmt(
+                    "Loaded {} sync configs from split repositories",
+                    configs.size());
+            }
+            return;
+        }
+        #endif
+
         if (!repo) return;
 
         auto loaded = repo->list_configs();
@@ -650,6 +717,27 @@ struct sync_manager::impl {
     }
 
     void load_conflicts_from_repo() {
+        #ifdef PACS_WITH_DATABASE_SYSTEM
+        if (conflict_repo) {
+            auto loaded = conflict_repo->find_unresolved();
+            if (loaded.is_err()) {
+                return;
+            }
+
+            {
+                std::lock_guard lock(conflicts_mutex);
+                conflicts = std::move(loaded.value());
+            }
+
+            if (logger && !conflicts.empty()) {
+                logger->info_fmt(
+                    "Loaded {} unresolved conflicts from split repositories",
+                    conflicts.size());
+            }
+            return;
+        }
+        #endif
+
         if (!repo) return;
 
         auto loaded = repo->list_unresolved_conflicts();
@@ -678,6 +766,18 @@ sync_manager::sync_manager(
                    std::move(job_manager), std::move(query_scu), std::move(logger)) {
 }
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+sync_manager::sync_manager(
+    const storage::sync_repository_set& repositories,
+    std::shared_ptr<remote_node_manager> node_manager,
+    std::shared_ptr<job_manager> job_manager,
+    std::shared_ptr<services::query_scu> query_scu,
+    std::shared_ptr<di::ILogger> logger)
+    : sync_manager(sync_manager_config{}, repositories, std::move(node_manager),
+                   std::move(job_manager), std::move(query_scu),
+                   std::move(logger)) {}
+#endif
+
 sync_manager::sync_manager(
     const sync_manager_config& config,
     std::shared_ptr<storage::sync_repository> repo,
@@ -697,6 +797,29 @@ sync_manager::sync_manager(
     impl_->load_configs_from_repo();
     impl_->load_conflicts_from_repo();
 }
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+sync_manager::sync_manager(
+    const sync_manager_config& config,
+    const storage::sync_repository_set& repositories,
+    std::shared_ptr<remote_node_manager> node_manager,
+    std::shared_ptr<job_manager> job_manager,
+    std::shared_ptr<services::query_scu> query_scu,
+    std::shared_ptr<di::ILogger> logger)
+    : impl_(std::make_unique<impl>()) {
+    impl_->config = config;
+    impl_->config_repo = repositories.configs;
+    impl_->conflict_repo = repositories.conflicts;
+    impl_->history_repo = repositories.history;
+    impl_->node_manager = std::move(node_manager);
+    impl_->job_mgr = std::move(job_manager);
+    impl_->query_scu = std::move(query_scu);
+    impl_->logger = logger ? std::move(logger) : di::null_logger();
+
+    impl_->load_configs_from_repo();
+    impl_->load_conflicts_from_repo();
+}
+#endif
 
 sync_manager::~sync_manager() {
     stop_scheduler();
@@ -767,6 +890,12 @@ pacs::VoidResult sync_manager::remove_config(std::string_view config_id) {
         impl_->configs.erase(it);
     }
 
+    #ifdef PACS_WITH_DATABASE_SYSTEM
+    if (impl_->config_repo) {
+        [[maybe_unused]] auto result =
+            impl_->config_repo->remove(std::string(config_id));
+    } else
+    #endif
     if (impl_->repo) {
         [[maybe_unused]] auto result = impl_->repo->remove_config(config_id);
     }
@@ -945,8 +1074,15 @@ pacs::VoidResult sync_manager::resolve_conflict(
     it->resolution_used = resolution;
     it->resolved_at = std::chrono::system_clock::now();
 
+    #ifdef PACS_WITH_DATABASE_SYSTEM
+    if (impl_->conflict_repo) {
+        [[maybe_unused]] auto result =
+            impl_->conflict_repo->resolve(study_uid, resolution);
+    } else
+    #endif
     if (impl_->repo) {
-        [[maybe_unused]] auto result = impl_->repo->resolve_conflict(study_uid, resolution);
+        [[maybe_unused]] auto result =
+            impl_->repo->resolve_conflict(study_uid, resolution);
     }
 
     if (impl_->logger) {

--- a/src/storage/prefetch_history_repository.cpp
+++ b/src/storage/prefetch_history_repository.cpp
@@ -213,6 +213,14 @@ auto prefetch_history_repository::find_recent(size_t limit) -> list_result_type 
     return list_result_type(std::move(entities));
 }
 
+auto prefetch_history_repository::count_completed_today() -> Result<size_t> {
+    return count_by_status_today("completed");
+}
+
+auto prefetch_history_repository::count_failed_today() -> Result<size_t> {
+    return count_by_status_today("failed");
+}
+
 auto prefetch_history_repository::update_status(
     int64_t pk,
     std::string_view status) -> VoidResult {
@@ -252,6 +260,38 @@ auto prefetch_history_repository::cleanup_old(std::chrono::hours max_age)
     }
 
     return Result<size_t>(static_cast<size_t>(result.value()));
+}
+
+auto prefetch_history_repository::count_by_status_today(std::string_view status)
+    -> Result<size_t> {
+    if (!db() || !db()->is_connected()) {
+        return Result<size_t>(kcenon::common::error_info{
+            -1, "Database not connected", "prefetch_history_repository"});
+    }
+
+    std::ostringstream sql;
+    sql << R"(
+        SELECT COUNT(*) as count FROM prefetch_history
+        WHERE status = ')" << status << R"('
+        AND date(prefetched_at) = date('now')
+    )";
+
+    auto result = storage_session().select(sql.str());
+    if (result.is_err()) {
+        return Result<size_t>(result.error());
+    }
+
+    if (result.value().empty()) {
+        return Result<size_t>(static_cast<size_t>(0));
+    }
+
+    try {
+        return Result<size_t>(std::stoull(result.value()[0].at("count")));
+    } catch (const std::exception& e) {
+        return Result<size_t>(kcenon::common::error_info{
+            -1, std::string("Failed to parse count: ") + e.what(),
+            "prefetch_history_repository"});
+    }
 }
 
 auto prefetch_history_repository::map_row_to_entity(

--- a/src/web/endpoints/viewer_state_endpoints.cpp
+++ b/src/web/endpoints/viewer_state_endpoints.cpp
@@ -49,6 +49,10 @@
 #endif
 
 #include "pacs/storage/index_database.hpp"
+#ifdef PACS_WITH_DATABASE_SYSTEM
+#include "pacs/storage/recent_study_repository.hpp"
+#include "pacs/storage/viewer_state_record_repository.hpp"
+#endif
 #include "pacs/storage/viewer_state_record.hpp"
 #include "pacs/storage/viewer_state_repository.hpp"
 #include "pacs/web/endpoints/system_endpoints.hpp"
@@ -300,11 +304,17 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
         }
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
-        storage::viewer_state_repository repo(ctx->database->db_adapter());
+        storage::viewer_state_record_repository state_repo(
+            ctx->database->db_adapter());
+        storage::recent_study_repository recent_repo(ctx->database->db_adapter());
 #else
         storage::viewer_state_repository repo(ctx->database->native_handle());
 #endif
+#ifdef PACS_WITH_DATABASE_SYSTEM
+        auto save_result = state_repo.insert(state);
+#else
         auto save_result = repo.save_state(state);
+#endif
         if (!save_result.is_ok()) {
           res.code = 500;
           res.body =
@@ -314,7 +324,11 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
 
         // Also record study access if user_id is provided
         if (!state.user_id.empty()) {
+#ifdef PACS_WITH_DATABASE_SYSTEM
+          (void)recent_repo.record_access(state.user_id, state.study_uid);
+#else
           (void)repo.record_study_access(state.user_id, state.study_uid);
+#endif
         }
 
         res.code = 201;
@@ -363,11 +377,22 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
         }
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
-        storage::viewer_state_repository repo(ctx->database->db_adapter());
+        storage::viewer_state_record_repository repo(ctx->database->db_adapter());
 #else
         storage::viewer_state_repository repo(ctx->database->native_handle());
 #endif
+#ifdef PACS_WITH_DATABASE_SYSTEM
+        auto states_result = repo.search(query);
+        if (!states_result.is_ok()) {
+          res.code = 500;
+          res.body =
+              make_error_json("QUERY_ERROR", states_result.error().message);
+          return res;
+        }
+        auto states = std::move(states_result.value());
+#else
         auto states = repo.search_states(query);
+#endif
 
         res.code = 200;
         res.body = viewer_states_to_json(states);
@@ -390,19 +415,47 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
             }
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
-            storage::viewer_state_repository repo(ctx->database->db_adapter());
+            storage::viewer_state_record_repository repo(
+                ctx->database->db_adapter());
 #else
             storage::viewer_state_repository repo(ctx->database->native_handle());
 #endif
+#ifdef PACS_WITH_DATABASE_SYSTEM
+            auto exists = repo.exists(state_id);
+            if (exists.is_err()) {
+              res.code = 500;
+              res.body =
+                  make_error_json("QUERY_ERROR", exists.error().message);
+              return res;
+            }
+            if (!exists.value()) {
+              res.code = 404;
+              res.body = make_error_json("NOT_FOUND", "Viewer state not found");
+              return res;
+            }
+
+            auto state = repo.find_by_id(state_id);
+            if (state.is_err()) {
+              res.code = 500;
+              res.body =
+                  make_error_json("QUERY_ERROR", state.error().message);
+              return res;
+            }
+#else
             auto state = repo.find_state_by_id(state_id);
             if (!state.has_value()) {
               res.code = 404;
               res.body = make_error_json("NOT_FOUND", "Viewer state not found");
               return res;
             }
+#endif
 
             res.code = 200;
+#ifdef PACS_WITH_DATABASE_SYSTEM
             res.body = viewer_state_to_json(state.value());
+#else
+            res.body = viewer_state_to_json(state.value());
+#endif
             return res;
           });
 
@@ -422,10 +475,29 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
             }
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
-            storage::viewer_state_repository repo(ctx->database->db_adapter());
+            storage::viewer_state_record_repository repo(
+                ctx->database->db_adapter());
 #else
             storage::viewer_state_repository repo(ctx->database->native_handle());
 #endif
+#ifdef PACS_WITH_DATABASE_SYSTEM
+            auto exists = repo.exists(state_id);
+            if (exists.is_err()) {
+              res.code = 500;
+              res.add_header("Content-Type", "application/json");
+              res.body =
+                  make_error_json("QUERY_ERROR", exists.error().message);
+              return res;
+            }
+            if (!exists.value()) {
+              res.code = 404;
+              res.add_header("Content-Type", "application/json");
+              res.body = make_error_json("NOT_FOUND", "Viewer state not found");
+              return res;
+            }
+
+            auto remove_result = repo.remove(state_id);
+#else
             auto existing = repo.find_state_by_id(state_id);
             if (!existing.has_value()) {
               res.code = 404;
@@ -435,6 +507,7 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
             }
 
             auto remove_result = repo.remove_state(state_id);
+#endif
             if (!remove_result.is_ok()) {
               res.code = 500;
               res.add_header("Content-Type", "application/json");
@@ -476,15 +549,36 @@ void register_viewer_state_endpoints_impl(crow::SimpleApp &app,
             }
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
-            storage::viewer_state_repository repo(ctx->database->db_adapter());
+            storage::recent_study_repository repo(ctx->database->db_adapter());
 #else
             storage::viewer_state_repository repo(ctx->database->native_handle());
 #endif
+#ifdef PACS_WITH_DATABASE_SYSTEM
+            auto records = repo.find_by_user(user_id, limit);
+            if (records.is_err()) {
+              res.code = 500;
+              res.body =
+                  make_error_json("QUERY_ERROR", records.error().message);
+              return res;
+            }
+
+            auto total = repo.count_for_user(user_id);
+            if (total.is_err()) {
+              res.code = 500;
+              res.body =
+                  make_error_json("QUERY_ERROR", total.error().message);
+              return res;
+            }
+
+            res.code = 200;
+            res.body = recent_studies_to_json(records.value(), total.value());
+#else
             auto records = repo.get_recent_studies(user_id, limit);
             size_t total = repo.count_recent_studies(user_id);
 
             res.code = 200;
             res.body = recent_studies_to_json(records, total);
+#endif
             return res;
           });
 }

--- a/tests/client/prefetch_manager_test.cpp
+++ b/tests/client/prefetch_manager_test.cpp
@@ -11,8 +11,17 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+#include <pacs/storage/migration_runner.hpp>
+#include <pacs/storage/pacs_database_adapter.hpp>
+#include <pacs/storage/prefetch_history_repository.hpp>
+#include <pacs/storage/prefetch_rule_repository.hpp>
+#include <pacs/storage/repository_factory.hpp>
+#endif
+
 #include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -69,6 +78,45 @@ private:
 };
 
 }  // namespace
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+namespace {
+
+bool is_sqlite_backend_supported() {
+    pacs::storage::pacs_database_adapter db(":memory:");
+    auto result = db.connect();
+    return result.is_ok();
+}
+
+class test_database {
+public:
+    test_database() {
+        db_ = std::make_shared<pacs::storage::pacs_database_adapter>(":memory:");
+        auto conn_result = db_->connect();
+        if (conn_result.is_err()) {
+            throw std::runtime_error(
+                "Failed to connect: " + conn_result.error().message);
+        }
+
+        pacs::storage::migration_runner runner;
+        auto result = runner.run_migrations(*db_);
+        if (result.is_err()) {
+            throw std::runtime_error(
+                "Migration failed: " + result.error().message);
+        }
+    }
+
+    [[nodiscard]] auto get() const noexcept
+        -> std::shared_ptr<pacs::storage::pacs_database_adapter> {
+        return db_;
+    }
+
+private:
+    std::shared_ptr<pacs::storage::pacs_database_adapter> db_;
+};
+
+}  // namespace
+#endif
 
 // =============================================================================
 // Prefetch Types Tests
@@ -145,6 +193,49 @@ TEST_CASE("prefetch_manager_config default values", "[prefetch_types]") {
     CHECK(config.max_concurrent_prefetch == 4);
     CHECK(config.deduplicate_requests == true);
 }
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+TEST_CASE("prefetch_manager loads split repository sets",
+          "[prefetch_manager][storage]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+
+    test_database tdb;
+    pacs::storage::repository_factory factory(tdb.get());
+
+    prefetch_rule rule;
+    rule.rule_id = "rule-1";
+    rule.name = "CT Priors";
+    rule.trigger = prefetch_trigger::prior_studies;
+    rule.source_node_ids = {"archive"};
+    REQUIRE(factory.prefetch_rules()->insert(rule).is_ok());
+
+    prefetch_history history;
+    history.patient_id = "PATIENT001";
+    history.study_uid = "1.2.3.4";
+    history.rule_id = rule.rule_id;
+    history.source_node_id = "archive";
+    history.job_id = "job-1";
+    history.status = "completed";
+    history.prefetched_at = std::chrono::system_clock::now();
+    REQUIRE(factory.prefetch_history()->save(history).is_ok());
+
+    auto logger = std::make_shared<MockLogger>();
+    prefetch_manager manager(
+        factory.canonical_repositories().prefetch,
+        nullptr,
+        nullptr,
+        nullptr,
+        logger);
+
+    auto rules = manager.list_rules();
+    REQUIRE(rules.size() == 1);
+    CHECK(rules.front().rule_id == rule.rule_id);
+    CHECK(manager.completed_today() == 1);
+}
+#endif
 
 // =============================================================================
 // Prefetch Manager Construction Tests

--- a/tests/client/sync_manager_test.cpp
+++ b/tests/client/sync_manager_test.cpp
@@ -12,9 +12,18 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+#include <pacs/storage/migration_runner.hpp>
+#include <pacs/storage/pacs_database_adapter.hpp>
+#include <pacs/storage/repository_factory.hpp>
+#include <pacs/storage/sync_config_repository.hpp>
+#include <pacs/storage/sync_conflict_repository.hpp>
+#endif
+
 #include <atomic>
 #include <chrono>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -72,6 +81,45 @@ private:
 };
 
 }  // namespace
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+namespace {
+
+bool is_sqlite_backend_supported() {
+    pacs::storage::pacs_database_adapter db(":memory:");
+    auto result = db.connect();
+    return result.is_ok();
+}
+
+class test_database {
+public:
+    test_database() {
+        db_ = std::make_shared<pacs::storage::pacs_database_adapter>(":memory:");
+        auto conn_result = db_->connect();
+        if (conn_result.is_err()) {
+            throw std::runtime_error(
+                "Failed to connect: " + conn_result.error().message);
+        }
+
+        pacs::storage::migration_runner runner;
+        auto result = runner.run_migrations(*db_);
+        if (result.is_err()) {
+            throw std::runtime_error(
+                "Migration failed: " + result.error().message);
+        }
+    }
+
+    [[nodiscard]] auto get() const noexcept
+        -> std::shared_ptr<pacs::storage::pacs_database_adapter> {
+        return db_;
+    }
+
+private:
+    std::shared_ptr<pacs::storage::pacs_database_adapter> db_;
+};
+
+}  // namespace
+#endif
 
 // =============================================================================
 // Sync Direction Tests
@@ -278,6 +326,48 @@ TEST_CASE("sync_manager_config initialization", "[sync_types]") {
     CHECK(config.auto_resolve_conflicts == true);
     CHECK(config.default_resolution == conflict_resolution::prefer_newer);
 }
+
+#ifdef PACS_WITH_DATABASE_SYSTEM
+TEST_CASE("sync_manager loads split repository sets", "[sync_manager][storage]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+
+    test_database tdb;
+    pacs::storage::repository_factory factory(tdb.get());
+
+    sync_config config;
+    config.config_id = "daily-sync";
+    config.source_node_id = "archive";
+    config.name = "Daily Sync";
+    REQUIRE(factory.sync_configs()->insert(config).is_ok());
+
+    sync_conflict conflict;
+    conflict.config_id = config.config_id;
+    conflict.study_uid = "1.2.3.4";
+    conflict.patient_id = "PATIENT001";
+    conflict.conflict_type = sync_conflict_type::missing_local;
+    conflict.detected_at = std::chrono::system_clock::now();
+    REQUIRE(factory.sync_conflicts()->insert(conflict).is_ok());
+
+    auto logger = std::make_shared<MockLogger>();
+    sync_manager manager(
+        factory.canonical_repositories().sync,
+        nullptr,
+        nullptr,
+        nullptr,
+        logger);
+
+    auto configs = manager.list_configs();
+    REQUIRE(configs.size() == 1);
+    CHECK(configs.front().config_id == config.config_id);
+
+    auto conflicts = manager.get_conflicts();
+    REQUIRE(conflicts.size() == 1);
+    CHECK(conflicts.front().study_uid == conflict.study_uid);
+}
+#endif
 
 // =============================================================================
 // Sync Statistics Tests

--- a/tests/storage/repository_factory_test.cpp
+++ b/tests/storage/repository_factory_test.cpp
@@ -10,12 +10,22 @@
 
 #include <catch2/catch_test_macros.hpp>
 
+#include <pacs/client/prefetch_types.hpp>
+#include <pacs/client/sync_types.hpp>
+#include <pacs/storage/prefetch_repository.hpp>
+#include <pacs/storage/prefetch_rule_repository.hpp>
+#include <pacs/storage/recent_study_repository.hpp>
 #include <pacs/storage/repository_factory.hpp>
+#include <pacs/storage/sync_config_repository.hpp>
+#include <pacs/storage/sync_repository.hpp>
+#include <pacs/storage/viewer_state_repository.hpp>
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
 
 #include <pacs/storage/migration_runner.hpp>
 #include <pacs/storage/pacs_database_adapter.hpp>
+
+#include <stdexcept>
 
 using namespace pacs::storage;
 
@@ -232,6 +242,41 @@ TEST_CASE("repository_factory returns structured canonical and compatibility set
     CHECK(compatibility.sync_states == factory.sync_states());
     CHECK(compatibility.viewer_states == factory.viewer_states());
     CHECK(compatibility.prefetch_queue == factory.prefetch_queue());
+}
+
+TEST_CASE("repository_factory split and compatibility repositories share state",
+          "[storage][repository_factory]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+
+    test_database tdb;
+    repository_factory factory(tdb.get());
+    const auto canonical = factory.canonical_repositories();
+    const auto compatibility = factory.compatibility_repositories();
+
+    pacs::client::sync_config config;
+    config.config_id = "sync-config";
+    config.source_node_id = "archive";
+    config.name = "Shared Sync";
+    REQUIRE(canonical.sync.configs->insert(config).is_ok());
+
+    auto loaded_config = compatibility.sync_states->find_config(config.config_id);
+    REQUIRE(loaded_config.has_value());
+    CHECK(loaded_config->name == config.name);
+
+    pacs::client::prefetch_rule rule;
+    rule.rule_id = "prefetch-rule";
+    rule.name = "Shared Rule";
+    rule.trigger = pacs::client::prefetch_trigger::manual;
+    rule.source_node_ids = {"archive"};
+    REQUIRE(canonical.prefetch.rules->insert(rule).is_ok());
+    CHECK(compatibility.prefetch_queue->rule_exists(rule.rule_id));
+
+    REQUIRE(
+        canonical.viewer_state.recent_studies->record_access("user1", "1.2.3").is_ok());
+    CHECK(compatibility.viewer_states->count_recent_studies("user1") == 1);
 }
 
 #endif  // PACS_WITH_DATABASE_SYSTEM


### PR DESCRIPTION
## Background
- Issue #894 moves PACS-facing wiring away from aggregate repository bundles and onto the canonical split repository-set contract introduced in earlier storage migration work.
- This branch is intentionally stacked on top of feat/issue-893-storage-session-boundary because the split wiring should share the same session-boundary behavior added there.

## Problem
- repository_factory already exposed canonical split repositories, but higher-level PACS wiring still depended on aggregate repositories or aggregate endpoint adapters.
- That left the canonical contract underused and made it harder to validate that split repositories still share the same database session behavior.

## Approach
- Add DB-system specific constructors for sync_manager and prefetch_manager that accept canonical split repository sets while preserving aggregate compatibility constructors.
- Migrate viewer-state endpoint wiring to use viewer_state_record_repository and recent_study_repository directly on the DB-system path.
- Extend split prefetch history repositories with the day-level counters needed by existing prefetch manager statistics.
- Add targeted tests that exercise split wiring and verify split and compatibility repositories observe the same persisted state.

## Main Changes
- Added canonical split-set constructors to sync_manager and prefetch_manager and updated their internal persistence paths to prefer split repositories when available.
- Updated viewer-state REST endpoints to persist and query through split repositories on the DB-system build path.
- Added count_completed_today and count_failed_today to prefetch_history_repository for split-history statistics.
- Added coverage for split manager construction and repository-factory shared-state behavior.

## Verification
- cmake --build /Users/raphaelshin/Sources/pacs_system/build --target client_tests storage_tests web_tests
- ./bin/storage_tests "[storage][repository_factory]"
- ./bin/client_tests "[sync_manager][storage],[prefetch_manager][storage]"
- ./bin/web_tests "[web][viewer_state]"

## Risks / Follow-up
- This PR keeps aggregate repository constructors and compatibility accessors intact; they remain the fallback path for non-DB-system builds and any unmigrated callers.
- Because this PR is stacked on feat/issue-893-storage-session-boundary, final merge order should be the #893 change first and then this PR.

Part of #894
