### PR TITLE
refactor(storage): route client-state compatibility repos through split repositories

### DIFF
--- a/src/storage/prefetch_repository.cpp
+++ b/src/storage/prefetch_repository.cpp
@@ -37,7 +37,10 @@
  */
 
 #include "pacs/storage/prefetch_repository.hpp"
+#include "pacs/storage/prefetch_history_repository.hpp"
+#include "pacs/storage/prefetch_rule_repository.hpp"
 
+#include <algorithm>
 #include <chrono>
 #include <cstring>
 #include <sstream>
@@ -158,6 +161,14 @@ namespace {
 }
 
 }  // namespace
+
+template <typename T>
+[[nodiscard]] std::optional<T> optional_from_result(Result<T> result) {
+    if (result.is_err()) {
+        return std::nullopt;
+    }
+    return result.value();
+}
 
 // =============================================================================
 // JSON Serialization
@@ -302,83 +313,7 @@ VoidResult prefetch_repository::initialize_tables() {
 // =============================================================================
 
 VoidResult prefetch_repository::save_rule(const client::prefetch_rule& rule) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        INSERT INTO prefetch_rules (
-            rule_id, name, enabled, trigger_type,
-            modality_filter, body_part_filter, station_ae_filter,
-            prior_lookback_hours, max_prior_studies, prior_modalities_json,
-            source_node_ids_json, schedule_cron, advance_time_minutes,
-            triggered_count, studies_prefetched, last_triggered
-        ) VALUES (
-            ')" << rule.rule_id << "', "
-        << "'" << rule.name << "', "
-        << (rule.enabled ? 1 : 0) << ", "
-        << "'" << client::to_string(rule.trigger) << "', ";
-
-    if (rule.modality_filter.empty()) {
-        sql << "NULL, ";
-    } else {
-        sql << "'" << rule.modality_filter << "', ";
-    }
-
-    if (rule.body_part_filter.empty()) {
-        sql << "NULL, ";
-    } else {
-        sql << "'" << rule.body_part_filter << "', ";
-    }
-
-    if (rule.station_ae_filter.empty()) {
-        sql << "NULL, ";
-    } else {
-        sql << "'" << rule.station_ae_filter << "', ";
-    }
-
-    sql << rule.prior_lookback.count() << ", "
-        << rule.max_prior_studies << ", "
-        << "'" << serialize_modalities(rule.prior_modalities) << "', "
-        << "'" << serialize_node_ids(rule.source_node_ids) << "', ";
-
-    if (rule.schedule_cron.empty()) {
-        sql << "NULL, ";
-    } else {
-        sql << "'" << rule.schedule_cron << "', ";
-    }
-
-    sql << rule.advance_time.count() << ", "
-        << rule.triggered_count << ", "
-        << rule.studies_prefetched << ", ";
-
-    auto last_triggered_str = format_timestamp(rule.last_triggered);
-    if (last_triggered_str.empty()) {
-        sql << "NULL";
-    } else {
-        sql << "'" << last_triggered_str << "'";
-    }
-
-    sql << R"()
-        ON CONFLICT(rule_id) DO UPDATE SET
-            name = excluded.name,
-            enabled = excluded.enabled,
-            trigger_type = excluded.trigger_type,
-            modality_filter = excluded.modality_filter,
-            body_part_filter = excluded.body_part_filter,
-            station_ae_filter = excluded.station_ae_filter,
-            prior_lookback_hours = excluded.prior_lookback_hours,
-            max_prior_studies = excluded.max_prior_studies,
-            prior_modalities_json = excluded.prior_modalities_json,
-            source_node_ids_json = excluded.source_node_ids_json,
-            schedule_cron = excluded.schedule_cron,
-            advance_time_minutes = excluded.advance_time_minutes,
-            updated_at = CURRENT_TIMESTAMP
-    )";
-
-    auto result = db_->open_session().insert(sql.str());
+    auto result = prefetch_rule_repository(db_).save(rule);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -388,39 +323,37 @@ VoidResult prefetch_repository::save_rule(const client::prefetch_rule& rule) {
 
 std::optional<client::prefetch_rule> prefetch_repository::find_rule_by_id(
     std::string_view rule_id) const {
-    if (!db_ || !db_->is_connected()) return std::nullopt;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, rule_id, name, enabled, trigger_type,
-               modality_filter, body_part_filter, station_ae_filter,
-               prior_lookback_hours, max_prior_studies, prior_modalities_json,
-               source_node_ids_json, schedule_cron, advance_time_minutes,
-               triggered_count, studies_prefetched, last_triggered
-        FROM prefetch_rules WHERE rule_id = ')" << rule_id << "'";
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err() || result.value().empty()) {
-        return std::nullopt;
-    }
-
-    return map_row_to_rule(result.value()[0]);
+    return optional_from_result(
+        prefetch_rule_repository(db_).find_by_rule_id(rule_id));
 }
 
 std::optional<client::prefetch_rule> prefetch_repository::find_rule_by_pk(
     int64_t pk) const {
     if (!db_ || !db_->is_connected()) return std::nullopt;
 
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, rule_id, name, enabled, trigger_type,
-               modality_filter, body_part_filter, station_ae_filter,
-               prior_lookback_hours, max_prior_studies, prior_modalities_json,
-               source_node_ids_json, schedule_cron, advance_time_minutes,
-               triggered_count, studies_prefetched, last_triggered
-        FROM prefetch_rules WHERE pk = )" << pk;
+    auto builder = db_->open_session().create_query_builder();
+    builder.select({"pk",
+                    "rule_id",
+                    "name",
+                    "enabled",
+                    "trigger_type",
+                    "modality_filter",
+                    "body_part_filter",
+                    "station_ae_filter",
+                    "prior_lookback_hours",
+                    "max_prior_studies",
+                    "prior_modalities_json",
+                    "source_node_ids_json",
+                    "schedule_cron",
+                    "advance_time_minutes",
+                    "triggered_count",
+                    "studies_prefetched",
+                    "last_triggered"})
+        .from("prefetch_rules")
+        .where("pk", "=", pk)
+        .limit(1);
 
-    auto result = db_->open_session().select(sql.str());
+    auto result = db_->open_session().select(builder.build());
     if (result.is_err() || result.value().empty()) {
         return std::nullopt;
     }
@@ -433,28 +366,54 @@ std::vector<client::prefetch_rule> prefetch_repository::find_rules(
     std::vector<client::prefetch_rule> rules;
     if (!db_ || !db_->is_connected()) return rules;
 
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, rule_id, name, enabled, trigger_type,
-               modality_filter, body_part_filter, station_ae_filter,
-               prior_lookback_hours, max_prior_studies, prior_modalities_json,
-               source_node_ids_json, schedule_cron, advance_time_minutes,
-               triggered_count, studies_prefetched, last_triggered
-        FROM prefetch_rules WHERE 1=1
-    )";
+    auto builder = db_->open_session().create_query_builder();
+    builder.select({"pk",
+                    "rule_id",
+                    "name",
+                    "enabled",
+                    "trigger_type",
+                    "modality_filter",
+                    "body_part_filter",
+                    "station_ae_filter",
+                    "prior_lookback_hours",
+                    "max_prior_studies",
+                    "prior_modalities_json",
+                    "source_node_ids_json",
+                    "schedule_cron",
+                    "advance_time_minutes",
+                    "triggered_count",
+                    "studies_prefetched",
+                    "last_triggered"})
+        .from("prefetch_rules");
 
+    std::optional<database::query_condition> condition;
     if (options.enabled_only.has_value()) {
-        sql << " AND enabled = " << (options.enabled_only.value() ? "1" : "0");
+        condition = database::query_condition(
+            "enabled", "=", static_cast<int64_t>(options.enabled_only.value() ? 1 : 0));
     }
 
     if (options.trigger.has_value()) {
-        sql << " AND trigger_type = '" << client::to_string(options.trigger.value()) << "'";
+        auto trigger_condition = database::query_condition(
+            "trigger_type", "=",
+            std::string(client::to_string(options.trigger.value())));
+        if (condition.has_value()) {
+            condition = condition.value() && trigger_condition;
+        } else {
+            condition = trigger_condition;
+        }
     }
 
-    sql << " ORDER BY created_at DESC";
-    sql << " LIMIT " << options.limit << " OFFSET " << options.offset;
+    if (condition.has_value()) {
+        builder.where(condition.value());
+    }
 
-    auto result = db_->open_session().select(sql.str());
+    builder.order_by("created_at", database::sort_order::desc)
+        .limit(options.limit);
+    if (options.offset > 0) {
+        builder.offset(options.offset);
+    }
+
+    auto result = db_->open_session().select(builder.build());
     if (result.is_err()) return rules;
 
     rules.reserve(result.value().size());
@@ -472,15 +431,7 @@ std::vector<client::prefetch_rule> prefetch_repository::find_enabled_rules() con
 }
 
 VoidResult prefetch_repository::remove_rule(std::string_view rule_id) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << "DELETE FROM prefetch_rules WHERE rule_id = '" << rule_id << "'";
-
-    auto result = db_->open_session().remove(sql.str());
+    auto result = prefetch_rule_repository(db_).remove(std::string(rule_id));
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -489,13 +440,8 @@ VoidResult prefetch_repository::remove_rule(std::string_view rule_id) {
 }
 
 bool prefetch_repository::rule_exists(std::string_view rule_id) const {
-    if (!db_ || !db_->is_connected()) return false;
-
-    std::ostringstream sql;
-    sql << "SELECT 1 FROM prefetch_rules WHERE rule_id = '" << rule_id << "'";
-
-    auto result = db_->open_session().select(sql.str());
-    return result.is_ok() && !result.value().empty();
+    auto result = prefetch_rule_repository(db_).exists(std::string(rule_id));
+    return result.is_ok() && result.value();
 }
 
 // =============================================================================
@@ -503,87 +449,21 @@ bool prefetch_repository::rule_exists(std::string_view rule_id) const {
 // =============================================================================
 
 VoidResult prefetch_repository::increment_triggered(std::string_view rule_id) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        UPDATE prefetch_rules SET
-            triggered_count = triggered_count + 1,
-            last_triggered = CURRENT_TIMESTAMP
-        WHERE rule_id = ')" << rule_id << "'";
-
-    auto result = db_->open_session().update(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return prefetch_rule_repository(db_).increment_triggered(rule_id);
 }
 
 VoidResult prefetch_repository::increment_studies_prefetched(
     std::string_view rule_id, size_t count) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        UPDATE prefetch_rules SET
-            studies_prefetched = studies_prefetched + )" << count
-        << " WHERE rule_id = '" << rule_id << "'";
-
-    auto result = db_->open_session().update(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return prefetch_rule_repository(db_).increment_studies_prefetched(
+        rule_id, count);
 }
 
 VoidResult prefetch_repository::enable_rule(std::string_view rule_id) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        UPDATE prefetch_rules SET
-            enabled = 1,
-            updated_at = CURRENT_TIMESTAMP
-        WHERE rule_id = ')" << rule_id << "'";
-
-    auto result = db_->open_session().update(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return prefetch_rule_repository(db_).enable(rule_id);
 }
 
 VoidResult prefetch_repository::disable_rule(std::string_view rule_id) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        UPDATE prefetch_rules SET
-            enabled = 0,
-            updated_at = CURRENT_TIMESTAMP
-        WHERE rule_id = ')" << rule_id << "'";
-
-    auto result = db_->open_session().update(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return prefetch_rule_repository(db_).disable(rule_id);
 }
 
 // =============================================================================
@@ -591,36 +471,7 @@ VoidResult prefetch_repository::disable_rule(std::string_view rule_id) {
 // =============================================================================
 
 VoidResult prefetch_repository::save_history(const client::prefetch_history& history) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        INSERT INTO prefetch_history (
-            patient_id, study_uid, rule_id, source_node_id, job_id, status
-        ) VALUES (
-            ')" << history.patient_id << "', "
-        << "'" << history.study_uid << "', ";
-
-    if (history.rule_id.empty()) {
-        sql << "NULL, ";
-    } else {
-        sql << "'" << history.rule_id << "', ";
-    }
-
-    sql << "'" << history.source_node_id << "', ";
-
-    if (history.job_id.empty()) {
-        sql << "NULL, ";
-    } else {
-        sql << "'" << history.job_id << "', ";
-    }
-
-    sql << "'" << history.status << "')";
-
-    auto result = db_->open_session().insert(sql.str());
+    auto result = prefetch_history_repository(db_).save(history);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -633,28 +484,54 @@ std::vector<client::prefetch_history> prefetch_repository::find_history(
     std::vector<client::prefetch_history> histories;
     if (!db_ || !db_->is_connected()) return histories;
 
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, patient_id, study_uid, rule_id, source_node_id, job_id, status, prefetched_at
-        FROM prefetch_history WHERE 1=1
-    )";
+    auto builder = db_->open_session().create_query_builder();
+    builder.select({"pk",
+                    "patient_id",
+                    "study_uid",
+                    "rule_id",
+                    "source_node_id",
+                    "job_id",
+                    "status",
+                    "prefetched_at"})
+        .from("prefetch_history");
 
+    std::optional<database::query_condition> condition;
     if (options.patient_id.has_value()) {
-        sql << " AND patient_id = '" << options.patient_id.value() << "'";
+        condition = database::query_condition(
+            "patient_id", "=", options.patient_id.value());
     }
 
     if (options.rule_id.has_value()) {
-        sql << " AND rule_id = '" << options.rule_id.value() << "'";
+        auto rule_condition = database::query_condition(
+            "rule_id", "=", options.rule_id.value());
+        if (condition.has_value()) {
+            condition = condition.value() && rule_condition;
+        } else {
+            condition = rule_condition;
+        }
     }
 
     if (options.status.has_value()) {
-        sql << " AND status = '" << options.status.value() << "'";
+        auto status_condition = database::query_condition(
+            "status", "=", options.status.value());
+        if (condition.has_value()) {
+            condition = condition.value() && status_condition;
+        } else {
+            condition = status_condition;
+        }
     }
 
-    sql << " ORDER BY prefetched_at DESC";
-    sql << " LIMIT " << options.limit << " OFFSET " << options.offset;
+    if (condition.has_value()) {
+        builder.where(condition.value());
+    }
 
-    auto result = db_->open_session().select(sql.str());
+    builder.order_by("prefetched_at", database::sort_order::desc)
+        .limit(options.limit);
+    if (options.offset > 0) {
+        builder.offset(options.offset);
+    }
+
+    auto result = db_->open_session().select(builder.build());
     if (result.is_err()) return histories;
 
     histories.reserve(result.value().size());
@@ -666,81 +543,56 @@ std::vector<client::prefetch_history> prefetch_repository::find_history(
 }
 
 bool prefetch_repository::is_study_prefetched(std::string_view study_uid) const {
-    if (!db_ || !db_->is_connected()) return false;
+    auto result = prefetch_history_repository(db_).find_by_study(study_uid);
+    if (result.is_err()) {
+        return false;
+    }
 
-    std::ostringstream sql;
-    sql << R"(
-        SELECT 1 FROM prefetch_history
-        WHERE study_uid = ')" << study_uid << "' AND status IN ('completed', 'pending')";
-
-    auto result = db_->open_session().select(sql.str());
-    return result.is_ok() && !result.value().empty();
+    return std::any_of(
+        result.value().begin(),
+        result.value().end(),
+        [](const client::prefetch_history& history) {
+            return history.status == "completed" || history.status == "pending";
+        });
 }
 
 size_t prefetch_repository::count_completed_today() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select(R"(
-        SELECT COUNT(*) as count FROM prefetch_history
-        WHERE status = 'completed'
-        AND date(prefetched_at) = date('now')
-    )");
-
-    if (result.is_err() || result.value().empty()) return 0;
-    return std::stoull(result.value()[0].at("count"));
+    auto result = prefetch_history_repository(db_).count_completed_today();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value();
 }
 
 size_t prefetch_repository::count_failed_today() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select(R"(
-        SELECT COUNT(*) as count FROM prefetch_history
-        WHERE status = 'failed'
-        AND date(prefetched_at) = date('now')
-    )");
-
-    if (result.is_err() || result.value().empty()) return 0;
-    return std::stoull(result.value()[0].at("count"));
+    auto result = prefetch_history_repository(db_).count_failed_today();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value();
 }
 
 VoidResult prefetch_repository::update_history_status(
     std::string_view study_uid,
     std::string_view status) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
+    auto history_repo = prefetch_history_repository(db_);
+    auto history_result = history_repo.find_by_study(study_uid);
+    if (history_result.is_err()) {
+        return VoidResult(history_result.error());
     }
 
-    std::ostringstream sql;
-    sql << "UPDATE prefetch_history SET status = '" << status
-        << "' WHERE study_uid = '" << study_uid << "'";
-
-    auto result = db_->open_session().update(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
+    for (const auto& entry : history_result.value()) {
+        auto update_result = history_repo.update_status(entry.pk, status);
+        if (update_result.is_err()) {
+            return update_result;
+        }
     }
 
     return kcenon::common::ok();
 }
 
 Result<size_t> prefetch_repository::cleanup_old_history(std::chrono::hours max_age) {
-    if (!db_ || !db_->is_connected()) {
-        return Result<size_t>(kcenon::common::error_info{
-            -1, "Database not connected", "prefetch_repository"});
-    }
-
-    auto cutoff = std::chrono::system_clock::now() - max_age;
-    auto cutoff_str = format_timestamp(cutoff);
-
-    std::ostringstream sql;
-    sql << "DELETE FROM prefetch_history WHERE prefetched_at < '" << cutoff_str << "'";
-
-    auto result = db_->open_session().remove(sql.str());
-    if (result.is_err()) {
-        return Result<size_t>(result.error());
-    }
-
-    return kcenon::common::ok(static_cast<size_t>(result.value()));
+    return prefetch_history_repository(db_).cleanup_old(max_age);
 }
 
 // =============================================================================
@@ -748,28 +600,27 @@ Result<size_t> prefetch_repository::cleanup_old_history(std::chrono::hours max_a
 // =============================================================================
 
 size_t prefetch_repository::rule_count() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM prefetch_rules");
-    if (result.is_err() || result.value().empty()) return 0;
-    return std::stoull(result.value()[0].at("count"));
+    auto result = prefetch_rule_repository(db_).count();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value();
 }
 
 size_t prefetch_repository::enabled_rule_count() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select(
-        "SELECT COUNT(*) as count FROM prefetch_rules WHERE enabled = 1");
-    if (result.is_err() || result.value().empty()) return 0;
-    return std::stoull(result.value()[0].at("count"));
+    auto result = prefetch_rule_repository(db_).find_enabled();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value().size();
 }
 
 size_t prefetch_repository::history_count() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM prefetch_history");
-    if (result.is_err() || result.value().empty()) return 0;
-    return std::stoull(result.value()[0].at("count"));
+    auto result = prefetch_history_repository(db_).count();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value();
 }
 
 // =============================================================================

--- a/src/storage/sync_repository.cpp
+++ b/src/storage/sync_repository.cpp
@@ -37,6 +37,9 @@
  */
 
 #include "pacs/storage/sync_repository.hpp"
+#include "pacs/storage/sync_config_repository.hpp"
+#include "pacs/storage/sync_conflict_repository.hpp"
+#include "pacs/storage/sync_history_repository.hpp"
 
 #include <chrono>
 #include <cstring>
@@ -93,6 +96,42 @@ namespace {
 }
 
 }  // namespace
+
+template <typename T>
+[[nodiscard]] std::optional<T> optional_from_result(Result<T> result) {
+    if (result.is_err()) {
+        return std::nullopt;
+    }
+    return result.value();
+}
+
+template <typename T>
+[[nodiscard]] std::vector<T> vector_from_result(Result<std::vector<T>> result) {
+    if (result.is_err()) {
+        return {};
+    }
+    return result.value();
+}
+
+[[nodiscard]] bool is_same_utc_day(
+    std::chrono::system_clock::time_point lhs,
+    std::chrono::system_clock::time_point rhs) {
+    const auto lhs_time = std::chrono::system_clock::to_time_t(lhs);
+    const auto rhs_time = std::chrono::system_clock::to_time_t(rhs);
+
+    std::tm lhs_tm{};
+    std::tm rhs_tm{};
+#ifdef _WIN32
+    gmtime_s(&lhs_tm, &lhs_time);
+    gmtime_s(&rhs_tm, &rhs_time);
+#else
+    gmtime_r(&lhs_time, &lhs_tm);
+    gmtime_r(&rhs_time, &rhs_tm);
+#endif
+
+    return lhs_tm.tm_year == rhs_tm.tm_year &&
+           lhs_tm.tm_yday == rhs_tm.tm_yday;
+}
 
 // =============================================================================
 // JSON Serialization
@@ -187,57 +226,7 @@ auto sync_repository::format_timestamp(
 // =============================================================================
 
 VoidResult sync_repository::save_config(const client::sync_config& config) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "sync_repository"});
-    }
-
-    auto builder = db_->open_session().create_query_builder();
-    std::ostringstream sql;
-    sql << R"(
-        INSERT INTO sync_configs (
-            config_id, source_node_id, name, enabled,
-            lookback_hours, modalities_json, patient_patterns_json,
-            sync_direction, delete_missing, overwrite_existing, sync_metadata_only,
-            schedule_cron, last_sync, last_successful_sync,
-            total_syncs, studies_synced
-        ) VALUES (
-            ')" << config.config_id << "', "
-        << "'" << config.source_node_id << "', "
-        << "'" << config.name << "', "
-        << (config.enabled ? 1 : 0) << ", "
-        << config.lookback.count() << ", "
-        << "'" << serialize_vector(config.modalities) << "', "
-        << "'" << serialize_vector(config.patient_id_patterns) << "', "
-        << "'" << to_string(config.direction) << "', "
-        << (config.delete_missing ? 1 : 0) << ", "
-        << (config.overwrite_existing ? 1 : 0) << ", "
-        << (config.sync_metadata_only ? 1 : 0) << ", "
-        << "'" << config.schedule_cron << "', "
-        << "'" << format_timestamp(config.last_sync) << "', "
-        << "'" << format_timestamp(config.last_successful_sync) << "', "
-        << config.total_syncs << ", "
-        << config.studies_synced << R"()
-        ON CONFLICT(config_id) DO UPDATE SET
-            source_node_id = excluded.source_node_id,
-            name = excluded.name,
-            enabled = excluded.enabled,
-            lookback_hours = excluded.lookback_hours,
-            modalities_json = excluded.modalities_json,
-            patient_patterns_json = excluded.patient_patterns_json,
-            sync_direction = excluded.sync_direction,
-            delete_missing = excluded.delete_missing,
-            overwrite_existing = excluded.overwrite_existing,
-            sync_metadata_only = excluded.sync_metadata_only,
-            schedule_cron = excluded.schedule_cron,
-            last_sync = excluded.last_sync,
-            last_successful_sync = excluded.last_successful_sync,
-            total_syncs = excluded.total_syncs,
-            studies_synced = excluded.studies_synced,
-            updated_at = datetime('now')
-    )";
-
-    auto result = db_->open_session().insert(sql.str());
+    auto result = sync_config_repository(db_).save(config);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -247,83 +236,20 @@ VoidResult sync_repository::save_config(const client::sync_config& config) {
 
 std::optional<client::sync_config> sync_repository::find_config(
     std::string_view config_id) const {
-    if (!db_ || !db_->is_connected()) return std::nullopt;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, config_id, source_node_id, name, enabled,
-               lookback_hours, modalities_json, patient_patterns_json,
-               sync_direction, delete_missing, overwrite_existing, sync_metadata_only,
-               schedule_cron, last_sync, last_successful_sync,
-               total_syncs, studies_synced
-        FROM sync_configs WHERE config_id = ')" << config_id << "'";
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err() || result.value().empty()) {
-        return std::nullopt;
-    }
-
-    return map_row_to_config(result.value()[0]);
+    return optional_from_result(
+        sync_config_repository(db_).find_by_config_id(config_id));
 }
 
 std::vector<client::sync_config> sync_repository::list_configs() const {
-    std::vector<client::sync_config> configs;
-    if (!db_ || !db_->is_connected()) return configs;
-
-    const char* sql = R"(
-        SELECT pk, config_id, source_node_id, name, enabled,
-               lookback_hours, modalities_json, patient_patterns_json,
-               sync_direction, delete_missing, overwrite_existing, sync_metadata_only,
-               schedule_cron, last_sync, last_successful_sync,
-               total_syncs, studies_synced
-        FROM sync_configs ORDER BY name
-    )";
-
-    auto result = db_->open_session().select(sql);
-    if (result.is_err()) return configs;
-
-    configs.reserve(result.value().size());
-    for (const auto& row : result.value()) {
-        configs.push_back(map_row_to_config(row));
-    }
-
-    return configs;
+    return vector_from_result(sync_config_repository(db_).find_all());
 }
 
 std::vector<client::sync_config> sync_repository::list_enabled_configs() const {
-    std::vector<client::sync_config> configs;
-    if (!db_ || !db_->is_connected()) return configs;
-
-    const char* sql = R"(
-        SELECT pk, config_id, source_node_id, name, enabled,
-               lookback_hours, modalities_json, patient_patterns_json,
-               sync_direction, delete_missing, overwrite_existing, sync_metadata_only,
-               schedule_cron, last_sync, last_successful_sync,
-               total_syncs, studies_synced
-        FROM sync_configs WHERE enabled = 1 ORDER BY name
-    )";
-
-    auto result = db_->open_session().select(sql);
-    if (result.is_err()) return configs;
-
-    configs.reserve(result.value().size());
-    for (const auto& row : result.value()) {
-        configs.push_back(map_row_to_config(row));
-    }
-
-    return configs;
+    return vector_from_result(sync_config_repository(db_).find_enabled());
 }
 
 VoidResult sync_repository::remove_config(std::string_view config_id) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "sync_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << "DELETE FROM sync_configs WHERE config_id = '" << config_id << "'";
-
-    auto result = db_->open_session().remove(sql.str());
+    auto result = sync_config_repository(db_).remove(std::string(config_id));
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -335,36 +261,8 @@ VoidResult sync_repository::update_config_stats(
     std::string_view config_id,
     bool success,
     size_t studies_synced) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "sync_repository"});
-    }
-
-    std::ostringstream sql;
-    if (success) {
-        sql << R"(
-            UPDATE sync_configs SET
-                total_syncs = total_syncs + 1,
-                studies_synced = studies_synced + )" << studies_synced << R"(,
-                last_sync = datetime('now'),
-                last_successful_sync = datetime('now'),
-                updated_at = datetime('now')
-            WHERE config_id = ')" << config_id << "'";
-    } else {
-        sql << R"(
-            UPDATE sync_configs SET
-                total_syncs = total_syncs + 1,
-                last_sync = datetime('now'),
-                updated_at = datetime('now')
-            WHERE config_id = ')" << config_id << "'";
-    }
-
-    auto result = db_->open_session().update(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return sync_config_repository(db_).update_stats(
+        config_id, success, studies_synced);
 }
 
 // =============================================================================
@@ -372,52 +270,7 @@ VoidResult sync_repository::update_config_stats(
 // =============================================================================
 
 VoidResult sync_repository::save_conflict(const client::sync_conflict& conflict) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "sync_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        INSERT INTO sync_conflicts (
-            config_id, study_uid, patient_id, conflict_type,
-            local_modified, remote_modified,
-            local_instance_count, remote_instance_count,
-            resolved, resolution, detected_at, resolved_at
-        ) VALUES (
-            ')" << conflict.config_id << "', "
-        << "'" << conflict.study_uid << "', "
-        << "'" << conflict.patient_id << "', "
-        << "'" << to_string(conflict.conflict_type) << "', "
-        << "'" << format_timestamp(conflict.local_modified) << "', "
-        << "'" << format_timestamp(conflict.remote_modified) << "', "
-        << conflict.local_instance_count << ", "
-        << conflict.remote_instance_count << ", "
-        << (conflict.resolved ? 1 : 0) << ", "
-        << "'" << (conflict.resolved ? to_string(conflict.resolution_used) : "") << "', "
-        << "'" << format_timestamp(conflict.detected_at) << "', ";
-
-    if (conflict.resolved_at.has_value()) {
-        sql << "'" << format_timestamp(conflict.resolved_at.value()) << "'";
-    } else {
-        sql << "NULL";
-    }
-
-    sql << R"()
-        ON CONFLICT(config_id, study_uid) DO UPDATE SET
-            patient_id = excluded.patient_id,
-            conflict_type = excluded.conflict_type,
-            local_modified = excluded.local_modified,
-            remote_modified = excluded.remote_modified,
-            local_instance_count = excluded.local_instance_count,
-            remote_instance_count = excluded.remote_instance_count,
-            resolved = excluded.resolved,
-            resolution = excluded.resolution,
-            detected_at = excluded.detected_at,
-            resolved_at = excluded.resolved_at
-    )";
-
-    auto result = db_->open_session().insert(sql.str());
+    auto result = sync_conflict_repository(db_).save(conflict);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -427,114 +280,29 @@ VoidResult sync_repository::save_conflict(const client::sync_conflict& conflict)
 
 std::optional<client::sync_conflict> sync_repository::find_conflict(
     std::string_view study_uid) const {
-    if (!db_ || !db_->is_connected()) return std::nullopt;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, config_id, study_uid, patient_id, conflict_type,
-               local_modified, remote_modified,
-               local_instance_count, remote_instance_count,
-               resolved, resolution, detected_at, resolved_at
-        FROM sync_conflicts WHERE study_uid = ')" << study_uid << "'";
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err() || result.value().empty()) {
-        return std::nullopt;
-    }
-
-    return map_row_to_conflict(result.value()[0]);
+    return optional_from_result(
+        sync_conflict_repository(db_).find_by_study_uid(study_uid));
 }
 
 std::vector<client::sync_conflict> sync_repository::list_conflicts(
     std::string_view config_id) const {
-    std::vector<client::sync_conflict> conflicts;
-    if (!db_ || !db_->is_connected()) return conflicts;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, config_id, study_uid, patient_id, conflict_type,
-               local_modified, remote_modified,
-               local_instance_count, remote_instance_count,
-               resolved, resolution, detected_at, resolved_at
-        FROM sync_conflicts WHERE config_id = ')" << config_id << R"(' ORDER BY detected_at DESC)";
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err()) return conflicts;
-
-    conflicts.reserve(result.value().size());
-    for (const auto& row : result.value()) {
-        conflicts.push_back(map_row_to_conflict(row));
-    }
-
-    return conflicts;
+    return vector_from_result(
+        sync_conflict_repository(db_).find_by_config(config_id));
 }
 
 std::vector<client::sync_conflict> sync_repository::list_unresolved_conflicts() const {
-    std::vector<client::sync_conflict> conflicts;
-    if (!db_ || !db_->is_connected()) return conflicts;
-
-    const char* sql = R"(
-        SELECT pk, config_id, study_uid, patient_id, conflict_type,
-               local_modified, remote_modified,
-               local_instance_count, remote_instance_count,
-               resolved, resolution, detected_at, resolved_at
-        FROM sync_conflicts WHERE resolved = 0 ORDER BY detected_at DESC
-    )";
-
-    auto result = db_->open_session().select(sql);
-    if (result.is_err()) return conflicts;
-
-    conflicts.reserve(result.value().size());
-    for (const auto& row : result.value()) {
-        conflicts.push_back(map_row_to_conflict(row));
-    }
-
-    return conflicts;
+    return vector_from_result(
+        sync_conflict_repository(db_).find_unresolved());
 }
 
 VoidResult sync_repository::resolve_conflict(
     std::string_view study_uid,
     client::conflict_resolution resolution) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "sync_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        UPDATE sync_conflicts SET
-            resolved = 1,
-            resolution = ')" << to_string(resolution) << R"(',
-            resolved_at = datetime('now')
-        WHERE study_uid = ')" << study_uid << "' AND resolved = 0";
-
-    auto result = db_->open_session().update(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return sync_conflict_repository(db_).resolve(study_uid, resolution);
 }
 
 Result<size_t> sync_repository::cleanup_old_conflicts(std::chrono::hours max_age) {
-    if (!db_ || !db_->is_connected()) {
-        return kcenon::common::make_error<size_t>(-1,
-            "Database not connected", "sync_repository");
-    }
-
-    auto cutoff = std::chrono::system_clock::now() - max_age;
-    auto cutoff_str = format_timestamp(cutoff);
-
-    std::ostringstream sql;
-    sql << "DELETE FROM sync_conflicts WHERE resolved = 1 AND resolved_at < '"
-        << cutoff_str << "'";
-
-    auto result = db_->open_session().remove(sql.str());
-    if (result.is_err()) {
-        return Result<size_t>(result.error());
-    }
-
-    return static_cast<size_t>(result.value());
+    return sync_conflict_repository(db_).cleanup_old(max_age);
 }
 
 // =============================================================================
@@ -542,29 +310,7 @@ Result<size_t> sync_repository::cleanup_old_conflicts(std::chrono::hours max_age
 // =============================================================================
 
 VoidResult sync_repository::save_history(const client::sync_history& history) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "sync_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << R"(
-        INSERT INTO sync_history (
-            config_id, job_id, success,
-            studies_checked, studies_synced, conflicts_found,
-            errors_json, started_at, completed_at
-        ) VALUES (
-            ')" << history.config_id << "', "
-        << "'" << history.job_id << "', "
-        << (history.success ? 1 : 0) << ", "
-        << history.studies_checked << ", "
-        << history.studies_synced << ", "
-        << history.conflicts_found << ", "
-        << "'" << serialize_vector(history.errors) << "', "
-        << "'" << format_timestamp(history.started_at) << "', "
-        << "'" << format_timestamp(history.completed_at) << "')";
-
-    auto result = db_->open_session().insert(sql.str());
+    auto result = sync_history_repository(db_).save(history);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -574,66 +320,18 @@ VoidResult sync_repository::save_history(const client::sync_history& history) {
 
 std::vector<client::sync_history> sync_repository::list_history(
     std::string_view config_id, size_t limit) const {
-    std::vector<client::sync_history> histories;
-    if (!db_ || !db_->is_connected()) return histories;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, config_id, job_id, success,
-               studies_checked, studies_synced, conflicts_found,
-               errors_json, started_at, completed_at
-        FROM sync_history WHERE config_id = ')" << config_id
-        << "' ORDER BY started_at DESC LIMIT " << limit;
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err()) return histories;
-
-    histories.reserve(result.value().size());
-    for (const auto& row : result.value()) {
-        histories.push_back(map_row_to_history(row));
-    }
-
-    return histories;
+    return vector_from_result(
+        sync_history_repository(db_).find_by_config(config_id, limit));
 }
 
 std::optional<client::sync_history> sync_repository::get_last_history(
     std::string_view config_id) const {
-    if (!db_ || !db_->is_connected()) return std::nullopt;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, config_id, job_id, success,
-               studies_checked, studies_synced, conflicts_found,
-               errors_json, started_at, completed_at
-        FROM sync_history WHERE config_id = ')" << config_id
-        << "' ORDER BY started_at DESC LIMIT 1";
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err() || result.value().empty()) {
-        return std::nullopt;
-    }
-
-    return map_row_to_history(result.value()[0]);
+    return optional_from_result(
+        sync_history_repository(db_).find_last_for_config(config_id));
 }
 
 Result<size_t> sync_repository::cleanup_old_history(std::chrono::hours max_age) {
-    if (!db_ || !db_->is_connected()) {
-        return kcenon::common::make_error<size_t>(-1,
-            "Database not connected", "sync_repository");
-    }
-
-    auto cutoff = std::chrono::system_clock::now() - max_age;
-    auto cutoff_str = format_timestamp(cutoff);
-
-    std::ostringstream sql;
-    sql << "DELETE FROM sync_history WHERE completed_at < '" << cutoff_str << "'";
-
-    auto result = db_->open_session().remove(sql.str());
-    if (result.is_err()) {
-        return Result<size_t>(result.error());
-    }
-
-    return static_cast<size_t>(result.value());
+    return sync_history_repository(db_).cleanup_old(max_age);
 }
 
 // =============================================================================
@@ -641,34 +339,35 @@ Result<size_t> sync_repository::cleanup_old_history(std::chrono::hours max_age) 
 // =============================================================================
 
 size_t sync_repository::count_configs() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM sync_configs");
-    if (result.is_err() || result.value().empty()) return 0;
-
-    return std::stoull(result.value()[0].at("count"));
+    auto result = sync_config_repository(db_).count();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value();
 }
 
 size_t sync_repository::count_unresolved_conflicts() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select(
-        "SELECT COUNT(*) as count FROM sync_conflicts WHERE resolved = 0");
-    if (result.is_err() || result.value().empty()) return 0;
-
-    return std::stoull(result.value()[0].at("count"));
+    auto result = sync_conflict_repository(db_).find_unresolved();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value().size();
 }
 
 size_t sync_repository::count_syncs_today() const {
-    if (!db_ || !db_->is_connected()) return 0;
+    auto result = sync_history_repository(db_).find_all();
+    if (result.is_err()) {
+        return 0;
+    }
 
-    auto result = db_->open_session().select(R"(
-        SELECT COUNT(*) as count FROM sync_history
-        WHERE date(completed_at) = date('now')
-    )");
-    if (result.is_err() || result.value().empty()) return 0;
-
-    return std::stoull(result.value()[0].at("count"));
+    const auto now = std::chrono::system_clock::now();
+    size_t count = 0;
+    for (const auto& entry : result.value()) {
+        if (is_same_utc_day(entry.completed_at, now)) {
+            ++count;
+        }
+    }
+    return count;
 }
 
 // =============================================================================

--- a/src/storage/viewer_state_repository.cpp
+++ b/src/storage/viewer_state_repository.cpp
@@ -37,6 +37,8 @@
  */
 
 #include "pacs/storage/viewer_state_repository.hpp"
+#include "pacs/storage/recent_study_repository.hpp"
+#include "pacs/storage/viewer_state_record_repository.hpp"
 
 #include <chrono>
 #include <cstdio>
@@ -102,6 +104,22 @@ namespace {
 
 }  // namespace
 
+template <typename T>
+[[nodiscard]] std::optional<T> optional_from_result(Result<T> result) {
+    if (result.is_err()) {
+        return std::nullopt;
+    }
+    return result.value();
+}
+
+template <typename T>
+[[nodiscard]] std::vector<T> vector_from_result(Result<std::vector<T>> result) {
+    if (result.is_err()) {
+        return {};
+    }
+    return result.value();
+}
+
 // =============================================================================
 // Construction / Destruction
 // =============================================================================
@@ -136,30 +154,7 @@ auto viewer_state_repository::format_timestamp(
 // =============================================================================
 
 VoidResult viewer_state_repository::save_state(const viewer_state_record& record) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "viewer_state_repository"});
-    }
-
-    auto now_str = format_timestamp(std::chrono::system_clock::now());
-
-    std::ostringstream sql;
-    sql << R"(
-        INSERT INTO viewer_states (
-            state_id, study_uid, user_id, state_json, created_at, updated_at
-        ) VALUES (
-            ')" << record.state_id << "', "
-        << "'" << record.study_uid << "', "
-        << "'" << record.user_id << "', "
-        << "'" << record.state_json << "', "
-        << "'" << now_str << "', "
-        << "'" << now_str << R"(')
-        ON CONFLICT(state_id) DO UPDATE SET
-            state_json = excluded.state_json,
-            updated_at = excluded.updated_at
-    )";
-
-    auto result = db_->open_session().insert(sql.str());
+    auto result = viewer_state_record_repository(db_).save(record);
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -169,74 +164,25 @@ VoidResult viewer_state_repository::save_state(const viewer_state_record& record
 
 std::optional<viewer_state_record> viewer_state_repository::find_state_by_id(
     std::string_view state_id) const {
-    if (!db_ || !db_->is_connected()) return std::nullopt;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, state_id, study_uid, user_id, state_json, created_at, updated_at
-        FROM viewer_states WHERE state_id = ')" << state_id << "'";
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err() || result.value().empty()) {
-        return std::nullopt;
-    }
-
-    return map_row_to_state(result.value()[0]);
+    return optional_from_result(
+        viewer_state_record_repository(db_).find_by_id(std::string(state_id)));
 }
 
 std::vector<viewer_state_record> viewer_state_repository::find_states_by_study(
     std::string_view study_uid) const {
-    viewer_state_query query;
-    query.study_uid = std::string(study_uid);
-    return search_states(query);
+    return vector_from_result(
+        viewer_state_record_repository(db_).find_by_study(study_uid));
 }
 
 std::vector<viewer_state_record> viewer_state_repository::search_states(
     const viewer_state_query& query) const {
-    std::vector<viewer_state_record> states;
-    if (!db_ || !db_->is_connected()) return states;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, state_id, study_uid, user_id, state_json, created_at, updated_at
-        FROM viewer_states WHERE 1=1
-    )";
-
-    if (query.study_uid.has_value()) {
-        sql << " AND study_uid = '" << query.study_uid.value() << "'";
-    }
-
-    if (query.user_id.has_value()) {
-        sql << " AND user_id = '" << query.user_id.value() << "'";
-    }
-
-    sql << " ORDER BY updated_at DESC";
-
-    if (query.limit > 0) {
-        sql << " LIMIT " << query.limit << " OFFSET " << query.offset;
-    }
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err()) return states;
-
-    states.reserve(result.value().size());
-    for (const auto& row : result.value()) {
-        states.push_back(map_row_to_state(row));
-    }
-
-    return states;
+    return vector_from_result(
+        viewer_state_record_repository(db_).search(query));
 }
 
 VoidResult viewer_state_repository::remove_state(std::string_view state_id) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "viewer_state_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << "DELETE FROM viewer_states WHERE state_id = '" << state_id << "'";
-
-    auto result = db_->open_session().remove(sql.str());
+    auto result =
+        viewer_state_record_repository(db_).remove(std::string(state_id));
     if (result.is_err()) {
         return VoidResult(result.error());
     }
@@ -245,12 +191,11 @@ VoidResult viewer_state_repository::remove_state(std::string_view state_id) {
 }
 
 size_t viewer_state_repository::count_states() const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    auto result = db_->open_session().select("SELECT COUNT(*) as count FROM viewer_states");
-    if (result.is_err() || result.value().empty()) return 0;
-
-    return std::stoull(result.value()[0].at("count"));
+    auto result = viewer_state_record_repository(db_).count();
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value();
 }
 
 // =============================================================================
@@ -260,82 +205,26 @@ size_t viewer_state_repository::count_states() const {
 VoidResult viewer_state_repository::record_study_access(
     std::string_view user_id,
     std::string_view study_uid) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "viewer_state_repository"});
-    }
-
-    auto now_str = format_timestamp(std::chrono::system_clock::now());
-
-    std::ostringstream sql;
-    sql << R"(
-        INSERT INTO recent_studies (user_id, study_uid, accessed_at)
-        VALUES (')" << user_id << "', '" << study_uid << "', '" << now_str << R"(')
-        ON CONFLICT(user_id, study_uid) DO UPDATE SET
-            accessed_at = excluded.accessed_at
-    )";
-
-    auto result = db_->open_session().insert(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return recent_study_repository(db_).record_access(user_id, study_uid);
 }
 
 std::vector<recent_study_record> viewer_state_repository::get_recent_studies(
     std::string_view user_id,
     size_t limit) const {
-    std::vector<recent_study_record> studies;
-    if (!db_ || !db_->is_connected()) return studies;
-
-    std::ostringstream sql;
-    sql << R"(
-        SELECT pk, user_id, study_uid, accessed_at
-        FROM recent_studies
-        WHERE user_id = ')" << user_id << R"('
-        ORDER BY accessed_at DESC, pk DESC
-        LIMIT )" << limit;
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err()) return studies;
-
-    studies.reserve(result.value().size());
-    for (const auto& row : result.value()) {
-        studies.push_back(map_row_to_recent_study(row));
-    }
-
-    return studies;
+    return vector_from_result(
+        recent_study_repository(db_).find_by_user(user_id, limit));
 }
 
 VoidResult viewer_state_repository::clear_recent_studies(std::string_view user_id) {
-    if (!db_ || !db_->is_connected()) {
-        return VoidResult(kcenon::common::error_info{
-            -1, "Database not connected", "viewer_state_repository"});
-    }
-
-    std::ostringstream sql;
-    sql << "DELETE FROM recent_studies WHERE user_id = '" << user_id << "'";
-
-    auto result = db_->open_session().remove(sql.str());
-    if (result.is_err()) {
-        return VoidResult(result.error());
-    }
-
-    return kcenon::common::ok();
+    return recent_study_repository(db_).clear_for_user(user_id);
 }
 
 size_t viewer_state_repository::count_recent_studies(std::string_view user_id) const {
-    if (!db_ || !db_->is_connected()) return 0;
-
-    std::ostringstream sql;
-    sql << "SELECT COUNT(*) as count FROM recent_studies WHERE user_id = '"
-        << user_id << "'";
-
-    auto result = db_->open_session().select(sql.str());
-    if (result.is_err() || result.value().empty()) return 0;
-
-    return std::stoull(result.value()[0].at("count"));
+    auto result = recent_study_repository(db_).count_for_user(user_id);
+    if (result.is_err()) {
+        return 0;
+    }
+    return result.value();
 }
 
 // =============================================================================

--- a/tests/storage/repository_factory_test.cpp
+++ b/tests/storage/repository_factory_test.cpp
@@ -13,11 +13,13 @@
 #include <pacs/client/prefetch_types.hpp>
 #include <pacs/client/sync_types.hpp>
 #include <pacs/storage/prefetch_repository.hpp>
+#include <pacs/storage/prefetch_history_repository.hpp>
 #include <pacs/storage/prefetch_rule_repository.hpp>
 #include <pacs/storage/recent_study_repository.hpp>
 #include <pacs/storage/repository_factory.hpp>
 #include <pacs/storage/sync_config_repository.hpp>
 #include <pacs/storage/sync_repository.hpp>
+#include <pacs/storage/viewer_state_record_repository.hpp>
 #include <pacs/storage/viewer_state_repository.hpp>
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
@@ -277,6 +279,74 @@ TEST_CASE("repository_factory split and compatibility repositories share state",
     REQUIRE(
         canonical.viewer_state.recent_studies->record_access("user1", "1.2.3").is_ok());
     CHECK(compatibility.viewer_states->count_recent_studies("user1") == 1);
+}
+
+TEST_CASE("repository_factory compatibility repositories delegate writes to canonical split repositories",
+          "[storage][repository_factory]") {
+    if (!is_sqlite_backend_supported()) {
+        SUCCEED("Skipped: SQLite backend not supported");
+        return;
+    }
+
+    test_database tdb;
+    repository_factory factory(tdb.get());
+    const auto canonical = factory.canonical_repositories();
+    const auto compatibility = factory.compatibility_repositories();
+
+    SECTION("sync compatibility writes are visible through split repositories") {
+        pacs::client::sync_config config;
+        config.config_id = "compat-sync";
+        config.source_node_id = "archive";
+        config.name = "Compatibility Sync";
+        REQUIRE(compatibility.sync_states->save_config(config).is_ok());
+
+        auto loaded = canonical.sync.configs->find_by_config_id(config.config_id);
+        REQUIRE(loaded.is_ok());
+        CHECK(loaded.value().name == config.name);
+    }
+
+    SECTION("viewer compatibility writes are visible through split repositories") {
+        pacs::storage::viewer_state_record state;
+        state.state_id = "compat-state";
+        state.study_uid = "1.2.3.4";
+        state.user_id = "user42";
+        state.state_json = R"({"layout":"compat"})";
+        state.created_at = std::chrono::system_clock::now();
+        state.updated_at = state.created_at;
+        REQUIRE(compatibility.viewer_states->save_state(state).is_ok());
+
+        auto loaded = canonical.viewer_state.records->find_by_id(state.state_id);
+        REQUIRE(loaded.is_ok());
+        CHECK(loaded.value().state_json == state.state_json);
+    }
+
+    SECTION("prefetch compatibility writes are visible through split repositories") {
+        pacs::client::prefetch_rule rule;
+        rule.rule_id = "compat-rule";
+        rule.name = "Compatibility Rule";
+        rule.trigger = pacs::client::prefetch_trigger::manual;
+        rule.source_node_ids = {"archive"};
+        REQUIRE(compatibility.prefetch_queue->save_rule(rule).is_ok());
+
+        auto loaded_rule = canonical.prefetch.rules->find_by_rule_id(rule.rule_id);
+        REQUIRE(loaded_rule.is_ok());
+        CHECK(loaded_rule.value().name == rule.name);
+
+        pacs::client::prefetch_history history;
+        history.patient_id = "PAT001";
+        history.study_uid = "1.2.3.4.5";
+        history.rule_id = rule.rule_id;
+        history.source_node_id = "archive";
+        history.job_id = "job-compat";
+        history.status = "pending";
+        history.prefetched_at = std::chrono::system_clock::now();
+        REQUIRE(compatibility.prefetch_queue->save_history(history).is_ok());
+
+        auto loaded_history = canonical.prefetch.history->find_by_study(history.study_uid);
+        REQUIRE(loaded_history.is_ok());
+        REQUIRE_FALSE(loaded_history.value().empty());
+        CHECK(loaded_history.value().front().status == history.status);
+    }
 }
 
 #endif  // PACS_WITH_DATABASE_SYSTEM


### PR DESCRIPTION
## Background
This change continues the Phase 5 client-state storage migration after the repository-set wiring introduced in #903. The compatibility repositories for sync, viewer state, and prefetch still owned PACS-facing persistence paths even when split repositories were available.

This PR is stacked on top of `feat/issue-894-split-repository-sets`.

## Problem
The compatibility repositories still built raw SQL strings directly in the `PACS_WITH_DATABASE_SYSTEM` path. That meant the aggregate repositories remained the primary write path for sync, viewer, and prefetch flows instead of acting as transitional adapters over the split repository contracts.

## Approach
Route the compatibility repositories through the split repository primitives where possible, and use query-builder based reads for the remaining compatibility query surfaces. This keeps the aggregate API available for compatibility while removing manual SQL assembly from the PACS-facing database-system path.

## Key Changes
- delegate `sync_repository` config, conflict, and history operations to `sync_config_repository`, `sync_conflict_repository`, and `sync_history_repository`
- delegate `viewer_state_repository` operations to `viewer_state_record_repository` and `recent_study_repository`
- delegate prefetch write/stat paths to `prefetch_rule_repository` and `prefetch_history_repository`
- replace compatibility query filtering in `prefetch_repository` with query-builder based reads instead of manual SQL string construction
- add regression coverage proving compatibility repository writes are visible through canonical split repositories

## Verification
- `cmake --build /Users/raphaelshin/Sources/pacs_system/build --target client_tests web_tests storage_tests -- -j4`
- `ctest --output-on-failure -R "repository_factory|sync_manager loads split repository sets|prefetch_manager loads split repository sets|Viewer state repository operations" -C Debug`

## Remaining Risks
- this PR keeps the aggregate compatibility repositories in place, so full removal still depends on higher-level callers being migrated off those compatibility APIs
- because this PR is stacked on a non-default base branch, issue closure should happen when the stacked series reaches `main`

Refs #895
Part of #891