### PR TITLE
feat(build): add CMake install/export infrastructure for pacs_system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,18 +104,12 @@ function(pacs_get_export_bridge_target out_var build_target install_target)
     if(NOT TARGET ${_bridge_target})
         add_library(${_bridge_target} INTERFACE)
 
-        # Bridge target carries ONLY the install-time dependency.
-        # No local build-target references here — CMake 3.31's
-        # install(EXPORT) validation pre-scans INTERFACE_LINK_LIBRARIES
-        # for target names before evaluating generator expressions,
-        # which breaks BUILD_LOCAL_INTERFACE wrapping of local targets.
-        #
-        # Set the interface property directly instead of using
-        # target_link_libraries() so CMake does not register a build-tree
-        # target dependency when the install-side package target name happens
-        # to exist as a local alias during the unified build.
-        set_property(TARGET ${_bridge_target} APPEND PROPERTY INTERFACE_LINK_LIBRARIES
-            "$<INSTALL_INTERFACE:${install_target}>"
+        # Leave bridge targets link-empty during export generation.
+        # The installed package config hydrates them after find_dependency()
+        # so CMake never resolves install-side package targets back to local
+        # unified-build aliases while validating install(EXPORT).
+        set_property(GLOBAL APPEND PROPERTY PACS_EXPORT_BRIDGE_MAPPINGS
+            "${_bridge_target}=${install_target}"
         )
 
         set_property(GLOBAL APPEND PROPERTY PACS_EXPORT_BRIDGE_TARGETS ${_bridge_target})
@@ -2170,6 +2164,25 @@ set(PACS_SYSTEM_WITH_AZURE_SDK FALSE)
 if(TARGET pacs_storage AND PACS_WITH_AZURE_SDK AND azure-storage-blobs-cpp_FOUND)
     set(PACS_SYSTEM_WITH_AZURE_SDK TRUE)
 endif()
+
+set(PACS_SYSTEM_BRIDGE_TARGET_SETUP "")
+get_property(PACS_EXPORT_BRIDGE_MAPPINGS GLOBAL PROPERTY PACS_EXPORT_BRIDGE_MAPPINGS)
+foreach(_bridge_mapping IN LISTS PACS_EXPORT_BRIDGE_MAPPINGS)
+    string(FIND "${_bridge_mapping}" "=" _bridge_sep)
+    if(_bridge_sep LESS 0)
+        continue()
+    endif()
+
+    string(SUBSTRING "${_bridge_mapping}" 0 ${_bridge_sep} _bridge_target_name)
+    math(EXPR _bridge_value_index "${_bridge_sep} + 1")
+    string(SUBSTRING "${_bridge_mapping}" ${_bridge_value_index} -1 _bridge_install_target)
+
+    string(APPEND PACS_SYSTEM_BRIDGE_TARGET_SETUP
+        "if(TARGET kcenon::pacs::${_bridge_target_name})\n"
+        "  set_property(TARGET kcenon::pacs::${_bridge_target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES \"${_bridge_install_target}\")\n"
+        "endif()\n"
+    )
+endforeach()
 
 install(DIRECTORY include/pacs
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}

--- a/cmake/pacs_systemConfig.cmake.in
+++ b/cmake/pacs_systemConfig.cmake.in
@@ -67,6 +67,8 @@ endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/pacs_systemTargets.cmake")
 
+@PACS_SYSTEM_BRIDGE_TARGET_SETUP@
+
 set(pacs_system_FOUND TRUE)
 set(PACS_SYSTEM_FOUND TRUE)
 


### PR DESCRIPTION
## Background

`pacs_system` defined the library targets needed for downstream use, but it did not install public headers, export target sets, or generate package config files. That blocked `find_package(pacs_system CONFIG)` consumers and made vcpkg packaging impossible.

## Problem

Without install/export infrastructure, downstream builds could only use `pacs_system` through source inclusion. Existing usage requirements also leaked build-tree paths and local target names that are not valid once the project is installed.

## Approach

- Added top-level install/export support for the core PACS libraries and conditionally built optional modules.
- Generated `pacs_systemConfig.cmake` and `pacs_systemConfigVersion.cmake` under `lib/cmake/pacs_system`.
- Exported installed targets under the `kcenon::pacs::` namespace.
- Switched install interfaces to package-resolved dependency targets so exported usage requirements no longer depend on local unified-build target names or absolute include paths.
- Added dependency discovery to the package config template for the kcenon packages and external libraries required by enabled modules.
- Kept build-tree export conditional because several unified-build local dependency targets are not currently exportable as part of the same build graph.

## Key Changes

- Added reusable CMake helpers for export target registration, build-only include bridging, and split build/install dependency linkage.
- Installed public headers from `include/pacs`.
- Installed the core PACS targets unconditionally and optional module targets only when they exist.
- Added `cmake/pacs_systemConfig.cmake.in` with `find_dependency(...)` calls for transitive dependencies.
- Generated and installed the package version file with `write_basic_package_version_file(...)`.
- Normalized install-side dependency targets for `common_system`, `ContainerSystem`, `NetworkSystem`, `ThreadSystem`, `LoggerSystem`, `monitoring_system`, `SQLite3`, `OpenJPEG`, `charls`, `openjph`, and `Crow`.

## Verification

- `cmake -S . -B build -DPACS_BUILD_TESTS=OFF -DPACS_BUILD_EXAMPLES=OFF -DPACS_BUILD_BENCHMARKS=OFF -DPACS_BUILD_SAMPLES=OFF -DBUILD_DATABASE=OFF`
- `cmake --build build --target pacs_core pacs_encoding pacs_network pacs_client pacs_services pacs_security pacs_storage pacs_ai pacs_monitoring pacs_workflow pacs_web pacs_integration -j8`
- `cmake --install build --prefix /tmp/pacs-system-905-install-n7ZIPO`
- `cmake -S /tmp/pacs-system-905-consumer -B /tmp/pacs-system-905-consumer/build -DCMAKE_PREFIX_PATH=/tmp/pacs-system-905-install-n7ZIPO`
- `cmake --build /tmp/pacs-system-905-consumer/build -j8`

## Remaining Risks

- Build-tree export is intentionally skipped in the current unified-build configuration because several local dependency targets are not exportable yet.
- Local verification used `-DBUILD_DATABASE=OFF` to avoid an upstream `database_system` export issue in the unified dependency graph. Installed package consumption for the tested PACS targets still succeeded.

Closes #905
