### PR TITLE
feat(deps): add vcpkg.json manifest with feature-based dependency declaration

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
+  "default-registry": {
+    "kind": "builtin",
+    "baseline": "c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d"
+  }
+}

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,0 +1,107 @@
+{
+  "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
+  "name": "kcenon-pacs-system",
+  "version": "0.1.0",
+  "port-version": 0,
+  "description": "Modern C++20 PACS implementation for DICOM medical imaging",
+  "homepage": "https://github.com/kcenon/pacs_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    "kcenon-common-system",
+    "kcenon-container-system",
+    "kcenon-network-system",
+    { "name": "vcpkg-cmake", "host": true },
+    { "name": "vcpkg-cmake-config", "host": true }
+  ],
+  "overrides": [
+    { "name": "sqlite3", "version": "3.45.1" },
+    { "name": "openssl", "version": "3.3.0" },
+    { "name": "libjpeg-turbo", "version": "3.0.2" },
+    { "name": "libpng", "version": "1.6.43" },
+    { "name": "openjpeg", "version": "2.5.2" },
+    { "name": "charls", "version": "2.4.2" },
+    { "name": "crow", "version": "1.2.1" },
+    { "name": "gtest", "version": "1.14.0" },
+    { "name": "benchmark", "version": "1.8.3" }
+  ],
+  "features": {
+    "storage": {
+      "description": "SQLite3-based PACS storage",
+      "dependencies": [
+        {
+          "name": "sqlite3",
+          "version>=": "3.45.1"
+        }
+      ]
+    },
+    "codecs": {
+      "description": "Optional image compression codecs (JPEG, JPEG2000, JPEG-LS, PNG)",
+      "dependencies": [
+        {
+          "name": "libjpeg-turbo",
+          "version>=": "3.0.2"
+        },
+        {
+          "name": "libpng",
+          "version>=": "1.6.43"
+        },
+        {
+          "name": "openjpeg",
+          "version>=": "2.5.2"
+        },
+        {
+          "name": "charls",
+          "version>=": "2.4.2"
+        }
+      ]
+    },
+    "ssl": {
+      "description": "TLS/SSL support for secure DICOM associations",
+      "dependencies": [
+        {
+          "name": "openssl",
+          "version>=": "3.0.0"
+        }
+      ]
+    },
+    "aws": {
+      "description": "AWS S3 integration for cloud-based PACS storage",
+      "dependencies": [
+        {
+          "name": "aws-sdk-cpp",
+          "default-features": false,
+          "features": ["s3"]
+        }
+      ]
+    },
+    "azure": {
+      "description": "Azure Blob storage integration for cloud-based PACS storage",
+      "dependencies": [
+        "azure-storage-blobs-cpp"
+      ]
+    },
+    "rest-api": {
+      "description": "DICOMweb REST API via Crow HTTP framework",
+      "dependencies": [
+        {
+          "name": "crow",
+          "version>=": "1.2.1"
+        }
+      ]
+    },
+    "testing": {
+      "description": "Build unit tests and benchmarks",
+      "dependencies": [
+        {
+          "name": "gtest",
+          "version>=": "1.14.0",
+          "features": ["gmock"]
+        },
+        {
+          "name": "benchmark"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #906

## Summary

- Creates `vcpkg.json` with `kcenon-pacs-system` as the package name (version 0.1.0)
- Declares required ecosystem dependencies: `kcenon-common-system`, `kcenon-container-system`, `kcenon-network-system`
- Defines 7 optional feature groups: `storage`, `codecs`, `ssl`, `aws`, `azure`, `rest-api`, `testing`
- Pins dependency versions via `overrides` for reproducible builds
- Creates `vcpkg-configuration.json` with ecosystem standard baseline (`c4af3593e1f1aa9e14a560a09e45ea2cb0dfd74d`)

## Acceptance Criteria

- [x] `vcpkg.json` created with correct metadata (name: `kcenon-pacs-system`, version: `0.1.0`, license: `BSD-3-Clause`)
- [x] All required kcenon dependencies declared (`common_system`, `container_system`, `network_system`)
- [x] Features declared for each optional module (`storage`, `codecs`, `ssl`, `aws`, `azure`, `rest-api`)
- [x] `vcpkg-configuration.json` created with ecosystem baseline
- [x] `sbom.yml` CI workflow can now detect and process `vcpkg.json`

## Test Plan

- Verify `sbom.yml` CI workflow no longer falls back to "No vcpkg.json found"
- Run `vcpkg install` with manifest mode to verify dependency resolution
- Test feature activation: `vcpkg install kcenon-pacs-system[storage,codecs,ssl]`