### PR TITLE
fix(build): remove unconditional OpenSSL and ZLIB from pacs_systemConfig.cmake.in

### DIFF
--- a/cmake/pacs_systemConfig.cmake.in
+++ b/cmake/pacs_systemConfig.cmake.in
@@ -3,8 +3,6 @@
 include(CMakeFindDependencyMacro)
 
 find_dependency(Threads REQUIRED)
-find_dependency(OpenSSL REQUIRED)
-find_dependency(ZLIB REQUIRED)
 find_dependency(common_system CONFIG REQUIRED)
 find_dependency(ContainerSystem CONFIG REQUIRED)
 find_dependency(NetworkSystem CONFIG REQUIRED)


### PR DESCRIPTION
## Summary

- Remove incorrect unconditional `find_dependency(OpenSSL REQUIRED)` from the config template
- Remove incorrect `find_dependency(ZLIB REQUIRED)` — pacs_system does not use ZLIB
- OpenSSL dependency is already correctly gated under `@PACS_SYSTEM_WITH_OPENSSL@` conditional block

## Problem

The `cmake/pacs_systemConfig.cmake.in` template had two bugs introduced in #920:

1. `find_dependency(OpenSSL REQUIRED)` was listed unconditionally at the top, causing `find_package(pacs_system CONFIG)` to fail on systems without OpenSSL even when pacs_system was built without SSL support. The conditional block at line 48 already handles OpenSSL correctly via `@PACS_SYSTEM_WITH_OPENSSL@`.

2. `find_dependency(ZLIB REQUIRED)` referenced a library that pacs_system does not use — no `find_package(ZLIB)` or ZLIB linkage exists anywhere in `CMakeLists.txt`.

## Test Plan

- [ ] Verify `cmake/pacs_systemConfig.cmake.in` no longer has unconditional OpenSSL or ZLIB dependencies
- [ ] Confirm `find_package(pacs_system CONFIG REQUIRED)` works on a system without OpenSSL when built without SSL
- [ ] Confirm `find_package(pacs_system CONFIG REQUIRED)` still works when built with OpenSSL (`PACS_SYSTEM_WITH_OPENSSL=TRUE`)

Closes #907