### PR TITLE
fix(docs): correct license metadata from MIT to BSD-3-Clause

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -152,4 +152,4 @@ Edit `src/index.css` to customize the color theme and design tokens.
 
 ## License
 
-MIT License - see [LICENSE](../LICENSE) for details.
+BSD-3-Clause License - see [LICENSE](../LICENSE) for details.


### PR DESCRIPTION
Closes #909

## Summary

- Fixed `web/README.md` license reference from "MIT License" to "BSD-3-Clause License"

## Audit Results

The issue originally identified multiple locations with incorrect MIT references. After thorough audit, most were already corrected:

| File | Status |
|------|--------|
| `docs/SOUP.md` (kcenon libs) | Already BSD-3-Clause |
| `dependency-security-scan.yml` | Already references BSD-3-Clause |
| `dependency-manifest.json` (internal_ecosystem) | Already BSD-3-Clause |
| `LICENSE-THIRD-PARTY` | Already exists with correct data |
| `vcpkg.json` | Already BSD-3-Clause |
| `sbom.yml` | Reads from dependency-manifest.json (correct) |
| **`web/README.md`** | **Fixed: MIT → BSD-3-Clause** |

Note: MIT references for third-party dependencies (fmt, React, Azure SDK, etc.) are correct and unchanged.

## Test Plan

- [x] Verify `web/README.md` license section matches root LICENSE file
- [x] Grep audit confirms no remaining incorrect MIT references to kcenon libraries
- [x] `dependency-manifest.json` internal_ecosystem entries all show BSD-3-Clause
- [x] `LICENSE-THIRD-PARTY` file exists and is accurate