### PR TITLE
chore(deps): create vcpkg overlay port for kcenon-pacs-system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ docs/latex/
 
 # vcpkg
 vcpkg_installed/
+!vcpkg-ports/**/*.cmake
 
 # Dependencies
 dependencies/

--- a/vcpkg-ports/kcenon-pacs-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-pacs-system/portfile.cmake
@@ -1,0 +1,58 @@
+# kcenon-pacs-system portfile
+# Modern C++20 PACS implementation for DICOM medical imaging
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/pacs_system
+    REF v0.1.0
+    SHA512 0  # TODO: Update with actual SHA512 hash after release
+    HEAD_REF main
+)
+
+# Feature-based option selection
+set(PACS_STORAGE OFF)
+if("storage" IN_LIST FEATURES)
+    set(PACS_STORAGE ON)
+endif()
+
+set(PACS_AWS OFF)
+if("aws" IN_LIST FEATURES)
+    set(PACS_AWS ON)
+endif()
+
+set(PACS_AZURE OFF)
+if("azure" IN_LIST FEATURES)
+    set(PACS_AZURE ON)
+endif()
+
+set(PACS_TESTS OFF)
+if("testing" IN_LIST FEATURES)
+    set(PACS_TESTS ON)
+endif()
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DPACS_BUILD_STORAGE=${PACS_STORAGE}
+        -DPACS_WITH_AWS_SDK=${PACS_AWS}
+        -DPACS_WITH_AZURE_SDK=${PACS_AZURE}
+        -DPACS_BUILD_TESTS=${PACS_TESTS}
+        -DPACS_BUILD_EXAMPLES=OFF
+        -DPACS_BUILD_BENCHMARKS=OFF
+        -DPACS_BUILD_SAMPLES=OFF
+        -DPACS_WARNINGS_AS_ERRORS=OFF
+        -DPACS_BUILD_MODULES=OFF
+        -DBUILD_SHARED_LIBS=OFF
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME pacs_system
+    CONFIG_PATH lib/cmake/pacs_system
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,0 +1,101 @@
+{
+  "name": "kcenon-pacs-system",
+  "version": "0.1.0",
+  "port-version": 0,
+  "description": "Modern C++20 PACS implementation for DICOM medical imaging",
+  "homepage": "https://github.com/kcenon/pacs_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    "kcenon-common-system",
+    "kcenon-container-system",
+    "kcenon-network-system"
+  ],
+  "features": {
+    "storage": {
+      "description": "SQLite3-based PACS storage",
+      "dependencies": [
+        {
+          "name": "sqlite3",
+          "version>=": "3.45.1"
+        }
+      ]
+    },
+    "codecs": {
+      "description": "Optional image compression codecs (JPEG, JPEG2000, JPEG-LS, PNG)",
+      "dependencies": [
+        {
+          "name": "libjpeg-turbo",
+          "version>=": "3.0.2"
+        },
+        {
+          "name": "libpng",
+          "version>=": "1.6.43"
+        },
+        {
+          "name": "openjpeg",
+          "version>=": "2.5.2"
+        },
+        {
+          "name": "charls",
+          "version>=": "2.4.2"
+        }
+      ]
+    },
+    "ssl": {
+      "description": "TLS/SSL support for secure DICOM associations",
+      "dependencies": [
+        {
+          "name": "openssl",
+          "version>=": "3.0.0"
+        }
+      ]
+    },
+    "aws": {
+      "description": "AWS S3 integration for cloud-based PACS storage",
+      "dependencies": [
+        {
+          "name": "aws-sdk-cpp",
+          "default-features": false,
+          "features": ["s3"]
+        }
+      ]
+    },
+    "azure": {
+      "description": "Azure Blob storage integration for cloud-based PACS storage",
+      "dependencies": [
+        "azure-storage-blobs-cpp"
+      ]
+    },
+    "rest-api": {
+      "description": "DICOMweb REST API via Crow HTTP framework",
+      "dependencies": [
+        {
+          "name": "crow",
+          "version>=": "1.2.1"
+        }
+      ]
+    },
+    "testing": {
+      "description": "Build unit tests and benchmarks",
+      "dependencies": [
+        {
+          "name": "gtest",
+          "version>=": "1.14.0",
+          "features": ["gmock"]
+        },
+        {
+          "name": "benchmark"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Closes #908

## Summary

Create vcpkg overlay port for `kcenon-pacs-system` (Tier 5), completing the full 8-port ecosystem for vcpkg registry submission.

### Port Structure

| File | Purpose |
|------|---------|
| `vcpkg-ports/kcenon-pacs-system/vcpkg.json` | Port manifest with feature declarations |
| `vcpkg-ports/kcenon-pacs-system/portfile.cmake` | Build recipe with feature-conditional CMake options |

### Feature Mapping

| vcpkg Feature | CMake Option / Mechanism | Dependencies |
|---------------|--------------------------|--------------|
| `storage` | `PACS_BUILD_STORAGE=ON` | sqlite3 |
| `codecs` | Auto-detected via `find_package` | libjpeg-turbo, libpng, openjpeg, charls |
| `ssl` | Auto-detected via `find_package` | openssl |
| `aws` | `PACS_WITH_AWS_SDK=ON` | aws-sdk-cpp[s3] |
| `azure` | `PACS_WITH_AZURE_SDK=ON` | azure-storage-blobs-cpp |
| `rest-api` | Auto-detected via Crow target | crow |
| `testing` | `PACS_BUILD_TESTS=ON` | gtest[gmock], benchmark |

### Core Dependencies

- `kcenon-common-system` (Tier 0)
- `kcenon-container-system` (Tier 1)
- `kcenon-network-system` (Tier 4)

### Notes

- `.gitignore` updated to allow `vcpkg-ports/**/*.cmake` (was blocked by `*.cmake` rule)
- SHA512 uses placeholder `0` following established ecosystem convention for pre-release ports
- Follows the same port structure as `kcenon-network-system` and `kcenon-database-system`

## Test Plan

- [ ] Verify `portfile.cmake` follows ecosystem patterns (compare with `kcenon-network-system`)
- [ ] Verify `vcpkg.json` features match project `vcpkg.json` manifest
- [ ] Verify feature-to-CMake-option mapping matches `CMakeLists.txt`
- [ ] Full integration test after SHA512 hash is populated with actual release tag