### PR TITLE
chore(vcpkg): update overlay port with v0.1.0 SHA512 and sync port-version

### DIFF
--- a/vcpkg-ports/kcenon-pacs-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-pacs-system/portfile.cmake
@@ -5,7 +5,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO kcenon/pacs_system
     REF v0.1.0
-    SHA512 0  # TODO: Update with actual SHA512 hash after release
+    SHA512 242dd7bc82f56e0267e4978dd406aebeebd1bb50e70f93a8c809d3474ae6de1d0e692cc8fbbbaa81dbb68e2642b48c14100b8d5daa5f99097287af2d9465904c
     HEAD_REF main
 )
 

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version": "0.1.0",
-  "port-version": 0,
+  "port-version": 2,
   "description": "Modern C++20 PACS implementation for DICOM medical imaging",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## What

Resolves the stale vcpkg overlay port by replacing the `SHA512 0` placeholder with the actual hash for the `v0.1.0` release archive, and bumps `port-version` from 0 to 2 to align with the central registry.

### Changes
- `vcpkg-ports/kcenon-pacs-system/portfile.cmake`: Replace `SHA512 0` placeholder with actual SHA512 hash
- `vcpkg-ports/kcenon-pacs-system/vcpkg.json`: Bump `port-version` from 0 to 2

## Why

- `SHA512 0` blocks actual vcpkg installation — vcpkg validates the archive integrity on download
- The v0.1.0 tag already exists on GitHub (`9d859d87`) but had no corresponding GitHub Release or valid SHA512
- Port-version 0 was out of sync with the central registry (port-version 2)

### Related
- Closes #938
- GitHub Release: https://github.com/kcenon/pacs_system/releases/tag/v0.1.0

## How

### Implementation Details

1. GitHub Release created for existing `v0.1.0` tag
2. SHA512 computed from release archive: `https://github.com/kcenon/pacs_system/archive/refs/tags/v0.1.0.tar.gz`
3. `portfile.cmake` updated with actual 128-char SHA512 hash
4. `port-version` bumped to 2 (matches central registry in monitoring_system)

**Note**: `PACS_WITH_NETWORK_SYSTEM=ON` is intentionally kept in the overlay port (set by #935) — this differs from the central registry's `OFF` setting but is correct for this project's overlay use case.

### Testing Done
- [x] SHA512 verified with both `sha512sum` and `openssl dgst -sha512`
- [x] Hash length confirmed: 128 hex characters (512 bits)
- [x] GitHub Release successfully created at https://github.com/kcenon/pacs_system/releases/tag/v0.1.0

### Acceptance Criteria Status
- [x] Annotated git tag exists on main (v0.1.0 at 9d859d87)
- [x] GitHub Release created with changelog
- [x] Central portfile REF is already on stable tag (v0.1.0) — no change needed
- [x] SHA512 hash is valid (not placeholder)
- [x] Local port synced: port-version bumped to 2, SHA512 updated