### PR TITLE
fix(build): gate logger_system includes behind PACS_WITH_LOGGER_SYSTEM and add vcpkg dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1864,21 +1864,6 @@ endif()
 
 # Integration library (requires container_system and logger_system via network_system)
 if(TARGET container_system AND COMMON_SYSTEM_FOUND AND TARGET NetworkSystem)
-    # Check for monitoring_system availability BEFORE defining pacs_integration
-    # This allows conditional inclusion of monitoring_adapter.cpp
-    set(_PACS_MONITORING_PATHS_EARLY
-        "$ENV{MONITORING_SYSTEM_ROOT}"
-        "${CMAKE_CURRENT_SOURCE_DIR}/../monitoring_system"
-        "${CMAKE_CURRENT_SOURCE_DIR}/monitoring_system"
-    )
-    set(MONITORING_SYSTEM_AVAILABLE FALSE)
-    foreach(_path ${_PACS_MONITORING_PATHS_EARLY})
-        if(EXISTS "${_path}/CMakeLists.txt" AND EXISTS "${_path}/include/kcenon/monitoring/core/performance_monitor.h")
-            set(MONITORING_SYSTEM_AVAILABLE TRUE)
-            break()
-        endif()
-    endforeach()
-
     # Define integration library sources
     set(PACS_INTEGRATION_SOURCES
         src/integration/container_adapter.cpp
@@ -1890,8 +1875,8 @@ if(TARGET container_system AND COMMON_SYSTEM_FOUND AND TARGET NetworkSystem)
         src/integration/dicom_session.cpp
     )
 
-    # Only include monitoring_adapter.cpp if monitoring_system is available
-    if(MONITORING_SYSTEM_AVAILABLE)
+    # Include monitoring_adapter.cpp when monitoring_system is available (local or vcpkg)
+    if(MONITORING_SYSTEM_FOUND OR TARGET monitoring_system)
         list(APPEND PACS_INTEGRATION_SOURCES src/integration/monitoring_adapter.cpp)
     endif()
 

--- a/src/integration/logger_adapter.cpp
+++ b/src/integration/logger_adapter.cpp
@@ -34,11 +34,13 @@
 
 #include <pacs/integration/logger_adapter.hpp>
 
+#ifdef PACS_WITH_LOGGER_SYSTEM
 #include <kcenon/common/interfaces/logger_interface.h>
 #include <kcenon/logger/core/logger.h>
 #include <kcenon/logger/interfaces/logger_types.h>
 #include <kcenon/logger/writers/console_writer.h>
 #include <kcenon/logger/writers/rotating_file_writer.h>
+#endif  // PACS_WITH_LOGGER_SYSTEM
 
 #include <atomic>
 #include <chrono>
@@ -53,6 +55,8 @@ namespace pacs::integration {
 // =============================================================================
 // Implementation Class
 // =============================================================================
+
+#ifdef PACS_WITH_LOGGER_SYSTEM
 
 class logger_adapter::impl {
 public:
@@ -319,7 +323,65 @@ auto logger_adapter::is_level_enabled(log_level level) noexcept -> bool {
 void logger_adapter::flush() { pimpl_->flush(); }
 
 // =============================================================================
-// DICOM Audit Logging
+// Configuration
+// =============================================================================
+
+void logger_adapter::set_min_level(log_level level) {
+    pimpl_->set_min_level(level);
+}
+
+auto logger_adapter::get_min_level() noexcept -> log_level {
+    return pimpl_->get_min_level();
+}
+
+auto logger_adapter::get_config() -> const logger_config& {
+    return pimpl_->get_config();
+}
+
+// =============================================================================
+// Private Helpers
+// =============================================================================
+
+void logger_adapter::write_audit_log(
+    const std::string& event_type,
+    const std::string& outcome,
+    const std::map<std::string, std::string>& fields) {
+    pimpl_->write_audit_log(event_type, outcome, fields);
+}
+
+#else  // PACS_WITH_LOGGER_SYSTEM not defined — no-op stubs
+
+// =============================================================================
+// No-op Implementation (logger_system not available)
+// =============================================================================
+
+class logger_adapter::impl {};
+
+std::unique_ptr<logger_adapter::impl> logger_adapter::pimpl_ = nullptr;
+
+void logger_adapter::initialize(const logger_config&) {}
+void logger_adapter::shutdown() {}
+auto logger_adapter::is_initialized() noexcept -> bool { return false; }
+void logger_adapter::log(log_level, const std::string&) {}
+auto logger_adapter::is_level_enabled(log_level) noexcept -> bool { return false; }
+void logger_adapter::flush() {}
+void logger_adapter::set_min_level(log_level) {}
+auto logger_adapter::get_min_level() noexcept -> log_level { return log_level::off; }
+
+auto logger_adapter::get_config() -> const logger_config& {
+    static const logger_config default_config;
+    return default_config;
+}
+
+void logger_adapter::write_audit_log(
+    const std::string&,
+    const std::string&,
+    const std::map<std::string, std::string>&) {}
+
+#endif  // PACS_WITH_LOGGER_SYSTEM
+
+// =============================================================================
+// DICOM Audit Logging (delegates to log()/write_audit_log() — always compiled)
 // =============================================================================
 
 void logger_adapter::log_association_established(const std::string& calling_ae,
@@ -440,31 +502,8 @@ void logger_adapter::log_security_event(security_event_type type,
 }
 
 // =============================================================================
-// Configuration
+// String Conversion Helpers (always compiled — no logger_system dependency)
 // =============================================================================
-
-void logger_adapter::set_min_level(log_level level) {
-    pimpl_->set_min_level(level);
-}
-
-auto logger_adapter::get_min_level() noexcept -> log_level {
-    return pimpl_->get_min_level();
-}
-
-auto logger_adapter::get_config() -> const logger_config& {
-    return pimpl_->get_config();
-}
-
-// =============================================================================
-// Private Helpers
-// =============================================================================
-
-void logger_adapter::write_audit_log(
-    const std::string& event_type,
-    const std::string& outcome,
-    const std::map<std::string, std::string>& fields) {
-    pimpl_->write_audit_log(event_type, outcome, fields);
-}
 
 auto logger_adapter::storage_status_to_string(storage_status status) -> std::string {
     switch (status) {

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version": "0.1.0",
-  "port-version": 2,
+  "port-version": 3,
   "description": "Modern C++20 PACS implementation for DICOM medical imaging",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",
@@ -17,6 +17,7 @@
     },
     "kcenon-common-system",
     "kcenon-container-system",
+    "kcenon-logger-system",
     "kcenon-network-system"
   ],
   "features": {


### PR DESCRIPTION
## What

The overlay vcpkg port (`vcpkg-ports/kcenon-pacs-system/vcpkg.json`) was missing
`kcenon-logger-system` as an explicit dependency. When pacs_system was built via vcpkg
with `PACS_WITH_NETWORK_SYSTEM=ON`, the `pacs_integration` library included
`logger_adapter.cpp`, which unconditionally included `<kcenon/logger/core/logger.h>` —
a header that was not installed because logger_system was not a declared dependency.

## Why

- Without `kcenon-logger-system` in vcpkg.json, `find_package(LoggerSystem)` fails,
  `PACS_WITH_LOGGER_SYSTEM` is never defined, but `logger_adapter.cpp` still tries to
  include logger_system headers → compilation error
- The central portfile comment "Network integration disabled: upstream include paths
  assume submodule layout (kcenon/logger/ vs logger_system/)" was caused by this
  missing dependency, not an actual path incompatibility (both layouts install to `kcenon/logger/`)

Closes #939

## Where

- `vcpkg-ports/kcenon-pacs-system/vcpkg.json` — added `kcenon-logger-system` dependency, bumped port-version to 3
- `src/integration/logger_adapter.cpp` — gated logger_system `#include` directives and pimpl implementation behind `#ifdef PACS_WITH_LOGGER_SYSTEM`; no-op stubs provided in `#else` branch; DICOM audit log methods and string-conversion helpers moved outside the guard (they delegate to the conditionally-defined primitives)
- `CMakeLists.txt` — replaced local-only `MONITORING_SYSTEM_AVAILABLE` path scan with `MONITORING_SYSTEM_FOUND OR TARGET monitoring_system` so `monitoring_adapter.cpp` is compiled when monitoring_system is installed via vcpkg

## How

### Implementation Details

1. **vcpkg.json** — added `kcenon-logger-system` to the overlay port so vcpkg installs it before building pacs_system. The include path `<kcenon/logger/core/logger.h>` is correct for both submodule and vcpkg layouts.

2. **logger_adapter.cpp** — restructured with `#ifdef PACS_WITH_LOGGER_SYSTEM`:
   - Full pimpl implementation when logger_system is available
   - Empty `impl` class + no-op public methods when not available
   - DICOM audit log methods (`log_association_established`, etc.) always compiled — they delegate through `log()` / `write_audit_log()`, which are no-ops when logger_system is absent
   - String conversion helpers always compiled (no logger_system types used)

3. **CMakeLists.txt** — `MONITORING_SYSTEM_FOUND` (set by both local path scan and `find_package()` fallback) is now the authoritative check for conditional inclusion of `monitoring_adapter.cpp`

### Testing Done
- [x] No regression in submodule/FetchContent build mode (logger_system found via local paths → `PACS_WITH_LOGGER_SYSTEM` defined → full implementation compiled)
- [x] vcpkg build with `kcenon-logger-system` dependency: `find_package(LoggerSystem)` succeeds, `PACS_WITH_LOGGER_SYSTEM` defined, full implementation compiled
- [x] Build without logger_system: no-op stubs prevent compilation and linker errors

### Breaking Changes
None — existing submodule/FetchContent builds are unaffected.