### PR TITLE
fix(vcpkg): add required kcenon ecosystem dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,11 @@
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",
   "supports": "!(uwp | xbox)",
-  "dependencies": [],
+  "dependencies": [
+    "kcenon-common-system",
+    "kcenon-container-system",
+    "kcenon-network-system"
+  ],
   "overrides": [
     { "name": "sqlite3", "version": "3.45.1" },
     { "name": "openssl", "version": "3.3.0" },


### PR DESCRIPTION
## What

Add `kcenon-common-system`, `kcenon-container-system`, and `kcenon-network-system` to the `dependencies` array in `vcpkg.json`.

- **Current**: `"dependencies": []` — vcpkg does not install kcenon packages automatically
- **Expected**: All three required packages are installed as transitive dependencies when running `vcpkg install kcenon-pacs-system`

## Why

`CMakeLists.txt:55-57` enables `PACS_WITH_COMMON_SYSTEM`, `PACS_WITH_CONTAINER_SYSTEM`, and `PACS_WITH_NETWORK_SYSTEM` as `ON` by default. If any of these packages are not found, the build terminates with `FATAL_ERROR`. A consumer on a clean machine hitting:

```
CMake Error: Could not find a package configuration file provided by "common_system"
```

...has no path to success using only vcpkg.

### Related Issues
- Closes #944

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg.json` | Added three `kcenon-*` entries to `dependencies` array |

## How

### Implementation Details
- Added `kcenon-common-system`, `kcenon-container-system`, `kcenon-network-system` to top-level `dependencies`
- `thread_system`, `logger_system`, and `monitoring_system` are installed transitively via `network_system` — no direct listing needed
- `vcpkg-configuration.json` already registers the `kcenon-*` custom git registry

### Breaking Changes
None — existing consumers using `add_subdirectory` or FetchContent are unaffected; `dependency-manifest.json` is unchanged.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described
- [x] Related issue linked with closing keyword