### PR TITLE
fix(cmake): correct find_dependency package names in pacs_systemConfig

### DIFF
--- a/cmake/pacs_systemConfig.cmake.in
+++ b/cmake/pacs_systemConfig.cmake.in
@@ -4,15 +4,15 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Threads REQUIRED)
 find_dependency(common_system CONFIG REQUIRED)
-find_dependency(ContainerSystem CONFIG REQUIRED)
-find_dependency(NetworkSystem CONFIG REQUIRED)
+find_dependency(container_system CONFIG REQUIRED)
+find_dependency(network_system CONFIG REQUIRED)
 
 if(@PACS_SYSTEM_WITH_THREAD_SYSTEM@)
     find_dependency(ThreadSystem CONFIG REQUIRED)
 endif()
 
 if(@PACS_SYSTEM_WITH_LOGGER_SYSTEM@)
-    find_dependency(LoggerSystem CONFIG REQUIRED)
+    find_dependency(logger_system CONFIG REQUIRED)
 endif()
 
 if(@PACS_SYSTEM_WITH_MONITORING_SYSTEM@)
@@ -20,7 +20,7 @@ if(@PACS_SYSTEM_WITH_MONITORING_SYSTEM@)
 endif()
 
 if(@PACS_SYSTEM_WITH_DATABASE_SYSTEM@)
-    find_dependency(DatabaseSystem CONFIG REQUIRED)
+    find_dependency(database_system CONFIG REQUIRED)
 endif()
 
 if(@PACS_SYSTEM_WITH_SQLITE@)


### PR DESCRIPTION
## What

Correct four `find_dependency()` package names in `cmake/pacs_systemConfig.cmake.in` to match the actual `snake_case` config filenames exported by kcenon ecosystem packages.

| Before | After | Actual config file |
|--------|-------|--------------------|
| `ContainerSystem` | `container_system` | `container_system-config.cmake` |
| `NetworkSystem` | `network_system` | `network_system-config.cmake` |
| `LoggerSystem` | `logger_system` | `logger_system-config.cmake` |
| `DatabaseSystem` | `database_system` | `database_system-config.cmake` |

`ThreadSystem` and `monitoring_system` were already correct and are unchanged.

## Why

`find_package(pacs_system CONFIG REQUIRED)` failed at consumer configure time with "Could not find ContainerSystem / NetworkSystem / LoggerSystem / DatabaseSystem" even when all packages were correctly installed via vcpkg. CMake searches for `ContainerSystemConfig.cmake` when given `find_dependency(ContainerSystem)`, but the kcenon ecosystem exports `container_system-config.cmake`.

### Related Issues
- Closes #945

## Where

### Files Changed
| File | Change |
|------|--------|
| `cmake/pacs_systemConfig.cmake.in` | 4 `find_dependency` name corrections |

## How

### Implementation Details
- Renamed 4 package names to match the actual cmake config file names exported by each kcenon package
- No functional logic changed — only the package search names used by CMake's `find_dependency` macro
- Target names (e.g., `ContainerSystem::container`) are defined in `Targets.cmake` and are unaffected by this change

### Breaking Changes
None — this fixes broken behavior. Consumers that were previously failing will now succeed.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No sensitive data exposed
- [x] Commits are atomic and well-described
- [x] Related issue linked with closing keyword