### PR TITLE
fix(build): add openjph to codecs feature for vcpkg resolution

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -19,6 +19,7 @@
     { "name": "libpng", "version": "1.6.43" },
     { "name": "openjpeg", "version": "2.5.2" },
     { "name": "charls", "version": "2.4.2" },
+    { "name": "openjph", "version": "0.21.0" },
     { "name": "crow", "version": "1.2.1" },
     { "name": "gtest", "version": "1.14.0" },
     { "name": "benchmark", "version": "1.8.3" }
@@ -34,7 +35,7 @@
       ]
     },
     "codecs": {
-      "description": "Optional image compression codecs (JPEG, JPEG2000, JPEG-LS, PNG)",
+      "description": "Optional image compression codecs (JPEG, JPEG2000, HTJ2K, JPEG-LS, PNG)",
       "dependencies": [
         {
           "name": "libjpeg-turbo",
@@ -51,6 +52,10 @@
         {
           "name": "charls",
           "version>=": "2.4.2"
+        },
+        {
+          "name": "openjph",
+          "version>=": "0.21.0"
         }
       ]
     },


### PR DESCRIPTION
## What

Add `openjph` (OpenJPH/HTJ2K) to the `codecs` feature dependencies and `overrides` in `vcpkg.json` so it can be pre-installed by vcpkg instead of being fetched at configure time via FetchContent.

## Why

Part of resolving the FetchContent fallback issue in vcpkg-mode builds. When `PACS_FETCH_OPENJPH=OFF` is set in the portfile (see companion PR in vcpkg-registry), the build must find openjph through normal vcpkg/pkg-config resolution. This change ensures `vcpkg install kcenon-pacs-system[codecs]` pre-installs openjph.

Closes #946

## Where

- `vcpkg.json` — `overrides` and `features.codecs.dependencies`

## How

### Changes
- Added `openjph` (version `0.21.0`) to `overrides` for version pinning
- Added `openjph` to `codecs` feature dependencies with `version>=: 0.21.0`
- Updated `codecs` description to include HTJ2K

### Test Plan
- [ ] `vcpkg install kcenon-pacs-system[codecs]` succeeds and installs openjph
- [ ] Configure with `PACS_FETCH_OPENJPH=OFF` and openjph pre-installed resolves HTJ2K support correctly