### PR TITLE
chore(deps): Align sqlite3 override version with ecosystem standard

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -13,7 +13,7 @@
     "kcenon-network-system"
   ],
   "overrides": [
-    { "name": "sqlite3", "version": "3.45.1" },
+    { "name": "sqlite3", "version": "3.45.3" },
     { "name": "openssl", "version": "3.3.0" },
     { "name": "libjpeg-turbo", "version": "3.0.2" },
     { "name": "libpng", "version": "1.6.43" },


### PR DESCRIPTION
## What

### Summary
Align sqlite3 override version from 3.45.1 to 3.45.3 to match the ecosystem standard set by database_system.

### Change Type
- [x] Chore (maintenance)

## Why

### Related Issues
- Closes #950

### Motivation
The pacs_system pinned sqlite3 to 3.45.1 while database_system uses 3.45.3. When both coexist in a consumer project, this version mismatch could cause conflicts. Version 3.45.3 includes additional bug fixes over 3.45.1.

## Where

- `vcpkg.json` — overrides section, sqlite3 version

## How

### Implementation Highlights
Single-line change: `3.45.1` → `3.45.3` in the overrides array.

### Test Plan
- [ ] vcpkg install with storage feature succeeds
- [ ] Existing storage tests pass with sqlite3 3.45.3