### PR TITLE
fix(deps): Add asio 1.30.2 override to vcpkg.json

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -22,7 +22,8 @@
     { "name": "openjph", "version": "0.21.0" },
     { "name": "crow", "version": "1.2.1" },
     { "name": "gtest", "version": "1.14.0" },
-    { "name": "benchmark", "version": "1.8.3" }
+    { "name": "benchmark", "version": "1.8.3" },
+    { "name": "asio", "version": "1.30.2" }
   ],
   "features": {
     "storage": {


### PR DESCRIPTION
## Summary
- Add asio 1.30.2 version override to vcpkg.json overrides array
- Aligns pacs_system with network_system and database_system that pin asio to 1.30.2

## Related Issues
- Closes #952
- Part of kcenon/common_system#454

## Test plan
- [ ] Verify vcpkg.json is valid JSON
- [ ] Verify asio override version matches ecosystem standard (1.30.2)