### PR TITLE
chore(deps): Remove fmt fallback and require std::format

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,51 +417,6 @@ else()
     set(PACS_OPENSSL_FOUND FALSE)
 endif()
 
-# fmt library (for std::format compatibility on older compilers)
-message(STATUS "")
-message(STATUS "=== Finding fmt library (for format compatibility) ===")
-
-# Check if std::format is available
-include(CheckCXXSourceCompiles)
-set(CMAKE_REQUIRED_FLAGS "-std=c++20")
-check_cxx_source_compiles("
-    #include <format>
-    int main() {
-        auto s = std::format(\"Hello {}\", \"World\");
-        return 0;
-    }
-" PACS_HAS_STD_FORMAT)
-
-if(PACS_HAS_STD_FORMAT)
-    message(STATUS "std::format is available - no fmt fallback needed")
-    set(PACS_FMT_NEEDED FALSE)
-else()
-    message(STATUS "std::format not available - using fmt library as fallback")
-    set(PACS_FMT_NEEDED TRUE)
-
-    # Try to find fmt library
-    find_package(fmt CONFIG QUIET)
-    if(NOT fmt_FOUND)
-        find_package(fmt QUIET)
-    endif()
-
-    if(fmt_FOUND)
-        message(STATUS "Found fmt library")
-        set(PACS_FMT_TARGET fmt::fmt)
-    else()
-        # Fetch fmt if not found
-        message(STATUS "fmt not found, fetching from source...")
-        FetchContent_Declare(
-            fmt
-            GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-            GIT_TAG 10.2.1
-        )
-        FetchContent_MakeAvailable(fmt)
-        set(PACS_FMT_TARGET fmt::fmt)
-        message(STATUS "fmt fetched and configured")
-    endif()
-endif()
-
 # ==========================================================================
 # kcenon Ecosystem SOUP Version Registry (IEC 62304 §8.1.2)
 # These SHA identifiers must match the pinned versions in:
@@ -1649,11 +1604,6 @@ if(PACS_BUILD_STORAGE AND SQLITE3_FOUND)
         message(STATUS "    database_system: linked (SQL injection protection enabled)")
     endif()
 
-    # Link fmt library for format compatibility (if needed)
-    if(PACS_FMT_NEEDED AND PACS_FMT_TARGET)
-        target_link_libraries(pacs_storage PUBLIC ${PACS_FMT_TARGET})
-    endif()
-
     # AWS SDK integration for S3 storage (Issue #724)
     if(PACS_WITH_AWS_SDK)
         find_package(AWSSDK COMPONENTS s3)
@@ -1846,11 +1796,6 @@ if(TARGET Crow::Crow)
         target_compile_definitions(pacs_web PUBLIC PACS_WITH_MONITORING)
     endif()
 
-    # Link fmt library for format compatibility (if needed)
-    if(PACS_FMT_NEEDED AND PACS_FMT_TARGET)
-        target_link_libraries(pacs_web PUBLIC ${PACS_FMT_TARGET})
-    endif()
-
     # Link OpenSSL for JWT signature verification (Issue #860)
     if(PACS_OPENSSL_FOUND)
         target_link_libraries(pacs_web PUBLIC OpenSSL::SSL OpenSSL::Crypto)
@@ -1900,11 +1845,6 @@ if(TARGET container_system AND COMMON_SYSTEM_FOUND AND TARGET NetworkSystem)
         container_system
         ContainerSystem::container
     )
-
-    # Link fmt library for format compatibility (if needed)
-    if(PACS_FMT_NEEDED AND PACS_FMT_TARGET)
-        target_link_libraries(pacs_integration PUBLIC ${PACS_FMT_TARGET})
-    endif()
 
     # Link logger_system (REQUIRED for logger_adapter)
     if(TARGET LoggerSystem)
@@ -2246,11 +2186,6 @@ endif()
 set(PACS_SYSTEM_WITH_OPENSSL FALSE)
 if(PACS_OPENSSL_FOUND)
     set(PACS_SYSTEM_WITH_OPENSSL TRUE)
-endif()
-
-set(PACS_SYSTEM_WITH_FMT FALSE)
-if(PACS_FMT_NEEDED AND PACS_FMT_TARGET)
-    set(PACS_SYSTEM_WITH_FMT TRUE)
 endif()
 
 set(PACS_SYSTEM_WITH_CROW FALSE)
@@ -2631,7 +2566,6 @@ if(PACS_BUILD_TESTS)
                 pacs_storage
                 pacs_services
                 Catch2::Catch2WithMain
-                $<$<BOOL:${fmt_FOUND}>:fmt::fmt>
                 $<$<TARGET_EXISTS:database>:database>
         )
         # Use mock S3/Azure clients in tests regardless of SDK availability (Issue #724)

--- a/dependency-manifest.json
+++ b/dependency-manifest.json
@@ -119,12 +119,6 @@
       "resolution": "find_package(openjph) or FetchContent fallback",
       "version": "0.18.2",
       "license": "BSD-2-Clause"
-    },
-    {
-      "name": "fmt",
-      "resolution": "find_package(fmt) or FetchContent fallback",
-      "version": "10.2.1",
-      "license": "MIT"
     }
   ],
   "web_frontend": {

--- a/include/pacs/compat/format.hpp
+++ b/include/pacs/compat/format.hpp
@@ -29,65 +29,32 @@
 
 /**
  * @file format.hpp
- * @brief Compatibility header for std::format vs fmt::format
+ * @brief Compatibility header providing pacs::compat::format as an alias for std::format
  *
- * This header provides a unified interface for string formatting that works
- * across different compilers and C++ standard library implementations.
- *
- * Detection is primarily based on the __cpp_lib_format feature test macro,
- * which is the most reliable way to detect std::format availability.
+ * All supported compilers (GCC 13+, Clang 17+, MSVC 2022+, Apple Clang 15+)
+ * provide C++20 std::format. This header aliases it into the pacs::compat namespace
+ * so existing call sites continue to work without modification.
  *
  * Usage:
  *   #include <pacs/compat/format.hpp>
  *   auto s = pacs::compat::format("Hello, {}!", name);
  *
- * @see logger_system/cmake/LoggerCompatibility.cmake for detection patterns
  * @author kcenon
  * @since 1.0.0
  */
 
 #pragma once
 
-#include <version>  // For feature test macros
+#include <format>
+#include <string>
 
-// Detect std::format availability
-//
-// Detection strategy:
-// 1. __cpp_lib_format feature test macro (most reliable for libstdc++ and libc++)
-// 2. Apple Clang 15+ with libc++ (may not define __cpp_lib_format)
-// 3. MSVC 19.29+ with C++20 mode
-//
-// Note: Non-Apple Clang on Linux typically uses libstdc++ which requires GCC 13+
-// for std::format support, so we rely on __cpp_lib_format for that case.
-#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
-    #define PACS_HAS_STD_FORMAT 1
-#elif defined(__APPLE__) && defined(__clang__) && __clang_major__ >= 15
-    // Apple Clang 15+ with libc++ supports std::format
-    // Note: __apple_build_version__ is always defined for Apple Clang
-    #define PACS_HAS_STD_FORMAT 1
-#elif defined(_MSC_VER) && _MSC_VER >= 1929 && defined(_HAS_CXX20) && _HAS_CXX20
-    // MSVC with C++20 mode enabled
-    #define PACS_HAS_STD_FORMAT 1
-#else
-    #define PACS_HAS_STD_FORMAT 0
-#endif
+#define PACS_HAS_STD_FORMAT 1
 
-#if PACS_HAS_STD_FORMAT
-    #include <format>
-    namespace pacs::compat {
-        using std::format;
-        template <typename... Args>
-        using format_string = std::format_string<Args...>;
-    }
-#else
-    // Use fmt library as fallback
-    #include <fmt/format.h>
-    namespace pacs::compat {
-        using fmt::format;
-        template <typename... Args>
-        using format_string = fmt::format_string<Args...>;
-    }
-#endif
+namespace pacs::compat {
+    using std::format;
+    template <typename... Args>
+    using format_string = std::format_string<Args...>;
+}
 
 // Convenience macro for simple string concatenation (no formatting needed)
 // Use when you just need to build error messages without {} placeholders


### PR DESCRIPTION
## Summary
- Simplify `include/pacs/compat/format.hpp` to always use `std::format` (no fmt fallback)
- Remove ~45 lines of fmt detection from CMakeLists.txt
- Remove 4 conditional fmt linking blocks (pacs_storage, pacs_web, pacs_integration, storage_tests)
- Remove fmt from dependency-manifest.json

**3 files changed, 12 insertions(+), 117 deletions(-)**

## Why
All supported compilers guarantee C++20 `std::format` availability. The `fmt 10.2.1` fallback was dead code that added build complexity and unnecessary FetchContent downloads.

17 source files using `pacs::compat::format` are unaffected — the alias now always resolves to `std::format`.

Closes #954

## Test plan
- [ ] `pacs::compat::format` resolves to `std::format` on all platforms
- [ ] CI builds pass on Ubuntu, macOS, Windows
- [ ] No `fmt` references remain in build configuration or source code