### PR TITLE
chore(cmake): Standardize export naming (kcenon::pacs:: -> pacs_system::)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,8 +147,8 @@ endfunction()
 function(pacs_register_export_target target_name export_name)
     if(TARGET ${target_name})
         set_target_properties(${target_name} PROPERTIES EXPORT_NAME ${export_name})
-        if(NOT TARGET kcenon::pacs::${export_name})
-            add_library(kcenon::pacs::${export_name} ALIAS ${target_name})
+        if(NOT TARGET pacs_system::${export_name})
+            add_library(pacs_system::${export_name} ALIAS ${target_name})
         endif()
     endif()
 endfunction()
@@ -2216,8 +2216,8 @@ foreach(_bridge_mapping IN LISTS PACS_EXPORT_BRIDGE_MAPPINGS)
     string(SUBSTRING "${_bridge_mapping}" ${_bridge_value_index} -1 _bridge_install_target)
 
     string(APPEND PACS_SYSTEM_BRIDGE_TARGET_SETUP
-        "if(TARGET kcenon::pacs::${_bridge_target_name})\n"
-        "  set_property(TARGET kcenon::pacs::${_bridge_target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES \"${_bridge_install_target}\")\n"
+        "if(TARGET pacs_system::${_bridge_target_name})\n"
+        "  set_property(TARGET pacs_system::${_bridge_target_name} APPEND PROPERTY INTERFACE_LINK_LIBRARIES \"${_bridge_install_target}\")\n"
         "endif()\n"
     )
 endforeach()
@@ -2230,7 +2230,7 @@ install(DIRECTORY include/pacs
 )
 
 install(TARGETS ${PACS_SYSTEM_INSTALL_TARGETS}
-    EXPORT pacs_systemTargets
+    EXPORT pacs_system-targets
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -2250,9 +2250,9 @@ write_basic_package_version_file(
     COMPATIBILITY AnyNewerVersion
 )
 
-install(EXPORT pacs_systemTargets
-    FILE pacs_systemTargets.cmake
-    NAMESPACE kcenon::pacs::
+install(EXPORT pacs_system-targets
+    FILE pacs_system-targets.cmake
+    NAMESPACE pacs_system::
     DESTINATION ${PACS_SYSTEM_CMAKE_INSTALL_DIR}
 )
 
@@ -2280,9 +2280,9 @@ foreach(_pacs_non_exportable_dep
 endforeach()
 
 if(PACS_SYSTEM_CAN_EXPORT_BUILD_TREE)
-    export(EXPORT pacs_systemTargets
-        FILE "${CMAKE_CURRENT_BINARY_DIR}/pacs_systemTargets.cmake"
-        NAMESPACE kcenon::pacs::
+    export(EXPORT pacs_system-targets
+        FILE "${CMAKE_CURRENT_BINARY_DIR}/pacs_system-targets.cmake"
+        NAMESPACE pacs_system::
     )
 else()
     message(STATUS "pacs_system: Skipping build-tree export (local dependency targets cannot be exported)")

--- a/cmake/pacs_systemConfig.cmake.in
+++ b/cmake/pacs_systemConfig.cmake.in
@@ -63,9 +63,16 @@ if(@PACS_SYSTEM_WITH_AZURE_SDK@)
     find_dependency(azure-storage-blobs-cpp CONFIG REQUIRED)
 endif()
 
-include("${CMAKE_CURRENT_LIST_DIR}/pacs_systemTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/pacs_system-targets.cmake")
 
 @PACS_SYSTEM_BRIDGE_TARGET_SETUP@
+
+# Backward compatibility aliases (kcenon::pacs:: -> pacs_system::)
+foreach(_compat_target core encoding network client services security storage ai monitoring workflow web integration)
+    if(TARGET pacs_system::${_compat_target} AND NOT TARGET kcenon::pacs::${_compat_target})
+        add_library(kcenon::pacs::${_compat_target} ALIAS pacs_system::${_compat_target})
+    endif()
+endforeach()
 
 set(pacs_system_FOUND TRUE)
 set(PACS_SYSTEM_FOUND TRUE)
@@ -76,17 +83,17 @@ set(pacs_system_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 set(PACS_SYSTEM_INCLUDE_DIRS "${pacs_system_INCLUDE_DIRS}")
 
 set(pacs_system_LIBRARIES
-    kcenon::pacs::core
-    kcenon::pacs::encoding
-    kcenon::pacs::network
-    kcenon::pacs::client
-    kcenon::pacs::services
-    kcenon::pacs::security
+    pacs_system::core
+    pacs_system::encoding
+    pacs_system::network
+    pacs_system::client
+    pacs_system::services
+    pacs_system::security
 )
 
 foreach(_optional_target storage ai monitoring workflow web integration)
-    if(TARGET kcenon::pacs::${_optional_target})
-        list(APPEND pacs_system_LIBRARIES kcenon::pacs::${_optional_target})
+    if(TARGET pacs_system::${_optional_target})
+        list(APPEND pacs_system_LIBRARIES pacs_system::${_optional_target})
     endif()
 endforeach()
 


### PR DESCRIPTION
## Summary
- Rename CMake export from `pacs_systemTargets` to `pacs_system-targets` (snake_case with hyphen)
- Change namespace from nested `kcenon::pacs::` to flat `pacs_system::` to match ecosystem convention
- Add backward compatibility aliases so existing consumers using `kcenon::pacs::` targets continue to work

## What changed

### CMakeLists.txt
- `install(TARGETS ... EXPORT pacs_systemTargets)` -> `pacs_system-targets`
- `install(EXPORT ...)` file and namespace updated
- `export(EXPORT ...)` build-tree export updated
- `pacs_register_export_target()` function uses `pacs_system::` namespace for aliases
- Bridge target setup uses `pacs_system::` namespace

### cmake/pacs_systemConfig.cmake.in
- Include file reference updated to `pacs_system-targets.cmake`
- `pacs_system_LIBRARIES` uses `pacs_system::` prefixed targets
- Added backward compatibility `foreach` loop creating `kcenon::pacs::` aliases pointing to `pacs_system::` targets

## Why
Standardize CMake export naming to use flat `pacs_system::` namespace matching the convention used by `common_system`, `network_system`, and other ecosystem packages.

## Related Issues
- Closes #956
- Part of kcenon/common_system#456

## Test plan
- [ ] Verify CI build passes (CMake configure + build)
- [ ] Verify `find_package(pacs_system)` works with new target names
- [ ] Verify legacy `kcenon::pacs::` references still resolve via aliases