### PR TITLE
docs: Add Doxygen comments to instance_repository public methods

### DIFF
--- a/include/pacs/storage/instance_repository.hpp
+++ b/include/pacs/storage/instance_repository.hpp
@@ -63,6 +63,10 @@ namespace pacs::storage {
  */
 class instance_repository : public base_repository<instance_record, int64_t> {
 public:
+    /**
+     * @brief Construct an instance repository with the given database adapter.
+     * @param db Shared pointer to the database adapter used for persistence
+     */
     explicit instance_repository(std::shared_ptr<pacs_database_adapter> db);
     ~instance_repository() override = default;
 
@@ -71,6 +75,17 @@ public:
     instance_repository(instance_repository&&) noexcept = default;
     auto operator=(instance_repository&&) noexcept -> instance_repository& = default;
 
+    /**
+     * @brief Insert or update an instance record by individual fields.
+     * @param series_pk Primary key of the parent series
+     * @param sop_uid SOP Instance UID (DICOM tag 0008,0018)
+     * @param sop_class_uid SOP Class UID (DICOM tag 0008,0016)
+     * @param file_path File system path where the instance is stored
+     * @param file_size Size of the stored file in bytes
+     * @param transfer_syntax Transfer Syntax UID (DICOM tag 0002,0010), empty if unknown
+     * @param instance_number Instance Number (DICOM tag 0020,0013), nullopt if absent
+     * @return Result containing the primary key of the upserted record, or an error
+     */
     [[nodiscard]] auto upsert_instance(int64_t series_pk,
                                        std::string_view sop_uid,
                                        std::string_view sop_class_uid,
@@ -79,25 +94,91 @@ public:
                                        std::string_view transfer_syntax = "",
                                        std::optional<int> instance_number = std::nullopt)
         -> Result<int64_t>;
+
+    /**
+     * @brief Insert or update an instance record from an existing record struct.
+     * @param record The instance record to upsert
+     * @return Result containing the primary key of the upserted record, or an error
+     */
     [[nodiscard]] auto upsert_instance(const instance_record& record)
         -> Result<int64_t>;
+
+    /**
+     * @brief Find an instance record by its SOP Instance UID.
+     * @param sop_uid SOP Instance UID to search for
+     * @return The matching instance record, or std::nullopt if not found
+     */
     [[nodiscard]] auto find_instance(std::string_view sop_uid)
         -> std::optional<instance_record>;
+
+    /**
+     * @brief Find an instance record by its database primary key.
+     * @param pk Primary key of the instance record
+     * @return The matching instance record, or std::nullopt if not found
+     */
     [[nodiscard]] auto find_instance_by_pk(int64_t pk)
         -> std::optional<instance_record>;
+
+    /**
+     * @brief List all instance records belonging to a given series.
+     * @param series_uid Series Instance UID to filter by
+     * @return Result containing a vector of matching instance records, or an error
+     */
     [[nodiscard]] auto list_instances(std::string_view series_uid)
         -> Result<std::vector<instance_record>>;
+
+    /**
+     * @brief Search for instance records matching the given query criteria.
+     * @param query Query parameters including optional filters and pagination
+     * @return Result containing a vector of matching instance records, or an error
+     */
     [[nodiscard]] auto search_instances(const instance_query& query)
         -> Result<std::vector<instance_record>>;
+
+    /**
+     * @brief Delete an instance record by its SOP Instance UID.
+     * @param sop_uid SOP Instance UID of the instance to delete
+     * @return VoidResult indicating success or an error
+     */
     [[nodiscard]] auto delete_instance(std::string_view sop_uid)
         -> VoidResult;
+
+    /**
+     * @brief Get the total number of instance records in the repository.
+     * @return Result containing the total instance count, or an error
+     */
     [[nodiscard]] auto instance_count() -> Result<size_t>;
+
+    /**
+     * @brief Get the number of instance records belonging to a given series.
+     * @param series_uid Series Instance UID to count instances for
+     * @return Result containing the instance count for the series, or an error
+     */
     [[nodiscard]] auto instance_count(std::string_view series_uid)
         -> Result<size_t>;
+
+    /**
+     * @brief Retrieve the file system path for a stored instance.
+     * @param sop_instance_uid SOP Instance UID to look up
+     * @return Result containing the file path if found, std::nullopt if the
+     *         instance exists but has no file, or an error
+     */
     [[nodiscard]] auto get_file_path(std::string_view sop_instance_uid)
         -> Result<std::optional<std::string>>;
+
+    /**
+     * @brief Retrieve all file paths for instances belonging to a study.
+     * @param study_instance_uid Study Instance UID to look up
+     * @return Result containing a vector of file paths, or an error
+     */
     [[nodiscard]] auto get_study_files(std::string_view study_instance_uid)
         -> Result<std::vector<std::string>>;
+
+    /**
+     * @brief Retrieve all file paths for instances belonging to a series.
+     * @param series_instance_uid Series Instance UID to look up
+     * @return Result containing a vector of file paths, or an error
+     */
     [[nodiscard]] auto get_series_files(std::string_view series_instance_uid)
         -> Result<std::vector<std::string>>;
 
@@ -137,6 +218,10 @@ using VoidResult = kcenon::common::VoidResult;
  */
 class instance_repository {
 public:
+    /**
+     * @brief Construct an instance repository with a raw SQLite database handle.
+     * @param db Pointer to the SQLite database connection
+     */
     explicit instance_repository(sqlite3* db);
     ~instance_repository();
 
@@ -145,6 +230,17 @@ public:
     instance_repository(instance_repository&&) noexcept;
     auto operator=(instance_repository&&) noexcept -> instance_repository&;
 
+    /**
+     * @brief Insert or update an instance record by individual fields.
+     * @param series_pk Primary key of the parent series
+     * @param sop_uid SOP Instance UID (DICOM tag 0008,0018)
+     * @param sop_class_uid SOP Class UID (DICOM tag 0008,0016)
+     * @param file_path File system path where the instance is stored
+     * @param file_size Size of the stored file in bytes
+     * @param transfer_syntax Transfer Syntax UID (DICOM tag 0002,0010), empty if unknown
+     * @param instance_number Instance Number (DICOM tag 0020,0013), nullopt if absent
+     * @return Result containing the primary key of the upserted record, or an error
+     */
     [[nodiscard]] auto upsert_instance(int64_t series_pk,
                                        std::string_view sop_uid,
                                        std::string_view sop_class_uid,
@@ -153,25 +249,91 @@ public:
                                        std::string_view transfer_syntax = "",
                                        std::optional<int> instance_number = std::nullopt)
         -> Result<int64_t>;
+
+    /**
+     * @brief Insert or update an instance record from an existing record struct.
+     * @param record The instance record to upsert
+     * @return Result containing the primary key of the upserted record, or an error
+     */
     [[nodiscard]] auto upsert_instance(const instance_record& record)
         -> Result<int64_t>;
+
+    /**
+     * @brief Find an instance record by its SOP Instance UID.
+     * @param sop_uid SOP Instance UID to search for
+     * @return The matching instance record, or std::nullopt if not found
+     */
     [[nodiscard]] auto find_instance(std::string_view sop_uid) const
         -> std::optional<instance_record>;
+
+    /**
+     * @brief Find an instance record by its database primary key.
+     * @param pk Primary key of the instance record
+     * @return The matching instance record, or std::nullopt if not found
+     */
     [[nodiscard]] auto find_instance_by_pk(int64_t pk) const
         -> std::optional<instance_record>;
+
+    /**
+     * @brief List all instance records belonging to a given series.
+     * @param series_uid Series Instance UID to filter by
+     * @return Result containing a vector of matching instance records, or an error
+     */
     [[nodiscard]] auto list_instances(std::string_view series_uid) const
         -> Result<std::vector<instance_record>>;
+
+    /**
+     * @brief Search for instance records matching the given query criteria.
+     * @param query Query parameters including optional filters and pagination
+     * @return Result containing a vector of matching instance records, or an error
+     */
     [[nodiscard]] auto search_instances(const instance_query& query) const
         -> Result<std::vector<instance_record>>;
+
+    /**
+     * @brief Delete an instance record by its SOP Instance UID.
+     * @param sop_uid SOP Instance UID of the instance to delete
+     * @return VoidResult indicating success or an error
+     */
     [[nodiscard]] auto delete_instance(std::string_view sop_uid)
         -> VoidResult;
+
+    /**
+     * @brief Get the total number of instance records in the repository.
+     * @return Result containing the total instance count, or an error
+     */
     [[nodiscard]] auto instance_count() const -> Result<size_t>;
+
+    /**
+     * @brief Get the number of instance records belonging to a given series.
+     * @param series_uid Series Instance UID to count instances for
+     * @return Result containing the instance count for the series, or an error
+     */
     [[nodiscard]] auto instance_count(std::string_view series_uid) const
         -> Result<size_t>;
+
+    /**
+     * @brief Retrieve the file system path for a stored instance.
+     * @param sop_instance_uid SOP Instance UID to look up
+     * @return Result containing the file path if found, std::nullopt if the
+     *         instance exists but has no file, or an error
+     */
     [[nodiscard]] auto get_file_path(std::string_view sop_instance_uid) const
         -> Result<std::optional<std::string>>;
+
+    /**
+     * @brief Retrieve all file paths for instances belonging to a study.
+     * @param study_instance_uid Study Instance UID to look up
+     * @return Result containing a vector of file paths, or an error
+     */
     [[nodiscard]] auto get_study_files(std::string_view study_instance_uid) const
         -> Result<std::vector<std::string>>;
+
+    /**
+     * @brief Retrieve all file paths for instances belonging to a series.
+     * @param series_instance_uid Series Instance UID to look up
+     * @return Result containing a vector of file paths, or an error
+     */
     [[nodiscard]] auto get_series_files(std::string_view series_instance_uid) const
         -> Result<std::vector<std::string>>;
 


### PR DESCRIPTION
## What

### Summary
Add `@brief`, `@param`, and `@return` Doxygen documentation to all 26 undocumented public methods in `instance_repository.hpp` (both base_repository and legacy SQLite class definitions).

### Change Type
- [x] Documentation

### Affected Components
- `include/pacs/storage/instance_repository.hpp`

### Methods Documented
| Method | Params | Both Classes |
|--------|--------|-------------|
| `upsert_instance` (7-param) | 7 @param | Yes |
| `upsert_instance` (record) | 1 @param | Yes |
| `find_instance` | 1 @param | Yes |
| `find_instance_by_pk` | 1 @param | Yes |
| `list_instances` | 1 @param | Yes |
| `search_instances` | 1 @param | Yes |
| `delete_instance` | 1 @param | Yes |
| `instance_count` (no-arg) | - | Yes |
| `instance_count` (series) | 1 @param | Yes |
| `get_file_path` | 1 @param | Yes |
| `get_study_files` | 1 @param | Yes |
| `get_series_files` | 1 @param | Yes |
| Constructor | 1 @param | Yes |

## Why

### Related Issues
- Closes #966

### Motivation
The storage module's repository classes are critical CRUD interfaces. All 13 public methods lacked documentation, leaving developers to read implementation code to understand parameter semantics and return values.

## How

### Implementation Highlights
- Documentation-only changes; no code logic modified
- Follows existing codebase convention from `instance_record.hpp`
- Both conditional compilation paths (`PACS_WITH_DATABASE_SYSTEM` and legacy) documented identically

### Testing Done
- [x] Documentation-only change, no functional impact