### PR TITLE
docs: Add CHANGELOG.md and CONTRIBUTING.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-03-13
+
+### Added
+- DICOM protocol implementation (C-ECHO, C-STORE, C-FIND, C-MOVE, C-GET)
+- Transfer syntax support (Implicit VR Little Endian, Explicit VR, JPEG, JPEG2000, HTJ2K, JPEG-LS, RLE)
+- PACS storage with SQLite backend
+- DICOMweb REST API via Crow HTTP framework
+- Image codec support (JPEG, JPEG2000, HTJ2K, JPEG-LS, PNG)
+- TLS/SSL support for secure DICOM associations
+- AWS S3 and Azure Blob storage integration
+- AI inference pipeline integration
+- CLI tools (pacs_echo, pacs_store, pacs_find, pacs_move, pacs_get, pacs_server)
+- Network layer migration to public tcp_facade API (#934)
+- vcpkg overlay port with feature-based dependency declaration (#921)
+- CMake install/export infrastructure (#920)
+- Release workflow for version tagging (#925)
+
+### Infrastructure
+- GitHub Actions CI/CD with sanitizer testing
+- Integration test workflow
+- SBOM generation workflow
+- Doxygen documentation with GitHub Pages deployment
+- vcpkg manifest with feature-based codecs, storage, and cloud features
+- Cross-platform support (Linux, macOS, Windows)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,160 @@
+# Contributing to PACS System
+
+Thank you for considering contributing to PACS System\! This document provides guidelines and instructions for contributors.
+
+## Table of Contents
+
+- [Getting Started](#getting-started)
+- [Development Workflow](#development-workflow)
+- [Code Standards](#code-standards)
+- [Testing](#testing)
+- [Pull Requests](#pull-requests)
+
+## Getting Started
+
+### Prerequisites
+
+- C++20 compatible compiler (GCC 13+, Clang 16+, MSVC 2022+)
+- CMake 3.20 or higher
+- Git
+- vcpkg (recommended)
+
+### Building from Source
+
+```bash
+git clone https://github.com/kcenon/pacs_system.git
+cd pacs_system
+cmake --preset default
+cmake --build build
+```
+
+### Running Tests
+
+```bash
+cd build
+ctest --output-on-failure
+```
+
+## Development Workflow
+
+1. Fork the repository
+2. Create a feature branch (`git checkout -b feature/your-feature`)
+3. Make your changes
+4. Run tests and ensure they pass
+5. Commit your changes (see commit message guidelines below)
+6. Push to your fork (`git push origin feature/your-feature`)
+7. Open a Pull Request
+
+### Commit Message Guidelines
+
+Follow the [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+```
+<type>(<scope>): <description>
+
+[optional body]
+
+[optional footer]
+```
+
+**Types:**
+- `feat`: New feature
+- `fix`: Bug fix
+- `docs`: Documentation changes
+- `refactor`: Code refactoring
+- `test`: Adding or modifying tests
+- `perf`: Performance improvement
+- `chore`: Maintenance tasks
+
+## Code Standards
+
+### C++ Style
+
+- Use C++20 features when beneficial
+- Follow existing code style (clang-format configuration provided)
+- Prefer RAII for resource management
+- Use `auto` for obvious types
+- Avoid raw pointers; use smart pointers
+- Prefer standard library over custom implementations
+
+### Naming Conventions
+
+- **Classes/Structs**: `snake_case`
+- **Functions/Methods**: `snake_case`
+- **Variables**: `snake_case`
+- **Constants**: `UPPER_SNAKE_CASE`
+- **Template Parameters**: `PascalCase`
+- **Namespaces**: `kcenon::pacs`
+
+### Documentation
+
+Use Doxygen-style comments:
+
+```cpp
+/**
+ * @brief Brief description
+ * @param param Parameter description
+ * @return Return value description
+ * @thread_safety Thread-safe / Not thread-safe
+ */
+auto function(int param) -> int;
+```
+
+## Testing
+
+### Test Requirements
+
+All code contributions must include tests:
+
+- **Unit tests**: Test individual components
+- **Integration tests**: Test component interactions
+- **Platform tests**: Test platform-specific code paths
+
+### Writing Tests
+
+Use Google Test framework:
+
+```cpp
+#include <gtest/gtest.h>
+
+TEST(ComponentTest, BasicFunctionality) {
+    // Test implementation
+}
+```
+
+### Test Coverage
+
+Aim for:
+- New code: > 80% coverage
+- Critical paths: 100% coverage
+- Error handling: Test failure scenarios
+
+## Pull Requests
+
+### PR Checklist
+
+Before submitting a PR, ensure:
+
+- [ ] Code compiles without warnings
+- [ ] All tests pass
+- [ ] New tests added for new functionality
+- [ ] Documentation updated
+- [ ] Code follows project style
+- [ ] Commit messages follow conventional format
+- [ ] No merge conflicts with main branch
+
+### Review Process
+
+1. Automated checks run (build, tests, linting)
+2. Maintainer reviews code
+3. Address review comments
+4. Approved PR is merged (squash merge preferred)
+
+## Getting Help
+
+- Check [existing issues](https://github.com/kcenon/pacs_system/issues)
+- Open a [discussion](https://github.com/kcenon/pacs_system/discussions) for questions
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the BSD 3-Clause License.


### PR DESCRIPTION
## What

### Summary
Add CHANGELOG.md (Keep a Changelog format) and CONTRIBUTING.md (standardized contributor guide) to the repository.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#475

### Motivation
- **CHANGELOG.md**: vcpkg users need to track breaking changes between versions. Previously only network_system had one (1/8 repos).
- **CONTRIBUTING.md**: GitHub displays a link to this file on issue/PR creation pages, improving contributor onboarding. Previously only monitoring_system had one (1/8 repos).

## How

### Implementation Details
- CHANGELOG.md generated from git tags with key commit summaries
- CONTRIBUTING.md follows ecosystem-standard template with build instructions, code standards, and PR guidelines

### Test Plan
- [ ] CHANGELOG.md version dates match git tags
- [ ] CONTRIBUTING.md build instructions are accurate