### PR TITLE
docs(doxygen): Add @code examples to public API headers

### DIFF
--- a/include/pacs/client/remote_node.hpp
+++ b/include/pacs/client/remote_node.hpp
@@ -34,6 +34,19 @@
  * This file provides data structures for representing external PACS nodes,
  * including connection parameters, supported services, and runtime status.
  *
+ * @code
+ * // Define a remote PACS node for C-ECHO verification
+ * remote_node node;
+ * node.ae_title = "REMOTE_PACS";
+ * node.host = "192.168.1.100";
+ * node.port = 11112;
+ *
+ * // Check node status
+ * if (node.status == node_status::online) {
+ *     // Node is reachable and verified
+ * }
+ * @endcode
+ *
  * @see Issue #535 - Implement Remote Node Manager
  * @see DICOM PS3.7 Section 9.1.5 - C-ECHO Service
  * @author kcenon


### PR DESCRIPTION
## What

### Summary
Add @code usage examples to core public API headers for improved Doxygen documentation.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Part of kcenon/common_system#476

### Motivation
API documentation without inline examples forces users to read source code or tests. @code blocks in Doxygen comments serve as inline tutorials directly in the generated docs.

## How

### Test Plan
- [ ] Doxygen build succeeds without warnings
- [ ] Code examples render correctly in generated HTML docs