### PR TITLE
fix(security): resolve race condition in oauth2_middleware last_claims_

### DIFF
--- a/include/pacs/web/auth/oauth2_middleware.hpp
+++ b/include/pacs/web/auth/oauth2_middleware.hpp
@@ -83,6 +83,22 @@ constexpr std::string_view delete_resource = "dicomweb.delete";
 }  // namespace dicomweb_scopes
 
 // =============================================================================
+// Authentication Result
+// =============================================================================
+
+/**
+ * @brief Result of a successful OAuth 2.0 authentication
+ *
+ * Contains both the user context (for RBAC) and the validated JWT claims
+ * (for scope checking). This ensures thread-safe authentication by
+ * returning all state from authenticate() instead of caching it.
+ */
+struct auth_result {
+    security::user_context context;
+    jwt_claims claims;
+};
+
+// =============================================================================
 // OAuth 2.0 Middleware
 // =============================================================================
 
@@ -109,10 +125,10 @@ constexpr std::string_view delete_resource = "dicomweb.delete";
  * middleware.set_jwks_provider(jwks);
  *
  * // In endpoint handler:
- * auto ctx = middleware.authenticate(req, res);
- * if (!ctx) return res;  // Error response already set
+ * auto result = middleware.authenticate(req, res);
+ * if (!result) return res;  // Error response already set
  *
- * if (!middleware.require_scope(req, res, dicomweb_scopes::read)) {
+ * if (!middleware.require_scope(result->claims, res, dicomweb_scopes::read)) {
  *     return res;  // 403 Forbidden
  * }
  * @endcode
@@ -142,22 +158,22 @@ public:
      * @brief Authenticate a request using OAuth 2.0 Bearer token
      *
      * Extracts the Bearer token, validates JWT claims, verifies the
-     * signature, and creates a user_context. On failure, sets an
+     * signature, and creates an auth_result containing both the
+     * user_context and validated claims. On failure, sets an
      * appropriate error response (401 or 403).
      *
      * @param req The HTTP request
      * @param res The HTTP response (set on error)
-     * @return user_context on success, std::nullopt on failure
+     * @return auth_result on success, std::nullopt on failure
      */
-    [[nodiscard]] std::optional<security::user_context> authenticate(
+    [[nodiscard]] std::optional<auth_result> authenticate(
         const crow::request& req, crow::response& res) const;
 
     /**
      * @brief Check if the authenticated request has a required scope
      *
-     * Must be called after authenticate(). Reads the cached token claims
-     * from the request. Returns false and sets 403 response if the
-     * required scope is missing.
+     * Must be called after authenticate(). Returns false and sets 403
+     * response if the required scope is missing.
      *
      * @param claims JWT claims from a previously validated token
      * @param res The HTTP response (set on failure)
@@ -192,17 +208,11 @@ public:
      */
     [[nodiscard]] const jwt_validator& validator() const noexcept;
 
-    /**
-     * @brief Get the last validated claims (for scope checking after authenticate)
-     */
-    [[nodiscard]] const jwt_claims& last_claims() const noexcept;
-
 private:
     oauth2_config config_;
     jwt_validator validator_;
     std::shared_ptr<jwks_provider> jwks_provider_;
     std::shared_ptr<security::access_control_manager> security_manager_;
-    mutable jwt_claims last_claims_;
 
     /// Extract Bearer token from Authorization header
     [[nodiscard]] std::optional<std::string_view> extract_bearer_token(

--- a/src/web/auth/oauth2_middleware.cpp
+++ b/src/web/auth/oauth2_middleware.cpp
@@ -67,7 +67,7 @@ void oauth2_middleware::set_access_control_manager(
     security_manager_ = std::move(manager);
 }
 
-std::optional<security::user_context> oauth2_middleware::authenticate(
+std::optional<auth_result> oauth2_middleware::authenticate(
     const crow::request& req, crow::response& res) const {
 
     // Extract Bearer token from Authorization header
@@ -97,9 +97,6 @@ std::optional<security::user_context> oauth2_middleware::authenticate(
         return std::nullopt;
     }
 
-    // Cache the validated claims for subsequent scope checks
-    last_claims_ = token.claims;
-
     // Create user_context from JWT subject
     // Try to find existing user in RBAC system, or create an OAuth-based context
     security::User user;
@@ -124,7 +121,7 @@ std::optional<security::user_context> oauth2_middleware::authenticate(
     ctx.set_source_ip(std::string(req.remote_ip_address));
     ctx.touch();
 
-    return ctx;
+    return auth_result{std::move(ctx), std::move(token.claims)};
 }
 
 bool oauth2_middleware::require_scope(
@@ -163,10 +160,6 @@ bool oauth2_middleware::enabled() const noexcept {
 
 const jwt_validator& oauth2_middleware::validator() const noexcept {
     return validator_;
-}
-
-const jwt_claims& oauth2_middleware::last_claims() const noexcept {
-    return last_claims_;
 }
 
 // =============================================================================

--- a/src/web/endpoints/dicomweb_endpoints.cpp
+++ b/src/web/endpoints/dicomweb_endpoints.cpp
@@ -1547,12 +1547,12 @@ bool check_dicomweb_auth(const std::shared_ptr<rest_server_context>& ctx,
                           crow::response& res,
                           const std::vector<std::string>& required_scopes) {
     if (ctx->oauth2 && ctx->oauth2->enabled()) {
-        auto user_ctx = ctx->oauth2->authenticate(req, res);
-        if (!user_ctx) return false;
+        auto auth = ctx->oauth2->authenticate(req, res);
+        if (!auth) return false;
 
         if (!required_scopes.empty()) {
             return ctx->oauth2->require_any_scope(
-                ctx->oauth2->last_claims(), res, required_scopes);
+                auth->claims, res, required_scopes);
         }
         return true;
     }

--- a/src/web/endpoints/storage_commitment_endpoints.cpp
+++ b/src/web/endpoints/storage_commitment_endpoints.cpp
@@ -360,12 +360,12 @@ bool check_storage_commitment_auth(
     crow::response& res,
     const std::vector<std::string>& required_scopes) {
     if (ctx->oauth2 && ctx->oauth2->enabled()) {
-        auto user_ctx = ctx->oauth2->authenticate(req, res);
-        if (!user_ctx) return false;
+        auto auth = ctx->oauth2->authenticate(req, res);
+        if (!auth) return false;
 
         if (!required_scopes.empty()) {
             return ctx->oauth2->require_any_scope(
-                ctx->oauth2->last_claims(), res, required_scopes);
+                auth->claims, res, required_scopes);
         }
         return true;
     }

--- a/src/web/endpoints/wado_uri_endpoints.cpp
+++ b/src/web/endpoints/wado_uri_endpoints.cpp
@@ -335,10 +335,10 @@ void register_wado_uri_endpoints_impl(
 
                 // OAuth 2.0 / legacy auth check (read scope for WADO-URI)
                 if (ctx->oauth2 && ctx->oauth2->enabled()) {
-                    auto user_ctx = ctx->oauth2->authenticate(req, res);
-                    if (!user_ctx) return res;
+                    auto auth = ctx->oauth2->authenticate(req, res);
+                    if (!auth) return res;
                     if (!ctx->oauth2->require_any_scope(
-                            ctx->oauth2->last_claims(), res,
+                            auth->claims, res,
                             {"dicomweb.read"})) {
                         return res;
                     }


### PR DESCRIPTION
## What

### Summary
Removes the thread-unsafe `mutable jwt_claims last_claims_` shared field from `oauth2_middleware`. Introduces an `auth_result` struct so `authenticate()` returns both `user_context` and `jwt_claims` together, eliminating shared mutable state.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `include/pacs/web/auth/oauth2_middleware.hpp` — New `auth_result` struct, updated return type
- `src/web/auth/oauth2_middleware.cpp` — Removed `last_claims_` write and accessor
- `src/web/endpoints/dicomweb_endpoints.cpp` — Use `auth->claims` instead of `last_claims()`
- `src/web/endpoints/wado_uri_endpoints.cpp` — Use `auth->claims` instead of `last_claims()`
- `src/web/endpoints/storage_commitment_endpoints.cpp` — Use `auth->claims` instead of `last_claims()`

## Why

### Problem Solved
`mutable jwt_claims last_claims_` was written inside `const authenticate()` without mutex protection. In Crow's multithreaded HTTP handling, concurrent requests could corrupt cached claims, potentially leading to privilege escalation (Thread A reads Thread B's claims).

### Related Issues
- Closes #972

### Alternative Approaches Considered
1. **Mutex protection** — Would serialize authentication and not address the architectural issue of shared mutable state in a const method
2. **thread_local storage** — Adds complexity; returning values from the function is simpler and more explicit

## How

### Implementation Details
1. Added `auth_result` struct containing `user_context` and `jwt_claims`
2. Changed `authenticate()` return type from `std::optional<security::user_context>` to `std::optional<auth_result>`
3. Removed `mutable jwt_claims last_claims_` field and `last_claims()` accessor
4. Updated all 3 call sites to use `auth->claims` from the returned result

### Testing Done
- [x] Full build (326 targets, 0 errors)
- [x] Unit tests (2300+ tests pass)
- [x] 2 pre-existing SEGFAULT tests in `dicom_server_v2` (unrelated to auth)

### Breaking Changes
- `oauth2_middleware::authenticate()` now returns `std::optional<auth_result>` instead of `std::optional<security::user_context>`
- `oauth2_middleware::last_claims()` accessor removed — use `auth_result::claims` instead