### PR TITLE
fix(security): harden PDU, JWT, and AE title access control

### DIFF
--- a/include/pacs/security/access_control_manager.hpp
+++ b/include/pacs/security/access_control_manager.hpp
@@ -127,10 +127,10 @@ public:
    * @brief Get user context for an AE Title
    * @param ae_title The AE Title to look up
    * @param session_id Session identifier for the context
-   * @return User context if found, anonymous context otherwise
+   * @return User context if found, std::nullopt for unregistered AE titles
    */
-  [[nodiscard]] user_context get_context_for_ae(std::string_view ae_title,
-                                                const std::string &session_id) const;
+  [[nodiscard]] std::optional<user_context> get_context_for_ae(
+      std::string_view ae_title, const std::string &session_id) const;
 
   // Configuration
   void set_role_permissions(Role role, std::vector<Permission> permissions);

--- a/src/network/pdu_decoder.cpp
+++ b/src/network/pdu_decoder.cpp
@@ -138,6 +138,15 @@ DecodeResult<uint32_t> pdu_decoder::validate_pdu_header(
     }
 
     const uint32_t pdu_length = read_uint32_be(data, 2);
+
+    // Reject unreasonably large PDUs to prevent memory exhaustion attacks
+    constexpr uint32_t MAX_PDU_LENGTH = 16 * 1024 * 1024; // 16 MB
+    if (pdu_length > MAX_PDU_LENGTH) {
+        return make_error<uint32_t>(pdu_decode_error::malformed_pdu,
+            "PDU length " + std::to_string(pdu_length) +
+            " exceeds maximum allowed " + std::to_string(MAX_PDU_LENGTH));
+    }
+
     const size_t total_length = PDU_HEADER_SIZE + pdu_length;
 
     if (data.size() < total_length) {

--- a/src/network/v2/dicom_association_handler.cpp
+++ b/src/network/v2/dicom_association_handler.cpp
@@ -703,6 +703,9 @@ Result<std::monostate> dicom_association_handler::dispatch_to_service(
     }
 
     // Perform access control check if enabled
+    if (access_control_enabled_ && access_control_ && !user_context_) {
+        return error_info("Access denied: unregistered AE title");
+    }
     if (access_control_enabled_ && access_control_ && user_context_) {
         // Map DIMSE command to DICOM operation
         security::DicomOperation op = security::DicomOperation::CEcho;

--- a/src/security/access_control_manager.cpp
+++ b/src/security/access_control_manager.cpp
@@ -234,31 +234,25 @@ access_control_manager::check_dicom_operation(const user_context &ctx,
   return result;
 }
 
-user_context access_control_manager::get_context_for_ae(
+std::optional<user_context> access_control_manager::get_context_for_ae(
     std::string_view ae_title, const std::string &session_id) const {
   std::lock_guard<std::mutex> lock(mutex_);
 
   // Look up AE Title to user mapping
   auto it = ae_to_user_id_.find(std::string(ae_title));
   if (it == ae_to_user_id_.end()) {
-    // No mapping found, return anonymous context
-    auto ctx = user_context::anonymous_context(session_id);
-    ctx.set_source_ae_title(std::string(ae_title));
-    return ctx;
+    // Reject unregistered AE titles
+    return std::nullopt;
   }
 
   // Get user from storage
   if (!storage_) {
-    auto ctx = user_context::anonymous_context(session_id);
-    ctx.set_source_ae_title(std::string(ae_title));
-    return ctx;
+    return std::nullopt;
   }
 
   auto user_result = storage_->get_user(it->second);
   if (user_result.is_err()) {
-    auto ctx = user_context::anonymous_context(session_id);
-    ctx.set_source_ae_title(std::string(ae_title));
-    return ctx;
+    return std::nullopt;
   }
 
   auto ctx = user_context(user_result.unwrap(), session_id);

--- a/src/web/auth/jwt_validator.cpp
+++ b/src/web/auth/jwt_validator.cpp
@@ -39,6 +39,7 @@
 
 #include <algorithm>
 #include <array>
+#include <set>
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
@@ -261,6 +262,13 @@ std::pair<jwt_token, jwt_error> jwt_validator::decode(
 
     if (token.header.alg.empty()) {
         return {token, jwt_error::missing_required_claim};
+    }
+
+    // Block dangerous algorithms unconditionally (CVE: JWT alg:none attack)
+    static const std::set<std::string> kDangerousAlgorithms = {
+        "none", "None", "NONE", "HS256", "HS384", "HS512"};
+    if (kDangerousAlgorithms.count(token.header.alg)) {
+        return {token, jwt_error::unsupported_algorithm};
     }
 
     // Check algorithm is allowed

--- a/tests/security/access_control_manager_test.cpp
+++ b/tests/security/access_control_manager_test.cpp
@@ -215,16 +215,16 @@ TEST_CASE("AccessControlManager: AE Title Mapping", "[security]") {
     acm.register_ae_title("CT_SCANNER_AE", "modality1");
 
     auto ctx = acm.get_context_for_ae("CT_SCANNER_AE", "session123");
-    REQUIRE(ctx.user().id == "modality1");
-    REQUIRE(ctx.session_id() == "session123");
-    REQUIRE(ctx.source_ae_title().has_value());
-    REQUIRE(ctx.source_ae_title().value() == "CT_SCANNER_AE");
+    REQUIRE(ctx.has_value());
+    REQUIRE(ctx->user().id == "modality1");
+    REQUIRE(ctx->session_id() == "session123");
+    REQUIRE(ctx->source_ae_title().has_value());
+    REQUIRE(ctx->source_ae_title().value() == "CT_SCANNER_AE");
   }
 
-  SECTION("get_context_for_ae returns anonymous context for unknown AE") {
+  SECTION("get_context_for_ae rejects unknown AE title") {
     auto ctx = acm.get_context_for_ae("UNKNOWN_AE", "session456");
-    REQUIRE(ctx.user().id == "anonymous");
-    REQUIRE(ctx.session_id() == "session456");
+    REQUIRE_FALSE(ctx.has_value());
   }
 
   SECTION("Unregister AE Title") {


### PR DESCRIPTION
## Summary

- **PDU length validation (#973)**: Add `MAX_PDU_LENGTH` (16 MB) constant in `pdu_decoder::validate_pdu_header()` to reject oversized PDUs that could cause memory exhaustion
- **JWT algorithm blocking (#974)**: Add a static deny list for dangerous algorithms (`none`, `None`, `NONE`, `HS256`, `HS384`, `HS512`) that is always enforced before the configurable allowed_algorithms whitelist check
- **Reject unregistered AE titles (#975)**: Change `get_context_for_ae()` to return `std::nullopt` instead of anonymous context for unknown AE titles; update the DICOM association handler to deny operations from unregistered AE titles when access control is enabled

## What

| Issue | File | Change |
|-------|------|--------|
| #973 | `src/network/pdu_decoder.cpp` | Validate PDU length <= 16MB |
| #974 | `src/web/auth/jwt_validator.cpp` | Block dangerous JWT algorithms unconditionally |
| #975 | `src/security/access_control_manager.cpp`, `include/pacs/security/access_control_manager.hpp`, `src/network/v2/dicom_association_handler.cpp` | Return nullopt for unregistered AE titles, reject at operation level |

## Why

These three issues address related security hardening gaps:
1. An attacker could send a PDU with a crafted length field to exhaust server memory
2. JWT `alg:none` attacks bypass signature verification entirely
3. Unregistered AE titles silently received anonymous access, bypassing RBAC

## Test plan

- [ ] CI passes (build + existing tests)
- [ ] Updated `access_control_manager_test.cpp` to validate nullopt return for unknown AE titles
- [ ] Verify PDU decoder rejects lengths > 16MB with `malformed_pdu` error
- [ ] Verify JWT validator rejects tokens with `none`/`HS*` algorithms

Closes #973, Closes #974, Closes #975