### PR TITLE
chore(ci): add OSV vulnerability scanner and codecov configuration

### DIFF
--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,74 @@
+name: OSV Vulnerability Scan
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+      - '.github/workflows/osv-scanner.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+  schedule:
+    # Run every Sunday at 3:17 AM UTC (offset from Trivy daily scan at 2 AM)
+    - cron: '17 3 * * 0'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+# OSV-Scanner complements the existing dependency security scan:
+#   - dependency-security-scan: filesystem scan via Trivy
+#   - OSV-Scanner: dependency manifest scan using the OSV database
+#
+# OSV-Scanner covers vcpkg ecosystem packages, GitHub Advisory Database, and more.
+
+jobs:
+  osv-scan:
+    name: OSV Scanner
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/gh-pages'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run OSV-Scanner on vcpkg manifest
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
+        with:
+          scan-args: |-
+            --lockfile=vcpkg.json
+            --format=sarif
+            --output=osv-results.sarif
+        continue-on-error: true
+
+      - name: Run OSV-Scanner filesystem scan (fallback)
+        if: hashFiles('osv-results.sarif') == ''
+        uses: google/osv-scanner-action/osv-scanner-action@v2.3.3
+        with:
+          scan-args: |-
+            --recursive
+            .
+            --format=sarif
+            --output=osv-results.sarif
+        continue-on-error: true
+
+      - name: Upload OSV SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        if: always() && hashFiles('osv-results.sarif') != ''
+        continue-on-error: true
+        with:
+          sarif_file: osv-results.sarif
+          category: osv-scanner
+
+      - name: Upload OSV results artifact
+        uses: actions/upload-artifact@v7
+        if: always() && hashFiles('osv-results.sarif') != ''
+        with:
+          name: osv-scan-results-${{ github.sha }}
+          path: osv-results.sarif
+          retention-days: 30

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,52 @@
+# Codecov Configuration for pacs_system
+# https://docs.codecov.com/docs/codecovyml-reference
+
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "40...80"
+  status:
+    project:
+      default:
+        target: 40%
+        threshold: 2%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 60%
+        threshold: 5%
+        if_ci_failed: error
+
+# Gradual improvement plan:
+# - Phase 1 (Current): 40% project, 60% patch
+# - Phase 2: 50% project, 70% patch
+# - Phase 3: 60% project, 80% patch
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+ignore:
+  - "tests/**/*"
+  - "benchmarks/**/*"
+  - "examples/**/*"
+  - "samples/**/*"
+  - "docs/**/*"
+  - "build/**/*"
+  - "build_*/**/*"
+  - "build-*/**/*"
+  - "web/**/*"
+  - "cmake/**/*"
+  - "scripts/**/*"
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: no


### PR DESCRIPTION
## Summary
- Add OSV vulnerability scanner workflow to detect known vulnerabilities in vcpkg dependencies using the OSV database
- Add codecov.yml with initial coverage thresholds (40% project, 60% patch) and ignore paths for generated/non-source directories
- Brings pacs_system in line with other systems (network_system, thread_system, monitoring_system) that already have these CI quality checks

## Test plan
- [ ] Verify osv-scanner.yml workflow triggers on vcpkg.json changes and manual dispatch
- [ ] Verify codecov.yml is picked up by Codecov on next coverage report upload
- [ ] Confirm SARIF results upload to GitHub Security tab