### PR TITLE
fix(security): deny unknown OAuth users by default

### DIFF
--- a/include/pacs/web/auth/oauth2_config.hpp
+++ b/include/pacs/web/auth/oauth2_config.hpp
@@ -70,6 +70,11 @@ struct oauth2_config {
 
     /// Allowed signing algorithms (default: RS256, ES256)
     std::vector<std::string> allowed_algorithms = {"RS256", "ES256"};
+
+    /// Allow unknown OAuth users not found in RBAC to access as Viewer
+    /// When false (default): unknown users receive 401 Unauthorized
+    /// When true: unknown users are granted Role::Viewer (backward compatibility)
+    bool allow_unknown_users = false;
 };
 
 }  // namespace pacs::web::auth

--- a/src/web/auth/oauth2_middleware.cpp
+++ b/src/web/auth/oauth2_middleware.cpp
@@ -109,12 +109,18 @@ std::optional<auth_result> oauth2_middleware::authenticate(
         auto user_result = security_manager_->get_user(token.claims.sub);
         if (user_result.is_ok()) {
             user = user_result.unwrap();
-        } else {
-            // OAuth user not in RBAC system: grant Viewer role by default
+        } else if (config_.allow_unknown_users) {
+            // Backward compatibility: grant Viewer role to unknown OAuth users
             user.roles = {security::Role::Viewer};
+        } else {
+            set_unauthorized(res, "Unknown user: not registered in access control system");
+            return std::nullopt;
         }
-    } else {
+    } else if (config_.allow_unknown_users) {
         user.roles = {security::Role::Viewer};
+    } else {
+        set_unauthorized(res, "Unknown user: no access control manager configured");
+        return std::nullopt;
     }
 
     auto ctx = security::user_context(std::move(user), token.claims.jti);


### PR DESCRIPTION
## What

### Summary
Changes the OAuth2 middleware to deny access to JWT subjects not found in the RBAC system, instead of silently granting Viewer role. Adds a configurable `allow_unknown_users` flag for backward compatibility.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `include/pacs/web/auth/oauth2_config.hpp` - New `allow_unknown_users` config field
- `src/web/auth/oauth2_middleware.cpp` - Deny-by-default logic for unknown users

## Why

### Problem Solved
When a valid JWT token contained a `sub` claim for a user not registered in the RBAC system, the middleware silently granted `Role::Viewer` access. This meant any user with a valid token from the configured OAuth provider could access DICOMweb read endpoints without being explicitly registered, violating the principle of least privilege.

### Related Issues
- Closes #976

## Where

### Files Changed
| Directory | Files | Type of Change |
|-----------|-------|----------------|
| `include/pacs/web/auth/` | 1 | Config field addition |
| `src/web/auth/` | 1 | Security fix |

## How

### Implementation Details
1. Added `allow_unknown_users` boolean field to `oauth2_config` struct (default: `false`)
2. When `allow_unknown_users` is `false` (default):
   - Unknown users get 401 Unauthorized with descriptive message
   - Both code paths handled: with and without `security_manager_`
3. When `allow_unknown_users` is `true`:
   - Previous behavior preserved: unknown users get `Role::Viewer`

### Testing Done
- [x] Code review of all authentication paths
- [x] Verified existing tests don't set `security_manager_` (no test breakage expected)
- [ ] CI build and test verification

### Breaking Changes
**Yes - intentional security hardening.** Deployments that relied on unknown OAuth users getting Viewer access must now explicitly set `allow_unknown_users = true` in their `oauth2_config`. This is the desired behavior per the security issue.