### PR TITLE
fix: harden metrics auth, block mock S3 in release, modernize timestamp parsing

### DIFF
--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -35,8 +35,14 @@ option(PACS_WITH_NETWORK_SYSTEM "Enable network_system integration (REQUIRED)" O
 option(PACS_BUILD_STORAGE "Build storage module (requires SQLite3)" ON)
 option(PACS_WITH_AWS_SDK "Enable AWS SDK integration for S3 storage" OFF)
 option(PACS_WITH_AZURE_SDK "Enable Azure SDK integration for Blob storage" OFF)
+option(PACS_USE_MOCK_S3 "Use mock S3 client instead of AWS SDK (testing only)" OFF)
 option(PACS_WARNINGS_AS_ERRORS "Treat warnings as errors (disable in CI if dependency warnings occur)" ON)
 option(PACS_BUILD_MODULES "Build C++20 module version of pacs_system" OFF)
+
+# Prevent mock S3 from being used in Release builds
+if(PACS_USE_MOCK_S3 AND CMAKE_BUILD_TYPE STREQUAL "Release")
+    message(FATAL_ERROR "PACS_USE_MOCK_S3 cannot be enabled in Release builds")
+endif()
 
 ##################################################
 # Utility Functions

--- a/src/storage/annotation_repository.cpp
+++ b/src/storage/annotation_repository.cpp
@@ -40,6 +40,7 @@
 #include "pacs/storage/annotation_repository.hpp"
 
 #include <chrono>
+#include <iomanip>
 #include <sstream>
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
@@ -130,13 +131,11 @@ auto annotation_repository::parse_timestamp(const std::string& str) const
     }
 
     std::tm tm{};
-    if (std::sscanf(str.c_str(), "%d-%d-%d %d:%d:%d", &tm.tm_year, &tm.tm_mon,
-                    &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+    std::istringstream ss(str);
+    ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
+    if (ss.fail()) {
         return {};
     }
-
-    tm.tm_year -= 1900;
-    tm.tm_mon -= 1;
 
 #ifdef _WIN32
     auto time = _mkgmtime(&tm);
@@ -522,13 +521,11 @@ namespace {
         return {};
     }
     std::tm tm{};
-    if (std::sscanf(str, "%d-%d-%d %d:%d:%d",
-                    &tm.tm_year, &tm.tm_mon, &tm.tm_mday,
-                    &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+    std::istringstream ss(str);
+    ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
+    if (ss.fail()) {
         return {};
     }
-    tm.tm_year -= 1900;
-    tm.tm_mon -= 1;
 #ifdef _WIN32
     auto time = _mkgmtime(&tm);
 #else

--- a/src/storage/patient_repository.cpp
+++ b/src/storage/patient_repository.cpp
@@ -71,13 +71,11 @@ auto patient_repository::parse_timestamp(const std::string& str) const
     }
 
     std::tm tm{};
-    if (std::sscanf(str.c_str(), "%d-%d-%d %d:%d:%d", &tm.tm_year, &tm.tm_mon,
-                    &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+    std::istringstream ss(str);
+    ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
+    if (ss.fail()) {
         return {};
     }
-
-    tm.tm_year -= 1900;
-    tm.tm_mon -= 1;
 
 #ifdef _WIN32
     auto time = _mkgmtime(&tm);

--- a/src/storage/routing_repository.cpp
+++ b/src/storage/routing_repository.cpp
@@ -41,6 +41,7 @@
 
 #include <chrono>
 #include <cstring>
+#include <iomanip>
 #include <sstream>
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
@@ -292,13 +293,11 @@ auto routing_repository::parse_timestamp(const std::string& str) const
     }
 
     std::tm tm{};
-    if (std::sscanf(str.c_str(), "%d-%d-%d %d:%d:%d", &tm.tm_year, &tm.tm_mon,
-                    &tm.tm_mday, &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+    std::istringstream ss(str);
+    ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
+    if (ss.fail()) {
         return {};
     }
-
-    tm.tm_year -= 1900;
-    tm.tm_mon -= 1;
 
 #ifdef _WIN32
     auto time = _mkgmtime(&tm);
@@ -773,13 +772,11 @@ namespace {
         return {};
     }
     std::tm tm{};
-    if (std::sscanf(str, "%d-%d-%d %d:%d:%d",
-                    &tm.tm_year, &tm.tm_mon, &tm.tm_mday,
-                    &tm.tm_hour, &tm.tm_min, &tm.tm_sec) != 6) {
+    std::istringstream ss(str);
+    ss >> std::get_time(&tm, "%Y-%m-%d %H:%M:%S");
+    if (ss.fail()) {
         return {};
     }
-    tm.tm_year -= 1900;
-    tm.tm_mon -= 1;
 #ifdef _WIN32
     auto time = _mkgmtime(&tm);
 #else

--- a/src/web/endpoints/metrics_endpoints.cpp
+++ b/src/web/endpoints/metrics_endpoints.cpp
@@ -40,6 +40,7 @@
 #include "crow.h"
 
 #include "pacs/services/monitoring/database_metrics_service.hpp"
+#include "pacs/web/auth/oauth2_middleware.hpp"
 #include "pacs/web/endpoints/metrics_endpoints.hpp"
 #include "pacs/web/endpoints/system_endpoints.hpp"
 #include "pacs/web/rest_config.hpp"
@@ -96,6 +97,24 @@ int get_query_param_int(const crow::request& req, const std::string& key,
     }
 }
 
+/**
+ * @brief Check OAuth2 authentication for metrics endpoints
+ * @return true if authentication passed or OAuth2 is not enabled
+ */
+bool check_metrics_auth(const std::shared_ptr<rest_server_context>& ctx,
+                        const crow::request& req,
+                        crow::response& res) {
+    if (ctx->oauth2 && ctx->oauth2->enabled()) {
+        auto auth = ctx->oauth2->authenticate(req, res);
+        if (!auth) return false;
+        if (!ctx->oauth2->require_any_scope(
+                auth->claims, res, {"metrics.read", "admin"})) {
+            return false;
+        }
+    }
+    return true;
+}
+
 }  // namespace
 
 void register_metrics_endpoints_impl(
@@ -104,10 +123,12 @@ void register_metrics_endpoints_impl(
 
     // GET /api/health/database - Database health check
     CROW_ROUTE(app, "/api/health/database")
-        .methods(crow::HTTPMethod::GET)([ctx]([[maybe_unused]] const crow::request& req) {
+        .methods(crow::HTTPMethod::GET)([ctx](const crow::request& req) {
             crow::response res;
             res.add_header("Content-Type", "application/json");
             add_cors_headers(res, *ctx);
+
+            if (!check_metrics_auth(ctx, req, res)) return res;
 
             // Check if database metrics service is available
             if (!ctx->database_metrics) {
@@ -157,10 +178,12 @@ void register_metrics_endpoints_impl(
 
     // GET /api/metrics/database - Current metrics in JSON format
     CROW_ROUTE(app, "/api/metrics/database")
-        .methods(crow::HTTPMethod::GET)([ctx]([[maybe_unused]] const crow::request& req) {
+        .methods(crow::HTTPMethod::GET)([ctx](const crow::request& req) {
             crow::response res;
             res.add_header("Content-Type", "application/json");
             add_cors_headers(res, *ctx);
+
+            if (!check_metrics_auth(ctx, req, res)) return res;
 
             if (!ctx->database_metrics) {
                 res.body = make_error_json(
@@ -203,6 +226,8 @@ void register_metrics_endpoints_impl(
             res.add_header("Content-Type", "application/json");
             add_cors_headers(res, *ctx);
 
+            if (!check_metrics_auth(ctx, req, res)) return res;
+
             if (!ctx->database_metrics) {
                 res.body = make_error_json(
                     "METRICS_UNAVAILABLE",
@@ -244,9 +269,11 @@ void register_metrics_endpoints_impl(
 
     // GET /metrics - Prometheus format
     CROW_ROUTE(app, "/metrics")
-        .methods(crow::HTTPMethod::GET)([ctx]([[maybe_unused]] const crow::request& req) {
+        .methods(crow::HTTPMethod::GET)([ctx](const crow::request& req) {
             crow::response res;
             add_cors_headers(res, *ctx);
+
+            if (!check_metrics_auth(ctx, req, res)) return res;
 
             if (!ctx->database_metrics) {
                 res.code = 503;


### PR DESCRIPTION
## Summary

- **MED-03**: Add OAuth2 authentication to metrics endpoints (`/api/health/database`, `/api/metrics/database`, `/api/metrics/database/slow-queries`, `/metrics`) using the established `check_*_auth` pattern. Requires `metrics.read` or `admin` scope when OAuth2 is enabled.
- **MED-04**: Add CMake guard in `cmake/options.cmake` that emits `FATAL_ERROR` when `PACS_USE_MOCK_S3` is enabled in Release builds, preventing mock S3 from reaching production.
- **LOW-01**: Replace `std::sscanf` timestamp parsing with `std::get_time` in `patient_repository.cpp`, `annotation_repository.cpp`, and `routing_repository.cpp` (both `parse_timestamp` methods and internal `from_timestamp_string` helpers).

## Test plan

- [ ] Verify metrics endpoints return 401/403 when OAuth2 is enabled and no valid token is provided
- [ ] Verify metrics endpoints work normally when OAuth2 is not enabled
- [ ] Verify `cmake -DPACS_USE_MOCK_S3=ON -DCMAKE_BUILD_TYPE=Release` fails with FATAL_ERROR
- [ ] Verify `cmake -DPACS_USE_MOCK_S3=ON -DCMAKE_BUILD_TYPE=Debug` succeeds
- [ ] Verify timestamp parsing still works correctly (existing storage tests)