### PR TITLE
fix(concurrency): replace std::localtime with thread-safe alternatives

### DIFF
--- a/src/security/anonymizer.cpp
+++ b/src/security/anonymizer.cpp
@@ -634,13 +634,18 @@ auto anonymizer::shift_date(std::string_view date_string) const -> std::string {
 
         // Convert back to date string
         auto shifted_time = std::chrono::system_clock::to_time_t(time_point);
-        std::tm* shifted_tm = std::localtime(&shifted_time);
+        std::tm shifted_tm{};
+#if defined(_WIN32)
+        localtime_s(&shifted_tm, &shifted_time);
+#else
+        localtime_r(&shifted_time, &shifted_tm);
+#endif
 
         std::ostringstream oss;
         oss << std::setfill('0')
-            << std::setw(4) << (shifted_tm->tm_year + 1900)
-            << std::setw(2) << (shifted_tm->tm_mon + 1)
-            << std::setw(2) << shifted_tm->tm_mday;
+            << std::setw(4) << (shifted_tm.tm_year + 1900)
+            << std::setw(2) << (shifted_tm.tm_mon + 1)
+            << std::setw(2) << shifted_tm.tm_mday;
 
         return oss.str();
 

--- a/src/services/mpps_scu.cpp
+++ b/src/services/mpps_scu.cpp
@@ -515,17 +515,27 @@ std::string mpps_scu::generate_mpps_uid() const {
 
 std::string mpps_scu::get_current_date() const {
     auto now = std::time(nullptr);
-    auto* tm = std::localtime(&now);
+    std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &now);
+#else
+    localtime_r(&now, &tm);
+#endif
     std::ostringstream oss;
-    oss << std::put_time(tm, "%Y%m%d");
+    oss << std::put_time(&tm, "%Y%m%d");
     return oss.str();
 }
 
 std::string mpps_scu::get_current_time() const {
     auto now = std::time(nullptr);
-    auto* tm = std::localtime(&now);
+    std::tm tm{};
+#if defined(_WIN32)
+    localtime_s(&tm, &now);
+#else
+    localtime_r(&now, &tm);
+#endif
     std::ostringstream oss;
-    oss << std::put_time(tm, "%H%M%S");
+    oss << std::put_time(&tm, "%H%M%S");
     return oss.str();
 }
 


### PR DESCRIPTION
## What

Replace `std::localtime` (which returns a pointer to a static internal buffer) with thread-safe alternatives across the codebase.

### Change Type
- [x] Bugfix (fixes a thread-safety issue)

### Affected Components
- `src/security/anonymizer.cpp` — date shift logic
- `src/services/mpps_scu.cpp` — current date/time formatting

## Why

`std::localtime` is not thread-safe — concurrent calls cause data races. DICOM servers handle multiple sessions simultaneously, so anonymization date shifts and MPPS timestamps could produce corrupted results.

Closes #990

## How

### Implementation
- `localtime_r` on POSIX, `localtime_s` on Windows
- Changed from pointer dereference (`tm->`) to value access (`tm.`)
- Follows the existing pattern used in `atna_audit_logger.cpp`

### Testing
- Existing date shift logic produces identical results
- Platform-specific selection via `#if defined(_WIN32)`