### PR TITLE
fix(security): set non_downgrading=true in BCP195 basic TLS profile

### DIFF
--- a/src/security/tls_policy.cpp
+++ b/src/security/tls_policy.cpp
@@ -79,7 +79,7 @@ tls_policy tls_policy::bcp195_basic_profile() {
     return {tls_profile::bcp195_basic,
             kTls12Version,
             kTls13Version,
-            false,
+            true,
             {std::string(kTls13Required), std::string(kTls12Recommended)},
             {2048, 256, 5, true}};
 }

--- a/tests/security/tls_policy_test.cpp
+++ b/tests/security/tls_policy_test.cpp
@@ -60,7 +60,7 @@ TEST_CASE("tls_policy BCP 195 basic profile", "[security][tls]") {
     SECTION("Profile properties") {
         CHECK(policy.profile() == tls_profile::bcp195_basic);
         CHECK(policy.profile_name() == "BCP195-Basic");
-        CHECK_FALSE(policy.non_downgrading());
+        CHECK(policy.non_downgrading());
     }
 
     SECTION("Protocol version requirements") {
@@ -203,7 +203,7 @@ TEST_CASE("tls_policy from_profile", "[security][tls]") {
     SECTION("Basic profile") {
         auto policy = tls_policy::from_profile(tls_profile::bcp195_basic);
         CHECK(policy.profile() == tls_profile::bcp195_basic);
-        CHECK_FALSE(policy.non_downgrading());
+        CHECK(policy.non_downgrading());
     }
 
     SECTION("Non-downgrading profile") {


### PR DESCRIPTION
## What

Corrects the `non_downgrading` flag in the BCP 195 basic TLS profile from `false` to `true`, aligning with RFC 7525 security requirements. Updates corresponding test expectations.

## Why

Fixes #991 -- The BCP 195 basic profile should enforce non-downgrading behavior by default. A `false` value weakens TLS negotiation by allowing protocol version downgrades, which contradicts the intent of the security profile.

## How

- `tls_policy.cpp`: Changed the 4th constructor argument from `false` to `true`
- `tls_policy_test.cpp`: Updated 2 test assertions from `CHECK_FALSE` to `CHECK` for `non_downgrading()`