### PR TITLE
fix(security): handle patient_age in basic profile per HIPAA Safe Harbor (#993)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Implement AES-256-GCM encryption for anonymizer `encrypt_value()` ([#987](https://github.com/kcenon/pacs_system/issues/987))
 - Replace non-cryptographic `std::hash` with SHA-256 in anonymizer `hash_value()` ([#988](https://github.com/kcenon/pacs_system/issues/988))
 - Set `non_downgrading=true` in BCP195 basic TLS profile to prevent version downgrade attacks ([#991](https://github.com/kcenon/pacs_system/issues/991))
+- Handle patient age in basic anonymization profile per HIPAA Safe Harbor requirements ([#993](https://github.com/kcenon/pacs_system/issues/993))
 
 ### Fixed
 

--- a/src/security/anonymizer.cpp
+++ b/src/security/anonymizer.cpp
@@ -335,7 +335,7 @@ auto anonymizer::get_profile_actions(anonymization_profile profile)
         actions[tags::patient_id] = tag_action_config::make_replace("ANON_ID");
         actions[tags::patient_birth_date] = tag_action_config::make_empty();
         actions[tags::patient_sex] = tag_action_config::make_keep();
-        actions[tags::patient_age] = tag_action_config::make_keep();
+        actions[tags::patient_age] = tag_action_config::make_remove();
         actions[tags::patient_address] = tag_action_config::make_remove();
         actions[tags::patient_comments] = tag_action_config::make_remove();
     };

--- a/tests/security/anonymizer_test.cpp
+++ b/tests/security/anonymizer_test.cpp
@@ -91,6 +91,10 @@ TEST_CASE("Anonymizer: Basic Profile", "[security][anonymization]") {
         REQUIRE(dataset.get_string(tags::patient_sex) == "M");
     }
 
+    SECTION("Patient age is removed per HIPAA Safe Harbor") {
+        REQUIRE(dataset.get(tags::patient_age) == nullptr);
+    }
+
     SECTION("Institution name is emptied") {
         REQUIRE(dataset.get_string(tags::institution_name).empty());
     }


### PR DESCRIPTION
## What

### Summary
Changes the `basic` anonymization profile to remove `patient_age` instead of keeping it, ensuring compliance with HIPAA Safe Harbor de-identification requirements (45 CFR 164.514(b)(2)).

### Change Type
- [x] Enhancement (improved compliance)

### Affected Components
- `src/security/anonymizer.cpp` — Basic profile `patient_age` action changed
- `tests/security/anonymizer_test.cpp` — Test added for age removal

## Why

### Problem Solved
The `basic` anonymization profile kept `patient_age` unconditionally with `tag_action::keep`. Under HIPAA Safe Harbor (45 CFR 164.514(b)(2)), ages 90 and above must be aggregated into a single category. Rather than implementing conditional age handling (which would require runtime inspection of the age value during profile configuration), the conservative approach of removing `patient_age` entirely was chosen for the `basic` profile.

### Related Issues
- Closes #993

### Alternatives Considered
1. **Conditional handling (keep < 90, generalize >= 90)**: Would require the profile action map to have runtime value inspection, adding complexity to the tag_action_config system. Could be implemented as a future `tag_action::generalize_age` action.
2. **Replace with "090Y+"**: Simpler but loses information for patients under 90. Not chosen for the `basic` profile.

## How

### Implementation Details
1. Changed `patient_age` action in `add_patient_identifiers()` lambda from `make_keep()` to `make_remove()`
2. This affects all profiles that use `add_patient_identifiers()`: `basic`, `clean_pixel`, `clean_descriptions`, `retain_longitudinal`
3. `retain_patient_characteristics` profile explicitly overrides `patient_age` back to `make_keep()` (line 433), which is intentional — this profile is designed to preserve demographics and is not a HIPAA Safe Harbor profile
4. `hipaa_safe_harbor` profile already removes all HIPAA identifiers via `get_hipaa_identifier_tags()`

### Testing Done
- [x] Added test: "Patient age is removed per HIPAA Safe Harbor" in basic profile tests

### Breaking Changes
- `basic` profile now removes `patient_age` instead of keeping it
- Applications relying on `patient_age` being preserved in `basic` profile should switch to `retain_patient_characteristics` profile