### PR TITLE
feat(cmake): add vcpkg CMake preset to CMakePresets.json

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -92,6 +92,25 @@
                 "PACS_BUILD_EXAMPLES": "ON",
                 "PACS_BUILD_BENCHMARKS": "ON"
             }
+        },
+        {
+            "name": "vcpkg",
+            "displayName": "vcpkg Release",
+            "description": "Release build using vcpkg for dependency management",
+            "binaryDir": "${sourceDir}/build/vcpkg",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": {
+                    "type": "FILEPATH",
+                    "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+                },
+                "CMAKE_BUILD_TYPE": "Release",
+                "PACS_BUILD_TESTS": "OFF",
+                "PACS_BUILD_EXAMPLES": "OFF",
+                "PACS_BUILD_BENCHMARKS": "OFF",
+                "PACS_FETCH_CROW": "OFF",
+                "PACS_FETCH_OPENJPH": "OFF",
+                "FETCHCONTENT_FULLY_DISCONNECTED": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -122,6 +141,10 @@
         {
             "name": "ci",
             "configurePreset": "ci"
+        },
+        {
+            "name": "vcpkg",
+            "configurePreset": "vcpkg"
         }
     ],
     "testPresets": [


### PR DESCRIPTION
Closes #1001

## Summary

- Add `vcpkg` configure preset with `CMAKE_TOOLCHAIN_FILE` pointing to `$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake`
- Add matching build preset
- Disable FetchContent fallbacks (`PACS_FETCH_CROW`, `PACS_FETCH_OPENJPH`, `FETCHCONTENT_FULLY_DISCONNECTED`)
- Disable tests, examples, and benchmarks (matching portfile behavior)

## Usage

```bash
export VCPKG_ROOT=/path/to/vcpkg
cmake --preset vcpkg
cmake --build --preset vcpkg
```

## Test Plan

- [ ] `cmake --preset vcpkg` configures successfully when `VCPKG_ROOT` is set
- [ ] All vcpkg.json dependencies are resolved through the toolchain
- [ ] Preset disables FetchContent fallbacks and test/sample builds
- [ ] JSON is syntactically valid