### PR TITLE
fix: migrate to current database_system API

### DIFF
--- a/include/pacs/services/cache/database_cursor.hpp
+++ b/include/pacs/services/cache/database_cursor.hpp
@@ -280,14 +280,15 @@ private:
         const storage::database_row& row) -> storage::instance_record;
 
     /**
-     * @brief Build WHERE clause string from DICOM wildcard pattern
+     * @brief Add WHERE condition from DICOM wildcard pattern to query builder
      *
      * Converts DICOM wildcards (* and ?) to SQL LIKE pattern (% and _)
-     * and returns appropriate SQL condition.
+     * and adds appropriate condition to the builder.
      */
-    [[nodiscard]] static auto build_dicom_condition(
+    static void add_dicom_condition(
+        database::query_builder& builder,
         const std::string& field,
-        const std::string& value) -> std::string;
+        const std::string& value);
 
     /// Cached results from database query
     std::vector<query_record> results_;

--- a/src/services/cache/database_cursor.cpp
+++ b/src/services/cache/database_cursor.cpp
@@ -40,8 +40,6 @@
 
 #ifdef PACS_WITH_DATABASE_SYSTEM
 
-#include <database/query_builder/value_formatter.h>
-
 #include <iomanip>
 #include <sstream>
 
@@ -203,22 +201,17 @@ auto get_optional_int(const storage::database_row& row,
 
 }  // namespace
 
-auto database_cursor::build_dicom_condition(
+void database_cursor::add_dicom_condition(
+    database::query_builder& builder,
     const std::string& field,
-    const std::string& value) -> std::string {
-    // Use value_formatter for SQL injection protection
-    // This properly escapes single quotes and other special characters
-    database::query::value_formatter formatter(database::database_types::sqlite);
-
+    const std::string& value) {
     if (contains_dicom_wildcards(value)) {
         // Use LIKE with DICOM-to-SQL wildcard conversion
         auto pattern = to_like_pattern(value);
-        auto escaped_pattern = formatter.escape_string(pattern);
-        return field + " LIKE '" + escaped_pattern + "' ESCAPE '\\'";
+        builder.where(field, "LIKE", pattern);
     } else {
-        // Exact match with properly escaped value
-        auto escaped_value = formatter.escape_string(value);
-        return field + " = '" + escaped_value + "'";
+        // Exact match
+        builder.where(field, "=", value);
     }
 }
 
@@ -324,12 +317,10 @@ auto database_cursor::create_patient_cursor(
 
     // Apply DICOM wildcard conditions
     if (query.patient_id.has_value()) {
-        auto condition = build_dicom_condition("patient_id", *query.patient_id);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "patient_id", *query.patient_id);
     }
     if (query.patient_name.has_value()) {
-        auto condition = build_dicom_condition("patient_name", *query.patient_name);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "patient_name", *query.patient_name);
     }
     if (query.birth_date.has_value()) {
         builder.where("birth_date", "=", *query.birth_date);
@@ -385,19 +376,16 @@ auto database_cursor::create_study_cursor(
 
     // Apply DICOM wildcard conditions
     if (query.patient_id.has_value()) {
-        auto condition = build_dicom_condition("p.patient_id", *query.patient_id);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "p.patient_id", *query.patient_id);
     }
     if (query.patient_name.has_value()) {
-        auto condition = build_dicom_condition("p.patient_name", *query.patient_name);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "p.patient_name", *query.patient_name);
     }
     if (query.study_uid.has_value()) {
         builder.where("s.study_uid", "=", *query.study_uid);
     }
     if (query.study_id.has_value()) {
-        auto condition = build_dicom_condition("s.study_id", *query.study_id);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "s.study_id", *query.study_id);
     }
     if (query.study_date.has_value()) {
         builder.where("s.study_date", "=", *query.study_date);
@@ -409,23 +397,18 @@ auto database_cursor::create_study_cursor(
         builder.where("s.study_date", "<=", *query.study_date_to);
     }
     if (query.accession_number.has_value()) {
-        auto condition = build_dicom_condition("s.accession_number", *query.accession_number);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "s.accession_number", *query.accession_number);
     }
     if (query.modality.has_value()) {
-        // Escape modality value to prevent SQL injection
-        database::query::value_formatter formatter(database::database_types::sqlite);
-        auto escaped_modality = formatter.escape_string(*query.modality);
         builder.where(database::query_condition(
-            "s.modalities_in_study LIKE '%" + escaped_modality + "%'"));
+            "s.modalities_in_study", "LIKE",
+            std::string("%" + *query.modality + "%")));
     }
     if (query.referring_physician.has_value()) {
-        auto condition = build_dicom_condition("s.referring_physician", *query.referring_physician);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "s.referring_physician", *query.referring_physician);
     }
     if (query.study_description.has_value()) {
-        auto condition = build_dicom_condition("s.study_description", *query.study_description);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "s.study_description", *query.study_description);
     }
 
     auto sql = builder.build();
@@ -478,8 +461,7 @@ auto database_cursor::create_series_cursor(
         builder.where("se.series_number", "=", static_cast<int64_t>(*query.series_number));
     }
     if (query.series_description.has_value()) {
-        auto condition = build_dicom_condition("se.series_description", *query.series_description);
-        builder.where(database::query_condition(condition));
+        add_dicom_condition(builder, "se.series_description", *query.series_description);
     }
 
     auto sql = builder.build();

--- a/src/storage/audit_repository.cpp
+++ b/src/storage/audit_repository.cpp
@@ -202,12 +202,10 @@ auto audit_repository::query_audit_log(const audit_query& query)
         builder.where("study_uid", "=", *query.study_uid);
     }
     if (query.date_from.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "date(timestamp) >= date('{}')", *query.date_from)));
+        builder.where("date(timestamp)", ">=", *query.date_from);
     }
     if (query.date_to.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "date(timestamp) <= date('{}')", *query.date_to)));
+        builder.where("date(timestamp)", "<=", *query.date_to);
     }
 
     builder.order_by("timestamp", database::sort_order::desc);
@@ -263,8 +261,7 @@ auto audit_repository::cleanup_old_audit_logs(std::chrono::hours age)
 
     auto builder = query_builder();
     builder.delete_from(table_name())
-        .where(database::query_condition(
-            kcenon::pacs::compat::format("timestamp < '{}'", cutoff_str)));
+        .where("timestamp", "<", cutoff_str);
 
     auto result = db()->remove(builder.build());
     if (result.is_err()) {

--- a/src/storage/mpps_repository.cpp
+++ b/src/storage/mpps_repository.cpp
@@ -375,12 +375,12 @@ auto mpps_repository::search_mpps(const mpps_query& query)
         builder.where("accession_no", "=", *query.accession_no);
     }
     if (query.start_date_from.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "substr(start_datetime, 1, 8) >= '{}'", *query.start_date_from)));
+        builder.where("substr(start_datetime, 1, 8)", ">=",
+                       *query.start_date_from);
     }
     if (query.start_date_to.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "substr(start_datetime, 1, 8) <= '{}'", *query.start_date_to)));
+        builder.where("substr(start_datetime, 1, 8)", "<=",
+                       *query.start_date_to);
     }
 
     builder.order_by("start_datetime", database::sort_order::desc);

--- a/src/storage/sqlite_security_storage.cpp
+++ b/src/storage/sqlite_security_storage.cpp
@@ -128,7 +128,7 @@ auto sqlite_security_storage::create_user(const User &user) -> VoidResult {
                                  {"active", user.active ? 1 : 0}})
                         .build();
 
-  auto result = db_manager_->insert_query_result(insert_sql);
+  auto result = db_manager_->execute_query_result(insert_sql);
   if (result.is_err()) {
     return make_error<std::monostate>(
         kSqliteError, "Failed to insert user: " + result.error().message,
@@ -144,7 +144,7 @@ auto sqlite_security_storage::create_user(const User &user) -> VoidResult {
                                  {"role", std::string(to_string(role))}})
                         .build();
 
-    auto role_result = db_manager_->insert_query_result(role_sql);
+    auto role_result = db_manager_->execute_query_result(role_sql);
     if (role_result.is_err()) {
       // Log warning but continue (best effort for roles)
     }
@@ -312,7 +312,7 @@ auto sqlite_security_storage::update_user(const User &user) -> VoidResult {
                         .where("id", "=", user.id)
                         .build();
 
-  auto update_result = db_manager_->update_query_result(update_sql);
+  auto update_result = db_manager_->execute_query_result(update_sql);
   if (update_result.is_err()) {
     (void)db_manager_->rollback_transaction();
     return make_error<std::monostate>(
@@ -326,7 +326,7 @@ auto sqlite_security_storage::update_user(const User &user) -> VoidResult {
                         .where("user_id", "=", user.id)
                         .build();
 
-  auto delete_result = db_manager_->delete_query_result(delete_sql);
+  auto delete_result = db_manager_->execute_query_result(delete_sql);
   if (delete_result.is_err()) {
     (void)db_manager_->rollback_transaction();
     return make_error<std::monostate>(
@@ -344,7 +344,7 @@ auto sqlite_security_storage::update_user(const User &user) -> VoidResult {
                 {{"user_id", user.id}, {"role", std::string(to_string(role))}})
             .build();
 
-    auto role_result = db_manager_->insert_query_result(role_sql);
+    auto role_result = db_manager_->execute_query_result(role_sql);
     if (role_result.is_err()) {
       (void)db_manager_->rollback_transaction();
       return make_error<std::monostate>(
@@ -379,7 +379,7 @@ auto sqlite_security_storage::delete_user(std::string_view id) -> VoidResult {
                         .where("id", "=", std::string(id))
                         .build();
 
-  auto result = db_manager_->delete_query_result(delete_sql);
+  auto result = db_manager_->execute_query_result(delete_sql);
   if (result.is_err()) {
     return make_error<std::monostate>(
         kSqliteError, "Failed to delete user: " + result.error().message,

--- a/src/storage/ups_repository.cpp
+++ b/src/storage/ups_repository.cpp
@@ -408,14 +408,12 @@ auto ups_repository::search_ups_workitems(const ups_workitem_query& query)
         builder.where("performing_ae", "=", *query.performing_ae);
     }
     if (query.scheduled_date_from.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "scheduled_start_datetime >= '{}'",
-            *query.scheduled_date_from)));
+        builder.where("scheduled_start_datetime", ">=",
+                       *query.scheduled_date_from);
     }
     if (query.scheduled_date_to.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "scheduled_start_datetime <= '{}235959'",
-            *query.scheduled_date_to)));
+        builder.where("scheduled_start_datetime", "<=",
+                       *query.scheduled_date_to + "235959");
     }
 
     builder.order_by("scheduled_start_datetime", database::sort_order::asc);

--- a/src/storage/worklist_repository.cpp
+++ b/src/storage/worklist_repository.cpp
@@ -252,14 +252,14 @@ auto worklist_repository::query_worklist(const worklist_query& query)
         builder.where("modality", "=", *query.modality);
     }
     if (query.scheduled_date_from.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "substr(scheduled_datetime, 1, 8) >= '{}'",
-            *query.scheduled_date_from)));
+        builder.where(database::query_condition(
+            "substr(scheduled_datetime, 1, 8)", ">=",
+            *query.scheduled_date_from));
     }
     if (query.scheduled_date_to.has_value()) {
-        builder.where(database::query_condition(kcenon::pacs::compat::format(
-            "substr(scheduled_datetime, 1, 8) <= '{}'",
-            *query.scheduled_date_to)));
+        builder.where(database::query_condition(
+            "substr(scheduled_datetime, 1, 8)", "<=",
+            *query.scheduled_date_to));
     }
     if (query.patient_id.has_value()) {
         builder.where("patient_id", "LIKE",
@@ -374,8 +374,7 @@ auto worklist_repository::cleanup_old_worklist_items(std::chrono::hours age)
     auto builder = query_builder();
     builder.delete_from(table_name())
         .where("step_status", "!=", std::string("SCHEDULED"))
-        .where(database::query_condition(
-            kcenon::pacs::compat::format("created_at < '{}'", cutoff_str)));
+        .where(database::query_condition("created_at", "<", cutoff_str));
 
     auto result = db()->remove(builder.build());
     if (result.is_err()) {
@@ -406,8 +405,7 @@ auto worklist_repository::cleanup_worklist_items_before(
     auto builder = query_builder();
     builder.delete_from(table_name())
         .where("step_status", "!=", std::string("SCHEDULED"))
-        .where(database::query_condition(
-            kcenon::pacs::compat::format("scheduled_datetime < '{}'", before_str)));
+        .where(database::query_condition("scheduled_datetime", "<", before_str));
 
     auto result = db()->remove(builder.build());
     if (result.is_err()) {

--- a/tests/integration/load_integration_test.cpp
+++ b/tests/integration/load_integration_test.cpp
@@ -547,7 +547,7 @@ TEST_CASE("No deadlocks under concurrent access",
 
         for (int i = 0; i < outer_count; ++i) {
             outer_futures.push_back(pool->submit(
-                [i, &total_completed, &pool]() {
+                [&total_completed, &pool]() {
                     std::vector<std::future<void>> inner_futures;
 
                     for (int j = 0; j < inner_count; ++j) {


### PR DESCRIPTION
## Summary
- Update all call sites to match database_system current API after deprecated methods were removed

## Changes
- Replace `query_condition(string)` single-arg constructor with 3-arg `query_condition(field, op, value)` or `builder.where(field, op, value)` across 6 files
- Replace `insert_query_result`/`update_query_result`/`delete_query_result` with unified `execute_query_result` in sqlite_security_storage.cpp
- Refactor `build_dicom_condition` → `add_dicom_condition` to add conditions directly to query builder
- Remove unused lambda capture in load_integration_test.cpp

## Files changed
- `src/services/cache/database_cursor.cpp` + header
- `src/storage/sqlite_security_storage.cpp`
- `src/storage/worklist_repository.cpp`
- `src/storage/ups_repository.cpp`
- `src/storage/audit_repository.cpp`
- `src/storage/mpps_repository.cpp`
- `tests/integration/load_integration_test.cpp`

## Test plan
- [x] `./build.sh --clean` compiles all 800 targets successfully
- [x] No compilation errors or warnings-as-errors