### PR TITLE
chore: synchronize vcpkg default-registry baseline with ecosystem

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "dd306f32e07d87fdb16837af64f33b6b415c770a"
+    "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
   },
   "registries": [
     {


### PR DESCRIPTION
## Summary

- Synchronize the vcpkg default-registry baseline from `dd306f32` (2026-03-11) to `d90a9b15` (2026-03-17) to match the other 6 ecosystem repos

## Context

The kcenon ecosystem had two different Microsoft vcpkg baselines in use:
- `d90a9b15...` (2026-03-17): common, logger, container, monitoring, database, network
- `dd306f32...` (2026-03-11): thread, **pacs**

This inconsistency could cause transitive dependency version mismatches across tiers.

## Test plan

- [ ] CI builds pass with the updated baseline
- [ ] vcpkg dependency resolution succeeds without version conflicts

Ref: kcenon/vcpkg-registry#35