### PR TITLE
chore: add local vcpkg portfile for registry synchronization

### DIFF
--- a/vcpkg-ports/kcenon-pacs-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-pacs-system/portfile.cmake
@@ -1,0 +1,49 @@
+# kcenon-pacs-system portfile
+# Modern C++20 PACS implementation built on the kcenon ecosystem
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO kcenon/pacs_system
+    REF "v${VERSION}"
+    SHA512 242dd7bc82f56e0267e4978dd406aebeebd1bb50e70f93a8c809d3474ae6de1d0e692cc8fbbbaa81dbb68e2642b48c14100b8d5daa5f99097287af2d9465904c
+    HEAD_REF main
+)
+
+vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        storage  PACS_BUILD_STORAGE
+        aws      PACS_WITH_AWS_SDK
+        azure    PACS_WITH_AZURE_SDK
+)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH "${SOURCE_PATH}"
+    OPTIONS
+        -DPACS_BUILD_TESTS=OFF
+        -DPACS_BUILD_EXAMPLES=OFF
+        -DPACS_BUILD_BENCHMARKS=OFF
+        -DPACS_BUILD_SAMPLES=OFF
+        -DPACS_WITH_COMMON_SYSTEM=ON
+        -DPACS_WITH_CONTAINER_SYSTEM=ON
+        -DPACS_WITH_NETWORK_SYSTEM=ON
+        -DPACS_BUILD_MODULES=OFF
+        -DPACS_WARNINGS_AS_ERRORS=OFF
+        -DBUILD_SHARED_LIBS=OFF
+        # Disable all FetchContent fallbacks; all deps must be resolved via vcpkg
+        -DPACS_FETCH_OPENJPH=OFF
+        -DPACS_FETCH_CROW=OFF
+        -DFETCHCONTENT_FULLY_DISCONNECTED=ON
+        ${FEATURE_OPTIONS}
+)
+
+vcpkg_cmake_install()
+
+vcpkg_cmake_config_fixup(
+    PACKAGE_NAME pacs_system
+    CONFIG_PATH lib/cmake/pacs_system
+)
+
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include")
+file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/share")
+
+vcpkg_install_copyright(FILE_LIST "${SOURCE_PATH}/LICENSE")

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,0 +1,92 @@
+{
+  "name": "kcenon-pacs-system",
+  "version": "0.1.0",
+  "port-version": 4,
+  "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
+  "homepage": "https://github.com/kcenon/pacs_system",
+  "license": "BSD-3-Clause",
+  "supports": "!(uwp | xbox)",
+  "dependencies": [
+    "kcenon-common-system",
+    "kcenon-container-system",
+    "kcenon-network-system",
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    }
+  ],
+  "features": {
+    "storage": {
+      "description": "SQLite3-based PACS storage",
+      "dependencies": [
+        {
+          "name": "sqlite3",
+          "version>=": "3.45.1"
+        }
+      ]
+    },
+    "codecs": {
+      "description": "Optional image compression codecs (JPEG, JPEG2000, HTJ2K, JPEG-LS, PNG)",
+      "dependencies": [
+        {
+          "name": "libjpeg-turbo",
+          "version>=": "3.0.2"
+        },
+        {
+          "name": "libpng",
+          "version>=": "1.6.43"
+        },
+        {
+          "name": "openjpeg",
+          "version>=": "2.5.2"
+        },
+        {
+          "name": "charls",
+          "version>=": "2.4.2"
+        },
+        {
+          "name": "openjph",
+          "version>=": "0.21.0"
+        }
+      ]
+    },
+    "ssl": {
+      "description": "TLS/SSL support for secure DICOM associations",
+      "dependencies": [
+        {
+          "name": "openssl",
+          "version>=": "3.0.0"
+        }
+      ]
+    },
+    "aws": {
+      "description": "AWS S3 integration for cloud-based PACS storage",
+      "dependencies": [
+        {
+          "name": "aws-sdk-cpp",
+          "default-features": false,
+          "features": ["s3"]
+        }
+      ]
+    },
+    "azure": {
+      "description": "Azure Blob storage integration for cloud-based PACS storage",
+      "dependencies": [
+        "azure-storage-blobs-cpp"
+      ]
+    },
+    "rest-api": {
+      "description": "DICOMweb REST API via Crow HTTP framework",
+      "dependencies": [
+        {
+          "name": "crow",
+          "version>=": "1.2.1"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `vcpkg-ports/kcenon-pacs-system/` with `portfile.cmake` and `vcpkg.json` mirroring the canonical vcpkg-registry

## Rationale

Standardize portfile management (Strategy B: local + registry sync) across the ecosystem, following the pattern already established by `monitoring_system`. Local portfiles enable atomic source+port changes and CI validation.

## Test plan

- [ ] Verify portfile matches the canonical registry version
- [ ] CI builds pass without regression

Ref: kcenon/vcpkg-registry#36