### PR TITLE
Remove undefined @PACS_SYSTEM_WITH_FMT@ from config template

### DIFF
--- a/cmake/pacs_systemConfig.cmake.in
+++ b/cmake/pacs_systemConfig.cmake.in
@@ -47,10 +47,6 @@ if(@PACS_SYSTEM_WITH_OPENSSL@)
     find_dependency(OpenSSL REQUIRED)
 endif()
 
-if(@PACS_SYSTEM_WITH_FMT@)
-    find_dependency(fmt CONFIG REQUIRED)
-endif()
-
 if(@PACS_SYSTEM_WITH_CROW@)
     find_dependency(Crow CONFIG REQUIRED)
 endif()


### PR DESCRIPTION
## Summary
- Remove dead `@PACS_SYSTEM_WITH_FMT@` conditional from `pacs_systemConfig.cmake.in`
- This variable was never defined in `dependencies.cmake` or `install.cmake`
- `fmt` is not used in any pacs_system source or CMake files (confirmed via grep)
- The undefined substitution generated an empty `if()` in the installed config

## Test plan
- [ ] CI builds pass
- [ ] `find_package(pacs_system)` works correctly for consumers

Closes #1006