### PR TITLE
Standardize vcpkg builtin baseline to match ecosystem

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "dd306f32e07d87fdb16837af64f33b6b415c770a"
+    "baseline": "d90a9b159c08169f39adcd1b0f1ac0ca12c4b96c"
   },
   "registries": [
     {


### PR DESCRIPTION
## Summary
- Align Microsoft vcpkg builtin baseline from `dd306f32...` to `d90a9b15...`
- Matches the baseline used by 6 other kcenon ecosystem systems
- As Tier 5, pacs_system depends on multiple lower-tier systems — consistent dependency versions prevent ABI issues

## Related
- kcenon/thread_system#614 (same baseline standardization)

## Test plan
- [ ] CI builds pass with the standardized baseline
- [ ] All third-party dependencies (OpenSSL, SQLite3, libjpeg-turbo, etc.) resolve correctly

Closes #1007