### PR TITLE
chore(deps): upgrade gtest, benchmark, and openssl overrides

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -14,15 +14,15 @@
   ],
   "overrides": [
     { "name": "sqlite3", "version": "3.45.3" },
-    { "name": "openssl", "version": "3.3.0" },
+    { "name": "openssl", "version": "3.4.1" },
     { "name": "libjpeg-turbo", "version": "3.0.2" },
     { "name": "libpng", "version": "1.6.43" },
     { "name": "openjpeg", "version": "2.5.2" },
     { "name": "charls", "version": "2.4.2" },
     { "name": "openjph", "version": "0.21.0" },
     { "name": "crow", "version": "1.2.1" },
-    { "name": "gtest", "version": "1.14.0" },
-    { "name": "benchmark", "version": "1.8.3" },
+    { "name": "gtest", "version": "1.17.0" },
+    { "name": "benchmark", "version": "1.9.5" },
     { "name": "asio", "version": "1.30.2" }
   ],
   "features": {


### PR DESCRIPTION
## What

Upgrade three vcpkg dependency overrides in `vcpkg.json` to match the current ecosystem versions:

| Dependency | Old Version | New Version |
|-----------|-------------|-------------|
| gtest | 1.14.0 | 1.17.0 |
| benchmark | 1.8.3 | 1.9.5 |
| openssl | 3.3.0 | 3.4.1 |

## Why

Closes #1010

These overrides have fallen behind the versions used in the broader ecosystem. Upgrading ensures:
- Compatibility with upstream dependency registries
- Access to bug fixes and security patches (especially OpenSSL 3.4.1)
- Consistent build behavior across ecosystem projects

## Where

- `vcpkg.json` (overrides section only, lines 15-27)

## How

Direct version string updates in the overrides array. No API, schema, or feature changes.

## Test Plan

- [ ] CI builds pass on all platforms (Ubuntu, macOS, Windows)
- [ ] Unit tests pass with the updated dependency versions
- [ ] No regressions in benchmark or TLS-related tests