### PR TITLE
fix(vcpkg): add testing feature to vcpkg port manifest

### DIFF
--- a/vcpkg-ports/kcenon-pacs-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-pacs-system/portfile.cmake
@@ -14,14 +14,14 @@ vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
         storage  PACS_BUILD_STORAGE
         aws      PACS_WITH_AWS_SDK
         azure    PACS_WITH_AZURE_SDK
+        testing  PACS_BUILD_TESTS
+        testing  PACS_BUILD_BENCHMARKS
 )
 
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
-        -DPACS_BUILD_TESTS=OFF
         -DPACS_BUILD_EXAMPLES=OFF
-        -DPACS_BUILD_BENCHMARKS=OFF
         -DPACS_BUILD_SAMPLES=OFF
         -DPACS_WITH_COMMON_SYSTEM=ON
         -DPACS_WITH_CONTAINER_SYSTEM=ON

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version": "0.1.0",
-  "port-version": 4,
+  "port-version": 5,
   "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",
@@ -85,6 +85,19 @@
         {
           "name": "crow",
           "version>=": "1.2.1"
+        }
+      ]
+    },
+    "testing": {
+      "description": "Build unit tests and benchmarks",
+      "dependencies": [
+        {
+          "name": "gtest",
+          "version>=": "1.14.0",
+          "features": ["gmock"]
+        },
+        {
+          "name": "benchmark"
         }
       ]
     }


### PR DESCRIPTION
## What

Add the missing `testing` feature to the `kcenon-pacs-system` vcpkg port manifest, aligning it with the root `vcpkg.json` definition.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `vcpkg-ports/kcenon-pacs-system/vcpkg.json` - Added testing feature
- `vcpkg-ports/kcenon-pacs-system/portfile.cmake` - Added feature mapping

## Why

### Problem Solved
The root `vcpkg.json` defines a `testing` feature with gtest/gmock and benchmark dependencies, but the vcpkg port manifest was missing it. This meant consumers of the port could not enable test/benchmark builds via vcpkg features.

Additionally, `PACS_BUILD_TESTS` and `PACS_BUILD_BENCHMARKS` were hardcoded to `OFF` in the portfile, ignoring any feature toggle.

### Related Issues
- Closes #1014
- Part of kcenon/common_system#515

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-pacs-system/vcpkg.json` | Added `testing` feature, bumped `port-version` 4 -> 5 |
| `vcpkg-ports/kcenon-pacs-system/portfile.cmake` | Added `testing` to `vcpkg_check_features`, removed hardcoded OFF |

## How

### Implementation Details
1. Added `testing` feature to the port `vcpkg.json` with `gtest` (with `gmock`) and `benchmark` dependencies
2. Mapped the `testing` feature to both `PACS_BUILD_TESTS` and `PACS_BUILD_BENCHMARKS` CMake options in `vcpkg_check_features`
3. Removed hardcoded `-DPACS_BUILD_TESTS=OFF` and `-DPACS_BUILD_BENCHMARKS=OFF` from `vcpkg_cmake_configure` so the feature toggle properly controls them
4. Incremented `port-version` from 4 to 5

### Testing
- When `testing` feature is not selected: `PACS_BUILD_TESTS=OFF` and `PACS_BUILD_BENCHMARKS=OFF` (vcpkg_check_features defaults to OFF)
- When `testing` feature is selected: both are set to `ON`, and gtest/benchmark are resolved as dependencies