### PR TITLE
chore(ci): adopt setup-vcpkg composite action for ecosystem CI standardization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,17 +112,21 @@ jobs:
 
     - name: Install dependencies with vcpkg (Unix)
       if: runner.os != 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
+      id: vcpkg_install_unix
+      continue-on-error: true
       run: |
         ${{ env.VCPKG_ROOT }}/vcpkg install --x-manifest-root=pacs_system --x-install-root=${{ github.workspace }}/pacs_system/vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Install dependencies with vcpkg (Windows)
       if: runner.os == 'Windows' && steps.vcpkg-installed.outputs.cache-hit != 'true'
+      id: vcpkg_install_windows
+      continue-on-error: true
       shell: pwsh
       run: |
         ${{ env.VCPKG_ROOT }}\vcpkg install --x-manifest-root=pacs_system --x-install-root=${{ github.workspace }}\pacs_system\vcpkg_installed --triplet ${{ matrix.triplet }}
 
     - name: Build application (vcpkg - Unix)
-      if: runner.os != 'Windows'
+      if: runner.os != 'Windows' && steps.vcpkg_install_unix.outcome != 'failure'
       id: build_vcpkg_unix
       continue-on-error: true
       working-directory: pacs_system
@@ -147,7 +151,7 @@ jobs:
         ctest --output-on-failure --timeout 120
 
     - name: Build application (vcpkg - Windows)
-      if: runner.os == 'Windows'
+      if: runner.os == 'Windows' && steps.vcpkg_install_windows.outcome != 'failure'
       id: build_vcpkg_windows
       continue-on-error: true
       working-directory: pacs_system
@@ -173,7 +177,7 @@ jobs:
         ctest -C Release --output-on-failure --timeout 120
 
     - name: Build application (fallback - Unix)
-      if: runner.os != 'Windows' && steps.build_vcpkg_unix.outcome != 'success'
+      if: runner.os != 'Windows' && (steps.vcpkg_install_unix.outcome == 'failure' || steps.build_vcpkg_unix.outcome != 'success')
       working-directory: pacs_system
       run: |
         echo "vcpkg build failed. Falling back to system libraries..."
@@ -196,7 +200,7 @@ jobs:
         ctest --output-on-failure --timeout 120 || echo "Some tests failed"
 
     - name: Build application (fallback - Windows)
-      if: runner.os == 'Windows' && steps.build_vcpkg_windows.outcome != 'success'
+      if: runner.os == 'Windows' && (steps.vcpkg_install_windows.outcome == 'failure' || steps.build_vcpkg_windows.outcome != 'success')
       working-directory: pacs_system
       shell: pwsh
       run: |


### PR DESCRIPTION
## Summary
- Replace Windows-only `lukka/run-vcpkg@v11` with the shared `kcenon/common_system/.github/actions/setup-vcpkg@main` composite action across all platforms (Linux, macOS, Windows)
- Add `vcpkg_installed` caching keyed by OS/compiler/triplet/manifest hash for faster CI runs
- Add `continue-on-error: true` on vcpkg builds with FetchContent/system-library fallback
- Preserve the existing `checkout-kcenon-deps` custom action for IEC 62304 SOUP traceability

## What changed
| Area | Before | After |
|------|--------|-------|
| vcpkg setup | `lukka/run-vcpkg@v11` (Windows only) | `kcenon/common_system/.github/actions/setup-vcpkg@main` (all platforms) |
| Matrix | No `triplet` field | `triplet` added (x64-linux, arm64-osx, x64-windows) |
| Build strategy | Single build path per platform | vcpkg-first with `continue-on-error`, fallback to system libs |
| Caching | No vcpkg_installed cache | Keyed by OS/compiler/triplet/manifest hash |
| Ecosystem deps | `checkout-kcenon-deps` action | Preserved alongside vcpkg |

## Test plan
- [ ] CI passes on all 4 matrix entries (Ubuntu GCC, Ubuntu Clang, macOS Clang, Windows MSVC)
- [ ] vcpkg install step resolves dependencies from manifest + custom registry
- [ ] Fallback path works if vcpkg build fails
- [ ] Existing `checkout-kcenon-deps` action still clones pinned ecosystem dependencies

Part of kcenon/common_system#517