### PR TITLE
chore(vcpkg): update registry baseline to be8ea07

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+      "baseline": "be8ea077c3f81070d481cb463e263400ff998b13",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Summary
Updates vcpkg-registry baseline to include container_system port fix.

Previous attempt (#1019) failed because the registry baseline included
FETCHCONTENT_FULLY_DISCONNECTED=ON in the container_system port, which
broke the vcpkg build. This was fixed in vcpkg-registry PR #43.

### Baseline change
`77cc46d5ba5e` → `be8ea077c3f8`

### Included registry changes
- Port file sync for all 8 ecosystem ports (PR #41)
- Versions DB and baseline.json fix (PR #42)
- Container system FETCHCONTENT_FULLY_DISCONNECTED removal (PR #43)

Part of kcenon/common_system#528

## Test Plan
- CI build should pass (container_system port build no longer fails)