### PR TITLE
chore(vcpkg): update registry baseline to 09b9ee3

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+      "baseline": "09b9ee36eb3edf530d8d9a0c41dbd7f61a427e2f",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Summary
Updates vcpkg-registry baseline with all container_system port fixes.

### Previous attempts
- #1019: Failed — FETCHCONTENT_FULLY_DISCONNECTED blocked dependency resolution
- #1020: Failed — vcpkg_cmake_config_fixup used snake_case path but v0.1.0 uses PascalCase

### Root cause resolved
container_system v0.1.0 installs CMake config to `lib/cmake/ContainerSystem` (PascalCase), but the synced portfile expected `lib/cmake/container_system` (snake_case). Fixed in vcpkg-registry PR #44.

### Baseline: `09b9ee36eb3e`
Includes:
- Port file sync for all 8 ecosystem ports (PR #41)
- Versions DB and baseline.json fix (PR #42)
- Container system FETCHCONTENT fix (PR #43)
- Container system config path fix for v0.1.0 (PR #44)

Part of kcenon/common_system#528

## Test Plan
- kcenon-container-system:x64-linux and arm64-osx should build successfully
- vcpkg_cmake_config_fixup should find lib/cmake/ContainerSystem