### PR TITLE
chore(vcpkg): update registry baseline to a4c373f

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "77cc46d5ba5e2aef1581f2ec674f83e1ac906b43",
+      "baseline": "a4c373f250627f3b8ec51909dea0a18682970dea",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Summary
Final baseline update with all port config path fixes resolved.

### Previous attempts
- #1019: container_system FETCHCONTENT failure
- #1020: container_system config path mismatch (PascalCase)
- #1021: network_system config path mismatch (PascalCase)

### All fixes included in baseline `a4c373f`
- PR #41: Port sync
- PR #42: Versions DB fix
- PR #43: Container FETCHCONTENT removal
- PR #44: Container config path (PascalCase)
- PR #45: Logger/database/network config paths (PascalCase)

Part of kcenon/common_system#528

## Test Plan
- All vcpkg port builds should succeed (PascalCase config paths match release tags)