### PR TITLE
feat(vcpkg): add CMake options for codecs/ssl/rest-api and complete portfile mapping

### DIFF
--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -69,6 +69,7 @@ if(PACS_BUILD_STORAGE)
     endif()
 endif()
 
+if(PACS_BUILD_CODECS)
 # libjpeg-turbo (for JPEG compression codecs)
 message(STATUS "")
 message(STATUS "=== Finding libjpeg-turbo (for JPEG compression) ===")
@@ -265,25 +266,40 @@ if(NOT PACS_HTJ2K_FOUND AND PACS_FETCH_OPENJPH)
             SYMBOLIC)
     endif()
 endif()
-
-# OpenSSL (for digital signatures - Issue #191)
-message(STATUS "")
-message(STATUS "=== Finding OpenSSL (for digital signatures) ===")
-
-find_package(OpenSSL QUIET)
-
-if(OpenSSL_FOUND)
-    message(STATUS "Found system OpenSSL: ${OPENSSL_VERSION}")
-    set(PACS_OPENSSL_FOUND TRUE)
 else()
-    message(WARNING
-        "OpenSSL not found!\n"
-        "Digital signature features will be disabled.\n"
-        "\n"
-        "To enable digital signatures, install OpenSSL:\n"
-        "  - Ubuntu: sudo apt install libssl-dev\n"
-        "  - macOS: brew install openssl@3\n"
-        "  - Windows: vcpkg install openssl:x64-windows")
+    message(STATUS "")
+    message(STATUS "=== Image codecs disabled (PACS_BUILD_CODECS=OFF) ===")
+    set(PACS_JPEG_FOUND FALSE)
+    set(PACS_PNG_FOUND FALSE)
+    set(PACS_JPEG2000_FOUND FALSE)
+    set(PACS_JPEGLS_FOUND FALSE)
+    set(PACS_HTJ2K_FOUND FALSE)
+endif()
+
+if(PACS_WITH_OPENSSL)
+    # OpenSSL (for digital signatures - Issue #191)
+    message(STATUS "")
+    message(STATUS "=== Finding OpenSSL (for digital signatures) ===")
+
+    find_package(OpenSSL QUIET)
+
+    if(OpenSSL_FOUND)
+        message(STATUS "Found system OpenSSL: ${OPENSSL_VERSION}")
+        set(PACS_OPENSSL_FOUND TRUE)
+    else()
+        message(WARNING
+            "OpenSSL not found!\n"
+            "Digital signature features will be disabled.\n"
+            "\n"
+            "To enable digital signatures, install OpenSSL:\n"
+            "  - Ubuntu: sudo apt install libssl-dev\n"
+            "  - macOS: brew install openssl@3\n"
+            "  - Windows: vcpkg install openssl:x64-windows")
+        set(PACS_OPENSSL_FOUND FALSE)
+    endif()
+else()
+    message(STATUS "")
+    message(STATUS "=== OpenSSL disabled (PACS_WITH_OPENSSL=OFF) ===")
     set(PACS_OPENSSL_FOUND FALSE)
 endif()
 
@@ -717,53 +733,58 @@ if(PACS_WITH_NETWORK_SYSTEM)
     endif()
 endif()
 
-# Crow Web Framework (for REST API - Issue #194)
-message(STATUS "")
-option(PACS_FETCH_CROW "Fetch Crow web framework via FetchContent (disable for vcpkg builds)" ON)
+if(PACS_WITH_REST_API)
+    # Crow Web Framework (for REST API - Issue #194)
+    message(STATUS "")
+    option(PACS_FETCH_CROW "Fetch Crow web framework via FetchContent (disable for vcpkg builds)" ON)
 
-if(PACS_FETCH_CROW)
-    message(STATUS "=== Fetching Crow Web Framework (for REST API) ===")
+    if(PACS_FETCH_CROW)
+        message(STATUS "=== Fetching Crow Web Framework (for REST API) ===")
 
-    # Crow requires Asio. The network_system already fetched standalone ASIO.
-    # Point Crow to use the same ASIO headers.
-    if(DEFINED CACHE{network_system_asio_SOURCE_DIR})
-        set(ASIO_INCLUDE_DIR "${network_system_asio_SOURCE_DIR}/asio/include" CACHE PATH "" FORCE)
-        message(STATUS "  Using ASIO from network_system: ${ASIO_INCLUDE_DIR}")
-    elseif(EXISTS "${CMAKE_BINARY_DIR}/_deps/network_system_asio-src/asio/include")
-        set(ASIO_INCLUDE_DIR "${CMAKE_BINARY_DIR}/_deps/network_system_asio-src/asio/include" CACHE PATH "" FORCE)
-        message(STATUS "  Using ASIO from build deps: ${ASIO_INCLUDE_DIR}")
-    else()
-        # Fallback: fetch standalone ASIO for Crow
-        message(STATUS "  Fetching standalone ASIO for Crow...")
+        # Crow requires Asio. The network_system already fetched standalone ASIO.
+        # Point Crow to use the same ASIO headers.
+        if(DEFINED CACHE{network_system_asio_SOURCE_DIR})
+            set(ASIO_INCLUDE_DIR "${network_system_asio_SOURCE_DIR}/asio/include" CACHE PATH "" FORCE)
+            message(STATUS "  Using ASIO from network_system: ${ASIO_INCLUDE_DIR}")
+        elseif(EXISTS "${CMAKE_BINARY_DIR}/_deps/network_system_asio-src/asio/include")
+            set(ASIO_INCLUDE_DIR "${CMAKE_BINARY_DIR}/_deps/network_system_asio-src/asio/include" CACHE PATH "" FORCE)
+            message(STATUS "  Using ASIO from build deps: ${ASIO_INCLUDE_DIR}")
+        else()
+            # Fallback: fetch standalone ASIO for Crow
+            message(STATUS "  Fetching standalone ASIO for Crow...")
+            FetchContent_Declare(
+                asio
+                GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
+                GIT_TAG asio-1-30-2
+                GIT_SHALLOW TRUE
+            )
+            FetchContent_MakeAvailable(asio)
+            set(ASIO_INCLUDE_DIR "${asio_SOURCE_DIR}/asio/include" CACHE PATH "" FORCE)
+        endif()
+
         FetchContent_Declare(
-            asio
-            GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
-            GIT_TAG asio-1-30-2
+            Crow
+            GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
+            GIT_TAG v1.3.1  # Pinned release; compatible with ASIO 1.30+ io_context (IEC 62304 §8.1.2)
             GIT_SHALLOW TRUE
         )
-        FetchContent_MakeAvailable(asio)
-        set(ASIO_INCLUDE_DIR "${asio_SOURCE_DIR}/asio/include" CACHE PATH "" FORCE)
-    endif()
-
-    FetchContent_Declare(
-        Crow
-        GIT_REPOSITORY https://github.com/CrowCpp/Crow.git
-        GIT_TAG v1.3.1  # Pinned release; compatible with ASIO 1.30+ io_context (IEC 62304 §8.1.2)
-        GIT_SHALLOW TRUE
-    )
-    set(CROW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
-    set(CROW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
-    set(CROW_ENABLE_SSL OFF CACHE BOOL "" FORCE)
-    set(CROW_ENABLE_COMPRESSION OFF CACHE BOOL "" FORCE)
-    FetchContent_MakeAvailable(Crow)
-    message(STATUS "  [OK] Crow (v1.3.1) fetched")
-else()
-    find_package(Crow CONFIG QUIET)
-    if(Crow_FOUND)
-        message(STATUS "  [OK] Crow found via find_package")
+        set(CROW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
+        set(CROW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
+        set(CROW_ENABLE_SSL OFF CACHE BOOL "" FORCE)
+        set(CROW_ENABLE_COMPRESSION OFF CACHE BOOL "" FORCE)
+        FetchContent_MakeAvailable(Crow)
+        message(STATUS "  [OK] Crow (v1.3.1) fetched")
     else()
-        message(STATUS "  [SKIP] Crow not found and PACS_FETCH_CROW=OFF")
+        find_package(Crow CONFIG QUIET)
+        if(Crow_FOUND)
+            message(STATUS "  [OK] Crow found via find_package")
+        else()
+            message(STATUS "  [SKIP] Crow not found and PACS_FETCH_CROW=OFF")
+        endif()
     endif()
+else()
+    message(STATUS "")
+    message(STATUS "=== REST API disabled (PACS_WITH_REST_API=OFF) ===")
 endif()
 
 ##################################################

--- a/cmake/options.cmake
+++ b/cmake/options.cmake
@@ -38,6 +38,9 @@ option(PACS_WITH_AZURE_SDK "Enable Azure SDK integration for Blob storage" OFF)
 option(PACS_USE_MOCK_S3 "Use mock S3 client instead of AWS SDK (testing only)" OFF)
 option(PACS_WARNINGS_AS_ERRORS "Treat warnings as errors (disable in CI if dependency warnings occur)" ON)
 option(PACS_BUILD_MODULES "Build C++20 module version of pacs_system" OFF)
+option(PACS_BUILD_CODECS "Enable image compression codecs (JPEG, PNG, JPEG2000, JPEG-LS, HTJ2K)" ON)
+option(PACS_WITH_OPENSSL "Enable OpenSSL for digital signatures and TLS" ON)
+option(PACS_WITH_REST_API "Enable DICOMweb REST API via Crow HTTP framework" ON)
 
 # Prevent mock S3 from being used in Release builds
 if(PACS_USE_MOCK_S3 AND CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/vcpkg-ports/kcenon-pacs-system/portfile.cmake
+++ b/vcpkg-ports/kcenon-pacs-system/portfile.cmake
@@ -11,11 +11,14 @@ vcpkg_from_github(
 
 vcpkg_check_features(OUT_FEATURE_OPTIONS FEATURE_OPTIONS
     FEATURES
-        storage  PACS_BUILD_STORAGE
-        aws      PACS_WITH_AWS_SDK
-        azure    PACS_WITH_AZURE_SDK
-        testing  PACS_BUILD_TESTS
-        testing  PACS_BUILD_BENCHMARKS
+        storage   PACS_BUILD_STORAGE
+        codecs    PACS_BUILD_CODECS
+        ssl       PACS_WITH_OPENSSL
+        rest-api  PACS_WITH_REST_API
+        aws       PACS_WITH_AWS_SDK
+        azure     PACS_WITH_AZURE_SDK
+        testing   PACS_BUILD_TESTS
+        testing   PACS_BUILD_BENCHMARKS
 )
 
 vcpkg_cmake_configure(

--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version-semver": "0.1.0",
-  "port-version": 5,
+  "port-version": 6,
   "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",
@@ -10,6 +10,8 @@
     "kcenon-common-system",
     "kcenon-container-system",
     "kcenon-network-system",
+    "kcenon-thread-system",
+    "icu",
     {
       "name": "vcpkg-cmake",
       "host": true


### PR DESCRIPTION
## Summary
- Add 3 explicit CMake options (`PACS_BUILD_CODECS`, `PACS_WITH_OPENSSL`, `PACS_WITH_REST_API`) to gate optional feature detection
- Complete `vcpkg_check_features` mapping for all 8 features in portfile
- Add `icu` and `kcenon-thread-system` as explicit base dependencies (previously only transitive)
- Default behavior unchanged — all new options default to ON

## Test plan
- [ ] `cmake -DPACS_BUILD_CODECS=OFF` skips all codec detection
- [ ] `cmake -DPACS_WITH_OPENSSL=OFF` skips OpenSSL detection
- [ ] `cmake -DPACS_WITH_REST_API=OFF` skips Crow detection
- [ ] Default build (all ON) works identically to before
- [ ] `vcpkg install kcenon-pacs-system[codecs,ssl,rest-api]` builds with all features

Closes #1025
Closes #1026