### PR TITLE
chore(vcpkg): add thread-system to root manifest dependencies

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -11,6 +11,7 @@
     "kcenon-common-system",
     "kcenon-container-system",
     "kcenon-network-system",
+    "kcenon-thread-system",
     "icu"
   ],
   "overrides": [


### PR DESCRIPTION
## What

### Summary
Add `kcenon-thread-system` to root `vcpkg.json` dependencies to match port manifest.

### Change Type
- [x] Chore (dependency metadata alignment)

## Why

### Related Issues
- Closes #1029

### Motivation
Root vcpkg.json is missing `kcenon-thread-system` which is required for `thread_pool_adapter` (cmake/dependencies.cmake marks it REQUIRED). Port manifest already declares it correctly.

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg.json` | Add `kcenon-thread-system` to `dependencies` array |

## How

### Implementation
Added `"kcenon-thread-system"` string to the `dependencies` array between `kcenon-network-system` and `icu`.

### Testing Done
- [x] JSON validation (syntax check)
- [x] CI passes on all platforms

### Breaking Changes
None