### PR TITLE
chore(deps): update vcpkg-registry baseline to latest

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "a4c373f250627f3b8ec51909dea0a18682970dea",
+      "baseline": "50d89f5b1962e811dfb779bc46fa3d251db42ce7",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Summary

Update vcpkg-registry baseline in `vcpkg-configuration.json` to latest HEAD
(`50d89f5b1962e811dfb779bc46fa3d251db42ce7`).

## Why

Registry baselines drifted across ecosystem repos. 7 repos used `5716e4f`,
pacs_system used `a4c373f`, and the latest HEAD is `50d89f5`. This update
aligns all repos to the same baseline.

## Related

- Part of kcenon/common_system#545
- Part of kcenon/common_system#541 (Ecosystem vcpkg Registry Sync Automation)

## Test Plan

- CI build passes with updated baseline