### PR TITLE
chore(vcpkg): sync root manifest port-version and add local usage file

### DIFF
--- a/vcpkg-ports/kcenon-pacs-system/usage
+++ b/vcpkg-ports/kcenon-pacs-system/usage
@@ -1,0 +1,13 @@
+The package kcenon-pacs-system provides CMake targets:
+
+    find_package(pacs_system CONFIG REQUIRED)
+    target_link_libraries(main PRIVATE
+        pacs_system::core
+        pacs_system::encoding
+        pacs_system::network
+        pacs_system::client
+        pacs_system::services
+        pacs_system::security
+    )
+
+Available features: storage, codecs, ssl, aws, azure, rest-api

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg-tool/main/docs/vcpkg.schema.json",
   "name": "kcenon-pacs-system",
   "version-semver": "0.1.0",
-  "port-version": 0,
+  "port-version": 6,
   "description": "Modern C++20 PACS implementation for DICOM medical imaging",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",


### PR DESCRIPTION
## Summary
- Sync root `vcpkg.json` port-version from 0 to 6
- Add missing `usage` file to local port directory

## Related
- Closes #1040

## Test plan
- [ ] Verify root vcpkg.json port-version matches port definition
- [ ] Verify usage file is present