### PR TITLE
fix(readme): add explicit coverage percentage to README badge section

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 | **Phase 3**: Core Services | Storage SCP/SCU, File Storage, Index Database, Query/Retrieve, Logging, Monitoring | ✅ Complete |
 | **Phase 4**: Advanced Services | REST API, DICOMweb, AI Integration, Client Module, Cloud Storage, Print Management, Security, Workflow, Annotation/Viewer | ✅ Complete |
 
-**Test Coverage**: 1,980+ tests passing across 141+ test files
+**Test Coverage**: 1,980+ tests passing across 141+ test files | [![codecov](https://codecov.io/gh/kcenon/pacs_system/branch/main/graph/badge.svg)](https://codecov.io/gh/kcenon/pacs_system)
 
 > For detailed feature lists per phase, see [Features](docs/FEATURES.md).
 


### PR DESCRIPTION
Closes #1043

## Summary
- Added inline codecov badge next to the Test Coverage line in the Project Status section
- Makes the coverage percentage directly visible to users and contributors alongside the test count
- Follows the same pattern used in other ecosystem modules (thread_system, common_system)

## Test Plan
- Verify the codecov badge renders correctly in the README on the PR preview
- Confirm the badge links to the correct codecov dashboard for pacs_system
- No code changes; README-only update