### PR TITLE
docs: add YAML frontmatter to all docs/ markdown files

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-API-001"
+doc_title: "API 참조 - PACS 시스템"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "API"
+---
+
 # API 참조 - PACS 시스템
 
 > **버전:** 0.1.4.0

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-API-002"
+doc_title: "API Reference - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "API"
+---
+
 # API Reference - PACS System
 
 > **Version:** 0.1.5.0

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-ARCH-001"
+doc_title: "아키텍처 문서 - PACS 시스템"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "ARCH"
+---
+
 # 아키텍처 문서 - PACS 시스템
 
 > **버전:** 0.1.4.0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-ARCH-002"
+doc_title: "Architecture Documentation - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "ARCH"
+---
+
 # Architecture Documentation - PACS System
 
 > **Version:** 0.1.4.0

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PERF-001"
+doc_title: "PACS System 성능 벤치마크"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PERF"
+---
+
 # PACS System 성능 벤치마크
 
 > **언어:** [English](BENCHMARKS.md) | **한국어**

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PERF-002"
+doc_title: "PACS System Performance Benchmarks"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PERF"
+---
+
 # PACS System Performance Benchmarks
 
 > **Language:** **English** | [한국어](BENCHMARKS.kr.md)

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PROJ-001"
+doc_title: "변경 이력 - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PROJ"
+---
+
 # 변경 이력 - PACS System
 
 > **언어:** [English](CHANGELOG.md) | **한국어**

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PROJ-002"
+doc_title: "Changelog - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PROJ"
+---
+
 # Changelog - PACS System
 
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)

--- a/docs/CLI_REFERENCE.kr.md
+++ b/docs/CLI_REFERENCE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-API-003"
+doc_title: "CLI 레퍼런스"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "API"
+---
+
 # CLI 레퍼런스
 
 > **언어:** [English](CLI_REFERENCE.md) | **한국어**

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-API-004"
+doc_title: "CLI Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "API"
+---
+
 # CLI Reference
 
 > **Language:** **English** | [한국어](CLI_REFERENCE.kr.md)

--- a/docs/DICOM_CONFORMANCE_STATEMENT.md
+++ b/docs/DICOM_CONFORMANCE_STATEMENT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-INTR-001"
+doc_title: "DICOM Conformance Statement"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "INTR"
+---
+
 # DICOM Conformance Statement
 
 ## PACS System

--- a/docs/DOCUMENTATION_STATISTICS.md
+++ b/docs/DOCUMENTATION_STATISTICS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PROJ-003"
+doc_title: "Documentation Statistics Automation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PROJ"
+---
+
 # Documentation Statistics Automation
 
 This document describes the automated documentation statistics system that keeps README.md metrics in sync with actual codebase measurements.

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-FEAT-001"
+doc_title: "PACS 시스템 기능"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "FEAT"
+---
+
 # PACS 시스템 기능
 
 > **버전:** 0.2.0.0

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-FEAT-002"
+doc_title: "PACS System Features"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "FEAT"
+---
+
 # PACS System Features
 
 > **Version:** 0.2.0.0

--- a/docs/IHE_INTEGRATION_STATEMENT.md
+++ b/docs/IHE_INTEGRATION_STATEMENT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-INTR-002"
+doc_title: "IHE Integration Statement"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "INTR"
+---
+
 # IHE Integration Statement
 
 ## PACS System

--- a/docs/MIGRATION_COMPLETE.kr.md
+++ b/docs/MIGRATION_COMPLETE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-MIGR-001"
+doc_title: "스레드 시스템 마이그레이션 완료"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "MIGR"
+---
+
 # 스레드 시스템 마이그레이션 완료
 
 **버전:** 0.1.0.0

--- a/docs/MIGRATION_COMPLETE.md
+++ b/docs/MIGRATION_COMPLETE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-MIGR-002"
+doc_title: "Thread System Migration Complete"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "MIGR"
+---
+
 # Thread System Migration Complete
 
 **Version:** 0.1.0.0

--- a/docs/PACS_IMPLEMENTATION_ANALYSIS.kr.md
+++ b/docs/PACS_IMPLEMENTATION_ANALYSIS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-001"
+doc_title: "PACS 시스템 구현 분석"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # PACS 시스템 구현 분석
 
 > **언어:** [English](PACS_IMPLEMENTATION_ANALYSIS.md) | **한국어**

--- a/docs/PACS_IMPLEMENTATION_ANALYSIS.md
+++ b/docs/PACS_IMPLEMENTATION_ANALYSIS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-002"
+doc_title: "PACS System Implementation Analysis"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # PACS System Implementation Analysis
 
 > **Language:** **English** | [한국어](PACS_IMPLEMENTATION_ANALYSIS.kr.md)

--- a/docs/PERFORMANCE_BASELINE.md
+++ b/docs/PERFORMANCE_BASELINE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PERF-003"
+doc_title: "Performance Baseline for Thread Migration"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PERF"
+---
+
 # Performance Baseline for Thread Migration
 
 **Version:** 0.1.0.0

--- a/docs/PERFORMANCE_RESULTS.md
+++ b/docs/PERFORMANCE_RESULTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PERF-004"
+doc_title: "Performance Results After Thread Migration"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PERF"
+---
+
 # Performance Results After Thread Migration
 
 **Version:** 0.1.0.0

--- a/docs/PIPELINE_DESIGN.md
+++ b/docs/PIPELINE_DESIGN.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-ARCH-003"
+doc_title: "Pipeline Design Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "ARCH"
+---
+
 # Pipeline Design Documentation
 
 **Version:** 1.0.0

--- a/docs/PRD.kr.md
+++ b/docs/PRD.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-003"
+doc_title: "제품 요구사항 정의서 - PACS 시스템"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # 제품 요구사항 정의서 - PACS 시스템
 
 > **버전:** 0.2.0.0

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-004"
+doc_title: "Product Requirements Document - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # Product Requirements Document - PACS System
 
 > **Version:** 0.2.0.0

--- a/docs/PREFETCH_QUEUE_ANALYSIS.md
+++ b/docs/PREFETCH_QUEUE_ANALYSIS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-005"
+doc_title: "Prefetch Queue Lock-free Analysis Report"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # Prefetch Queue Lock-free Analysis Report
 
 ## Issue Reference

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-QUAL-001"
+doc_title: "PACS System 프로덕션 품질"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "QUAL"
+---
+
 # PACS System 프로덕션 품질
 
 > **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-QUAL-002"
+doc_title: "PACS System Production Quality"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "QUAL"
+---
+
 # PACS System Production Quality
 
 > **Language:** **English** | [한국어](PRODUCTION_QUALITY.kr.md)

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PROJ-004"
+doc_title: "프로젝트 구조 - PACS 시스템"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PROJ"
+---
+
 # 프로젝트 구조 - PACS 시스템
 
 > **버전:** 0.1.3.0

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PROJ-005"
+doc_title: "Project Structure - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PROJ"
+---
+
 # Project Structure - PACS System
 
 > **Version:** 0.1.3.0

--- a/docs/SDS.kr.md
+++ b/docs/SDS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-006"
+doc_title: "소프트웨어 설계 명세서 (SDS) - PACS 시스템"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # 소프트웨어 설계 명세서 (SDS) - PACS 시스템
 
 > **버전:** 0.2.0

--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-007"
+doc_title: "Software Design Specification (SDS) - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # Software Design Specification (SDS) - PACS System
 
 > **Version:** 0.2.0

--- a/docs/SDS_AI.md
+++ b/docs/SDS_AI.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-008"
+doc_title: "SDS - AI Service Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - AI Service Module
 
 > **Version:** 2.0.0

--- a/docs/SDS_CLIENT.md
+++ b/docs/SDS_CLIENT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-009"
+doc_title: "SDS - Client Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Client Module
 
 > **Version:** 1.0.0

--- a/docs/SDS_CLOUD_STORAGE.md
+++ b/docs/SDS_CLOUD_STORAGE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-010"
+doc_title: "SDS - Cloud Storage Backends Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Cloud Storage Backends Module
 
 > **Version:** 1.0.0

--- a/docs/SDS_COMPONENTS.kr.md
+++ b/docs/SDS_COMPONENTS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-011"
+doc_title: "SDS - 컴포넌트 설계 명세"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - 컴포넌트 설계 명세
 
 > **버전:** 0.1.2

--- a/docs/SDS_COMPONENTS.md
+++ b/docs/SDS_COMPONENTS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-012"
+doc_title: "SDS - Component Design Specifications"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Component Design Specifications
 
 > **Version:** 0.2.0

--- a/docs/SDS_COMPRESSION.md
+++ b/docs/SDS_COMPRESSION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-013"
+doc_title: "SDS - Compression Codecs Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Compression Codecs Module
 
 > **Version:** 1.0.0

--- a/docs/SDS_DATABASE.kr.md
+++ b/docs/SDS_DATABASE.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-014"
+doc_title: "SDS - 데이터베이스 설계"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - 데이터베이스 설계
 
 > **버전:** 0.1.1

--- a/docs/SDS_DATABASE.md
+++ b/docs/SDS_DATABASE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-015"
+doc_title: "SDS - Database Design"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Database Design
 
 > **Version:** 0.2.0

--- a/docs/SDS_DI.md
+++ b/docs/SDS_DI.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-016"
+doc_title: "SDS - Dependency Injection Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Dependency Injection Module
 
 > **Version:** 1.1.0

--- a/docs/SDS_INTERFACES.kr.md
+++ b/docs/SDS_INTERFACES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-017"
+doc_title: "SDS - 인터페이스 명세서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - 인터페이스 명세서
 
 > **버전:** 0.1.2

--- a/docs/SDS_INTERFACES.md
+++ b/docs/SDS_INTERFACES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-018"
+doc_title: "SDS - Interface Specifications"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Interface Specifications
 
 > **Version:** 0.1.3

--- a/docs/SDS_MONITORING_COLLECTORS.md
+++ b/docs/SDS_MONITORING_COLLECTORS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-019"
+doc_title: "SDS - Monitoring Collectors Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Monitoring Collectors Module
 
 > **Version:** 2.1.0

--- a/docs/SDS_NETWORK_V2.md
+++ b/docs/SDS_NETWORK_V2.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-020"
+doc_title: "SDS - Network V2 Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Network V2 Module
 
 > **Version:** 2.0.0

--- a/docs/SDS_SECURITY.md
+++ b/docs/SDS_SECURITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-SECU-001"
+doc_title: "SDS - Security Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "SECU"
+---
+
 # SDS - Security Module
 
 > **Version:** 1.0.0

--- a/docs/SDS_SEQUENCES.kr.md
+++ b/docs/SDS_SEQUENCES.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-021"
+doc_title: "SDS - 시퀀스 다이어그램"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - 시퀀스 다이어그램
 
 > **버전:** 0.1.1

--- a/docs/SDS_SEQUENCES.md
+++ b/docs/SDS_SEQUENCES.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-022"
+doc_title: "SDS - Sequence Diagrams"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Sequence Diagrams
 
 > **Version:** 0.1.1

--- a/docs/SDS_SERVICES_CACHE.md
+++ b/docs/SDS_SERVICES_CACHE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-023"
+doc_title: "SDS - Services Cache Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Services Cache Module
 
 > **Version:** 1.1.0

--- a/docs/SDS_TRACEABILITY.kr.md
+++ b/docs/SDS_TRACEABILITY.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-024"
+doc_title: "SDS - 요구사항 추적성 매트릭스"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - 요구사항 추적성 매트릭스
 
 > **버전:** 0.1.3

--- a/docs/SDS_TRACEABILITY.md
+++ b/docs/SDS_TRACEABILITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-025"
+doc_title: "SDS - Requirements Traceability Matrix"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Requirements Traceability Matrix
 
 > **Version:** 3.0.0

--- a/docs/SDS_WEB_API.md
+++ b/docs/SDS_WEB_API.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-026"
+doc_title: "SDS - Web/REST API Module Design Specification"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Web/REST API Module Design Specification
 
 > **Version:** 2.0.0

--- a/docs/SDS_WORKFLOW.md
+++ b/docs/SDS_WORKFLOW.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-027"
+doc_title: "SDS - Workflow Module"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # SDS - Workflow Module
 
 > **Version:** 1.0.0

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-SECU-002"
+doc_title: "Security Module Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "SECU"
+---
+
 # Security Module Documentation
 
 > **Version:** 0.1.1.0

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PROJ-006"
+doc_title: "SOUP List &mdash; pacs_system"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PROJ"
+---
+
 # SOUP List &mdash; pacs_system
 
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**

--- a/docs/SRS.kr.md
+++ b/docs/SRS.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-028"
+doc_title: "소프트웨어 요구사항 명세서 - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # 소프트웨어 요구사항 명세서 - PACS System
 
 > **버전:** 0.1.3.2

--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-029"
+doc_title: "Software Requirements Specification - PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # Software Requirements Specification - PACS System
 
 > **Version:** 0.1.3.2

--- a/docs/THREAD_POOL_MIGRATION.md
+++ b/docs/THREAD_POOL_MIGRATION.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-MIGR-003"
+doc_title: "Thread Pool Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "MIGR"
+---
+
 # Thread Pool Migration Guide
 
 This guide explains how to migrate from the deprecated `thread_adapter` singleton pattern to the new `thread_pool_adapter` with dependency injection.

--- a/docs/THREAD_SYSTEM_STABILITY_REPORT.md
+++ b/docs/THREAD_SYSTEM_STABILITY_REPORT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-QUAL-003"
+doc_title: "Thread System Stability Verification Report"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "QUAL"
+---
+
 # Thread System Stability Verification Report
 
 **Issue**: #155 - Verify thread_system stability and jthread support

--- a/docs/VALIDATION_REPORT.kr.md
+++ b/docs/VALIDATION_REPORT.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-QUAL-004"
+doc_title: "PACS 시스템 검증 보고서 (Validation Report)"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "QUAL"
+---
+
 # PACS 시스템 검증 보고서 (Validation Report)
 
 > **보고서 버전:** 0.1.3.0

--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-QUAL-005"
+doc_title: "PACS System Validation Report"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "QUAL"
+---
+
 # PACS System Validation Report
 
 > **Report Version:** 0.1.3.0

--- a/docs/VERIFICATION_REPORT.kr.md
+++ b/docs/VERIFICATION_REPORT.kr.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-QUAL-006"
+doc_title: "PACS 시스템 검증 보고서"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "QUAL"
+---
+
 # PACS 시스템 검증 보고서
 
 > **보고서 버전:** 0.1.6.0

--- a/docs/VERIFICATION_REPORT.md
+++ b/docs/VERIFICATION_REPORT.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-QUAL-007"
+doc_title: "PACS System Verification Report"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "QUAL"
+---
+
 # PACS System Verification Report
 
 > **Report Version:** 0.1.6.1

--- a/docs/adr/ADR-001-database-system-integration.md
+++ b/docs/adr/ADR-001-database-system-integration.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-ADR-001"
+doc_title: "ADR-001: Integrate database_system for Database Abstraction"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "ADR"
+---
+
 # ADR-001: Integrate database_system for Database Abstraction
 
 > **Status:** Accepted

--- a/docs/adr/ADR-002-pacs-storage-port-segmentation.md
+++ b/docs/adr/ADR-002-pacs-storage-port-segmentation.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-ADR-002"
+doc_title: "ADR-002: Define PACS Storage Port Segmentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "ADR"
+---
+
 # ADR-002: Define PACS Storage Port Segmentation
 
 > **Status:** Accepted

--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-030"
+doc_title: "PACS System Advanced Topics"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # PACS System Advanced Topics
 
 This directory contains advanced documentation for PACS System covering detailed design specifications and specialized topics.

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PROJ-007"
+doc_title: "Contributing to PACS System"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PROJ"
+---
+
 # Contributing to PACS System
 
 **Version:** 0.1.0.0

--- a/docs/database/API_REFERENCE.md
+++ b/docs/database/API_REFERENCE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-API-005"
+doc_title: "database_system API Reference"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "API"
+---
+
 # database_system API Reference
 
 > **Version:** 1.0.0

--- a/docs/database/MIGRATION_GUIDE.md
+++ b/docs/database/MIGRATION_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-MIGR-004"
+doc_title: "database_system Migration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "MIGR"
+---
+
 # database_system Migration Guide
 
 > **Version:** 1.0.1

--- a/docs/database/PERFORMANCE_GUIDE.md
+++ b/docs/database/PERFORMANCE_GUIDE.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-PERF-005"
+doc_title: "database_system Performance Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "PERF"
+---
+
 # database_system Performance Guide
 
 > **Version:** 1.0.0

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,13 @@
 ---
-layout: default
-title: Home
-nav_order: 1
+doc_id: "PAC-GUID-031"
+doc_title: "PACS System Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
 ---
+
 
 # PACS System Documentation
 

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-032"
+doc_title: "PACS System Integration Guide"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # PACS System Integration Guide
 
 This directory contains integration documentation for using PACS System with the kcenon ecosystem and external systems.

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -1,3 +1,13 @@
+---
+doc_id: "PAC-GUID-033"
+doc_title: "PACS System Performance Documentation"
+doc_version: "1.0.0"
+doc_date: "2026-04-04"
+doc_status: "Released"
+project: "pacs_system"
+category: "GUID"
+---
+
 # PACS System Performance Documentation
 
 This directory contains performance-related documentation for PACS System.


### PR DESCRIPTION
Part of kcenon/common_system#562

## Summary
- Add standardized YAML frontmatter metadata to 72 markdown files in `docs/`
- Each file gets a unique `doc_id` (`PAC-{CATEGORY}-{NNN}`), title, version, date, status, project, and category
- Existing Jekyll frontmatter in `docs/index.md` replaced with standardized schema

## Category Breakdown (72 files)
| Category | Count | Description |
|----------|-------|-------------|
| ADR | 2 | Decision Records |
| API | 5 | API Reference |
| ARCH | 3 | Architecture |
| FEAT | 2 | Features |
| GUID | 33 | User Guides |
| INTR | 2 | Integration |
| MIGR | 4 | Migration |
| PERF | 5 | Performance |
| PROJ | 7 | Project Info |
| QUAL | 7 | Quality |
| SECU | 2 | Security |

## Test Plan
- [x] Script runs idempotently (re-running skips all files)
- [x] No duplicate doc_id values
- [x] Existing document content unchanged (frontmatter prepended only)