### PR TITLE
docs: add SSOT documentation registry

### DIFF
--- a/docs/API_REFERENCE.kr.md
+++ b/docs/API_REFERENCE.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # API 참조 - PACS 시스템
 
+> **SSOT**: This document is the single source of truth for **API 참조 - PACS 시스템**.
+
 > **버전:** 0.1.4.0
 > **최종 수정일:** 2025-12-08
 > **언어:** [English](API_REFERENCE.md) | **한국어**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # API Reference - PACS System
 
+> **SSOT**: This document is the single source of truth for **API Reference - PACS System**.
+
 > **Version:** 0.1.5.0
 > **Last Updated:** 2025-12-13
 > **Language:** **English** | [한국어](API_REFERENCE.kr.md)

--- a/docs/ARCHITECTURE.kr.md
+++ b/docs/ARCHITECTURE.kr.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # 아키텍처 문서 - PACS 시스템
 
+> **SSOT**: This document is the single source of truth for **아키텍처 문서 - PACS 시스템**.
+
 > **버전:** 0.1.4.0
 > **최종 수정일:** 2026-02-09
 > **언어:** [English](ARCHITECTURE.md) | **한국어**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Architecture Documentation - PACS System
 
+> **SSOT**: This document is the single source of truth for **Architecture Documentation - PACS System**.
+
 > **Version:** 0.1.4.0
 > **Last Updated:** 2026-02-09
 > **Language:** **English** | [한국어](ARCHITECTURE.kr.md)

--- a/docs/BENCHMARKS.kr.md
+++ b/docs/BENCHMARKS.kr.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # PACS System 성능 벤치마크
 
+> **SSOT**: This document is the single source of truth for **PACS System 성능 벤치마크**.
+
 > **언어:** [English](BENCHMARKS.md) | **한국어**
 
 **최종 업데이트**: 2026-03-18

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # PACS System Performance Benchmarks
 
+> **SSOT**: This document is the single source of truth for **PACS System Performance Benchmarks**.
+
 > **Language:** **English** | [한국어](BENCHMARKS.kr.md)
 
 **Last Updated**: 2026-03-18

--- a/docs/CHANGELOG.kr.md
+++ b/docs/CHANGELOG.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # 변경 이력 - PACS System
 
+> **SSOT**: This document is the single source of truth for **변경 이력 - PACS System**.
+
 > **언어:** [English](CHANGELOG.md) | **한국어**
 
 PACS System 프로젝트의 모든 주요 변경 사항이 이 파일에 문서화됩니다.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Changelog - PACS System
 
+> **SSOT**: This document is the single source of truth for **Changelog - PACS System**.
+
 > **Language:** **English** | [한국어](CHANGELOG.kr.md)
 
 All notable changes to the PACS System project will be documented in this file.

--- a/docs/CLI_REFERENCE.kr.md
+++ b/docs/CLI_REFERENCE.kr.md
@@ -10,6 +10,8 @@ category: "API"
 
 # CLI 레퍼런스
 
+> **SSOT**: This document is the single source of truth for **CLI 레퍼런스**.
+
 > **언어:** [English](CLI_REFERENCE.md) | **한국어**
 
 PACS System에 포함된 32개 CLI 도구의 전체 문서입니다. 간단한 개요는 [README](../README.kr.md#cli-도구--예제)를 참조하세요.

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # CLI Reference
 
+> **SSOT**: This document is the single source of truth for **CLI Reference**.
+
 > **Language:** **English** | [한국어](CLI_REFERENCE.kr.md)
 
 Complete documentation for all 32 CLI tools included in the PACS System. For a quick overview, see the [README](../README.md#cli-tools--examples).

--- a/docs/DICOM_CONFORMANCE_STATEMENT.md
+++ b/docs/DICOM_CONFORMANCE_STATEMENT.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # DICOM Conformance Statement
 
+> **SSOT**: This document is the single source of truth for **DICOM Conformance Statement**.
+
 ## PACS System
 
 **Implementation Name**: PACS_SYSTEM_001

--- a/docs/DOCUMENTATION_STATISTICS.md
+++ b/docs/DOCUMENTATION_STATISTICS.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Documentation Statistics Automation
 
+> **SSOT**: This document is the single source of truth for **Documentation Statistics Automation**.
+
 This document describes the automated documentation statistics system that keeps README.md metrics in sync with actual codebase measurements.
 
 ## Overview

--- a/docs/FEATURES.kr.md
+++ b/docs/FEATURES.kr.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # PACS 시스템 기능
 
+> **SSOT**: This document is the single source of truth for **PACS 시스템 기능**.
+
 > **버전:** 0.2.0.0
 > **최종 수정일:** 2026-02-09
 > **언어:** [English](FEATURES.md) | **한국어**

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,8 @@ category: "FEAT"
 
 # PACS System Features
 
+> **SSOT**: This document is the single source of truth for **PACS System Features**.
+
 > **Version:** 0.2.0.0
 > **Last Updated:** 2026-02-09
 > **Language:** **English** | [한국어](FEATURES.kr.md)

--- a/docs/IHE_INTEGRATION_STATEMENT.md
+++ b/docs/IHE_INTEGRATION_STATEMENT.md
@@ -10,6 +10,8 @@ category: "INTR"
 
 # IHE Integration Statement
 
+> **SSOT**: This document is the single source of truth for **IHE Integration Statement**.
+
 ## PACS System
 
 **Product Name**: PACS System

--- a/docs/MIGRATION_COMPLETE.kr.md
+++ b/docs/MIGRATION_COMPLETE.kr.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # 스레드 시스템 마이그레이션 완료
 
+> **SSOT**: This document is the single source of truth for **스레드 시스템 마이그레이션 완료**.
+
 **버전:** 0.1.0.0
 **날짜:** 2025-12-07
 **관련 이슈:** #153 - Epic: std::thread에서 thread_system/network_system으로 마이그레이션

--- a/docs/MIGRATION_COMPLETE.md
+++ b/docs/MIGRATION_COMPLETE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Thread System Migration Complete
 
+> **SSOT**: This document is the single source of truth for **Thread System Migration Complete**.
+
 **Version:** 0.1.0.0
 **Date:** 2025-12-07
 **Related Issue:** #153 - Epic: Migrate from std::thread to thread_system/network_system

--- a/docs/PACS_IMPLEMENTATION_ANALYSIS.kr.md
+++ b/docs/PACS_IMPLEMENTATION_ANALYSIS.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # PACS 시스템 구현 분석
 
+> **SSOT**: This document is the single source of truth for **PACS 시스템 구현 분석**.
+
 > **언어:** [English](PACS_IMPLEMENTATION_ANALYSIS.md) | **한국어**
 
 ## 1. 개요

--- a/docs/PACS_IMPLEMENTATION_ANALYSIS.md
+++ b/docs/PACS_IMPLEMENTATION_ANALYSIS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # PACS System Implementation Analysis
 
+> **SSOT**: This document is the single source of truth for **PACS System Implementation Analysis**.
+
 > **Language:** **English** | [한국어](PACS_IMPLEMENTATION_ANALYSIS.kr.md)
 
 ## 1. Overview

--- a/docs/PERFORMANCE_BASELINE.md
+++ b/docs/PERFORMANCE_BASELINE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance Baseline for Thread Migration
 
+> **SSOT**: This document is the single source of truth for **Performance Baseline for Thread Migration**.
+
 **Version:** 0.1.0.0
 **Date:** 2024-12-04
 **Related Issue:** #154 - Establish performance baseline benchmarks for thread migration

--- a/docs/PERFORMANCE_RESULTS.md
+++ b/docs/PERFORMANCE_RESULTS.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # Performance Results After Thread Migration
 
+> **SSOT**: This document is the single source of truth for **Performance Results After Thread Migration**.
+
 **Version:** 0.1.0.0
 **Date:** 2024-12-05
 **Related Issue:** #160 - Performance testing and optimization after thread migration

--- a/docs/PIPELINE_DESIGN.md
+++ b/docs/PIPELINE_DESIGN.md
@@ -10,6 +10,8 @@ category: "ARCH"
 
 # Pipeline Design Documentation
 
+> **SSOT**: This document is the single source of truth for **Pipeline Design Documentation**.
+
 **Version:** 1.0.0
 **Date:** 2025-01-08
 **Related Issue:** #517 - Implement typed_thread_pool-based I/O Pipeline for DICOM Operations

--- a/docs/PRD.kr.md
+++ b/docs/PRD.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 제품 요구사항 정의서 - PACS 시스템
 
+> **SSOT**: This document is the single source of truth for **제품 요구사항 정의서 - PACS 시스템**.
+
 > **버전:** 0.2.0.0
 > **최종 수정일:** 2026-02-08
 > **언어:** [English](PRD.md) | **한국어**

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Product Requirements Document - PACS System
 
+> **SSOT**: This document is the single source of truth for **Product Requirements Document - PACS System**.
+
 > **Version:** 0.2.0.0
 > **Last Updated:** 2026-02-08
 > **Language:** **English** | [한국어](PRD.kr.md)

--- a/docs/PREFETCH_QUEUE_ANALYSIS.md
+++ b/docs/PREFETCH_QUEUE_ANALYSIS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Prefetch Queue Lock-free Analysis Report
 
+> **SSOT**: This document is the single source of truth for **Prefetch Queue Lock-free Analysis Report**.
+
 ## Issue Reference
 - **Issue**: [#338](https://github.com/kcenon/pacs_system/issues/338) - Apply lock-free queue to prefetch service
 - **Parent Issue**: [#314](https://github.com/kcenon/pacs_system/issues/314) - Apply Lock-free Structures

--- a/docs/PRODUCTION_QUALITY.kr.md
+++ b/docs/PRODUCTION_QUALITY.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # PACS System 프로덕션 품질
 
+> **SSOT**: This document is the single source of truth for **PACS System 프로덕션 품질**.
+
 > **언어:** [English](PRODUCTION_QUALITY.md) | **한국어**
 
 **최종 업데이트**: 2026-03-18

--- a/docs/PRODUCTION_QUALITY.md
+++ b/docs/PRODUCTION_QUALITY.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # PACS System Production Quality
 
+> **SSOT**: This document is the single source of truth for **PACS System Production Quality**.
+
 > **Language:** **English** | [한국어](PRODUCTION_QUALITY.kr.md)
 
 **Last Updated**: 2026-03-18

--- a/docs/PROJECT_STRUCTURE.kr.md
+++ b/docs/PROJECT_STRUCTURE.kr.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # 프로젝트 구조 - PACS 시스템
 
+> **SSOT**: This document is the single source of truth for **프로젝트 구조 - PACS 시스템**.
+
 > **버전:** 0.1.3.0
 > **최종 수정일:** 2025-12-20
 > **언어:** [English](PROJECT_STRUCTURE.md) | **한국어**

--- a/docs/PROJECT_STRUCTURE.md
+++ b/docs/PROJECT_STRUCTURE.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Project Structure - PACS System
 
+> **SSOT**: This document is the single source of truth for **Project Structure - PACS System**.
+
 > **Version:** 0.1.3.0
 > **Last Updated:** 2025-12-13
 > **Language:** **English** | [한국어](PROJECT_STRUCTURE.kr.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,216 @@
+# PACS System — Documentation Registry
+
+> **SSOT**: This file is the single source of truth for the documentation index
+> of **pacs_system**.
+
+Total documents: **72**
+
+## Document Index
+
+| # | doc_id | Topic | Authority Document | Status |
+|---|--------|-------|-------------------|--------|
+| 1 | PAC-ARCH-001 | 아키텍처 문서 - PACS 시스템 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| 2 | PAC-ARCH-002 | Architecture Documentation - PACS System | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| 3 | PAC-ARCH-003 | Pipeline Design Documentation | [PIPELINE_DESIGN.md](./PIPELINE_DESIGN.md) | Released |
+| 4 | PAC-API-001 | API 참조 - PACS 시스템 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| 5 | PAC-API-002 | API Reference - PACS System | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| 6 | PAC-API-003 | CLI 레퍼런스 | [CLI_REFERENCE.kr.md](./CLI_REFERENCE.kr.md) | Released |
+| 7 | PAC-API-004 | CLI Reference | [CLI_REFERENCE.md](./CLI_REFERENCE.md) | Released |
+| 8 | PAC-API-005 | database_system API Reference | [API_REFERENCE.md](./database/API_REFERENCE.md) | Released |
+| 9 | PAC-FEAT-001 | PACS 시스템 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| 10 | PAC-FEAT-002 | PACS System Features | [FEATURES.md](./FEATURES.md) | Released |
+| 11 | PAC-GUID-001 | PACS 시스템 구현 분석 | [PACS_IMPLEMENTATION_ANALYSIS.kr.md](./PACS_IMPLEMENTATION_ANALYSIS.kr.md) | Released |
+| 12 | PAC-GUID-002 | PACS System Implementation Analysis | [PACS_IMPLEMENTATION_ANALYSIS.md](./PACS_IMPLEMENTATION_ANALYSIS.md) | Released |
+| 13 | PAC-GUID-003 | 제품 요구사항 정의서 - PACS 시스템 | [PRD.kr.md](./PRD.kr.md) | Released |
+| 14 | PAC-GUID-004 | Product Requirements Document - PACS System | [PRD.md](./PRD.md) | Released |
+| 15 | PAC-GUID-005 | Prefetch Queue Lock-free Analysis Report | [PREFETCH_QUEUE_ANALYSIS.md](./PREFETCH_QUEUE_ANALYSIS.md) | Released |
+| 16 | PAC-GUID-006 | 소프트웨어 설계 명세서 (SDS) - PACS 시스템 | [SDS.kr.md](./SDS.kr.md) | Released |
+| 17 | PAC-GUID-007 | Software Design Specification (SDS) - PACS System | [SDS.md](./SDS.md) | Released |
+| 18 | PAC-GUID-008 | SDS - AI Service Module | [SDS_AI.md](./SDS_AI.md) | Released |
+| 19 | PAC-GUID-009 | SDS - Client Module | [SDS_CLIENT.md](./SDS_CLIENT.md) | Released |
+| 20 | PAC-GUID-010 | SDS - Cloud Storage Backends Module | [SDS_CLOUD_STORAGE.md](./SDS_CLOUD_STORAGE.md) | Released |
+| 21 | PAC-GUID-011 | SDS - 컴포넌트 설계 명세 | [SDS_COMPONENTS.kr.md](./SDS_COMPONENTS.kr.md) | Released |
+| 22 | PAC-GUID-012 | SDS - Component Design Specifications | [SDS_COMPONENTS.md](./SDS_COMPONENTS.md) | Released |
+| 23 | PAC-GUID-013 | SDS - Compression Codecs Module | [SDS_COMPRESSION.md](./SDS_COMPRESSION.md) | Released |
+| 24 | PAC-GUID-014 | SDS - 데이터베이스 설계 | [SDS_DATABASE.kr.md](./SDS_DATABASE.kr.md) | Released |
+| 25 | PAC-GUID-015 | SDS - Database Design | [SDS_DATABASE.md](./SDS_DATABASE.md) | Released |
+| 26 | PAC-GUID-016 | SDS - Dependency Injection Module | [SDS_DI.md](./SDS_DI.md) | Released |
+| 27 | PAC-GUID-017 | SDS - 인터페이스 명세서 | [SDS_INTERFACES.kr.md](./SDS_INTERFACES.kr.md) | Released |
+| 28 | PAC-GUID-018 | SDS - Interface Specifications | [SDS_INTERFACES.md](./SDS_INTERFACES.md) | Released |
+| 29 | PAC-GUID-019 | SDS - Monitoring Collectors Module | [SDS_MONITORING_COLLECTORS.md](./SDS_MONITORING_COLLECTORS.md) | Released |
+| 30 | PAC-GUID-020 | SDS - Network V2 Module | [SDS_NETWORK_V2.md](./SDS_NETWORK_V2.md) | Released |
+| 31 | PAC-GUID-021 | SDS - 시퀀스 다이어그램 | [SDS_SEQUENCES.kr.md](./SDS_SEQUENCES.kr.md) | Released |
+| 32 | PAC-GUID-022 | SDS - Sequence Diagrams | [SDS_SEQUENCES.md](./SDS_SEQUENCES.md) | Released |
+| 33 | PAC-GUID-023 | SDS - Services Cache Module | [SDS_SERVICES_CACHE.md](./SDS_SERVICES_CACHE.md) | Released |
+| 34 | PAC-GUID-024 | SDS - 요구사항 추적성 매트릭스 | [SDS_TRACEABILITY.kr.md](./SDS_TRACEABILITY.kr.md) | Released |
+| 35 | PAC-GUID-025 | SDS - Requirements Traceability Matrix | [SDS_TRACEABILITY.md](./SDS_TRACEABILITY.md) | Released |
+| 36 | PAC-GUID-026 | SDS - Web/REST API Module Design Specification | [SDS_WEB_API.md](./SDS_WEB_API.md) | Released |
+| 37 | PAC-GUID-027 | SDS - Workflow Module | [SDS_WORKFLOW.md](./SDS_WORKFLOW.md) | Released |
+| 38 | PAC-GUID-028 | 소프트웨어 요구사항 명세서 - PACS System | [SRS.kr.md](./SRS.kr.md) | Released |
+| 39 | PAC-GUID-029 | Software Requirements Specification - PACS System | [SRS.md](./SRS.md) | Released |
+| 40 | PAC-GUID-030 | PACS System Advanced Topics | [README.md](./advanced/README.md) | Released |
+| 41 | PAC-GUID-031 | PACS System Documentation | [index.md](./index.md) | Released |
+| 42 | PAC-GUID-032 | PACS System Integration Guide | [README.md](./integration/README.md) | Released |
+| 43 | PAC-GUID-033 | PACS System Performance Documentation | [README.md](./performance/README.md) | Released |
+| 44 | PAC-PERF-001 | PACS System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| 45 | PAC-PERF-002 | PACS System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| 46 | PAC-PERF-003 | Performance Baseline for Thread Migration | [PERFORMANCE_BASELINE.md](./PERFORMANCE_BASELINE.md) | Released |
+| 47 | PAC-PERF-004 | Performance Results After Thread Migration | [PERFORMANCE_RESULTS.md](./PERFORMANCE_RESULTS.md) | Released |
+| 48 | PAC-PERF-005 | database_system Performance Guide | [PERFORMANCE_GUIDE.md](./database/PERFORMANCE_GUIDE.md) | Released |
+| 49 | PAC-MIGR-001 | 스레드 시스템 마이그레이션 완료 | [MIGRATION_COMPLETE.kr.md](./MIGRATION_COMPLETE.kr.md) | Released |
+| 50 | PAC-MIGR-002 | Thread System Migration Complete | [MIGRATION_COMPLETE.md](./MIGRATION_COMPLETE.md) | Released |
+| 51 | PAC-MIGR-003 | Thread Pool Migration Guide | [THREAD_POOL_MIGRATION.md](./THREAD_POOL_MIGRATION.md) | Released |
+| 52 | PAC-MIGR-004 | database_system Migration Guide | [MIGRATION_GUIDE.md](./database/MIGRATION_GUIDE.md) | Released |
+| 53 | PAC-INTR-001 | DICOM Conformance Statement | [DICOM_CONFORMANCE_STATEMENT.md](./DICOM_CONFORMANCE_STATEMENT.md) | Released |
+| 54 | PAC-INTR-002 | IHE Integration Statement | [IHE_INTEGRATION_STATEMENT.md](./IHE_INTEGRATION_STATEMENT.md) | Released |
+| 55 | PAC-QUAL-001 | PACS System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| 56 | PAC-QUAL-002 | PACS System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| 57 | PAC-QUAL-003 | Thread System Stability Verification Report | [THREAD_SYSTEM_STABILITY_REPORT.md](./THREAD_SYSTEM_STABILITY_REPORT.md) | Released |
+| 58 | PAC-QUAL-004 | PACS 시스템 검증 보고서 (Validation Report) | [VALIDATION_REPORT.kr.md](./VALIDATION_REPORT.kr.md) | Released |
+| 59 | PAC-QUAL-005 | PACS System Validation Report | [VALIDATION_REPORT.md](./VALIDATION_REPORT.md) | Released |
+| 60 | PAC-QUAL-006 | PACS 시스템 검증 보고서 | [VERIFICATION_REPORT.kr.md](./VERIFICATION_REPORT.kr.md) | Released |
+| 61 | PAC-QUAL-007 | PACS System Verification Report | [VERIFICATION_REPORT.md](./VERIFICATION_REPORT.md) | Released |
+| 62 | PAC-SECU-001 | SDS - Security Module | [SDS_SECURITY.md](./SDS_SECURITY.md) | Released |
+| 63 | PAC-SECU-002 | Security Module Documentation | [SECURITY.md](./SECURITY.md) | Released |
+| 64 | PAC-ADR-001 | ADR-001: Integrate database_system for Database Abstraction | [ADR-001-database-system-integration.md](./adr/ADR-001-database-system-integration.md) | Released |
+| 65 | PAC-ADR-002 | ADR-002: Define PACS Storage Port Segmentation | [ADR-002-pacs-storage-port-segmentation.md](./adr/ADR-002-pacs-storage-port-segmentation.md) | Released |
+| 66 | PAC-PROJ-001 | 변경 이력 - PACS System | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| 67 | PAC-PROJ-002 | Changelog - PACS System | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| 68 | PAC-PROJ-003 | Documentation Statistics Automation | [DOCUMENTATION_STATISTICS.md](./DOCUMENTATION_STATISTICS.md) | Released |
+| 69 | PAC-PROJ-004 | 프로젝트 구조 - PACS 시스템 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| 70 | PAC-PROJ-005 | Project Structure - PACS System | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| 71 | PAC-PROJ-006 | SOUP List &mdash; pacs_system | [SOUP.md](./SOUP.md) | Released |
+| 72 | PAC-PROJ-007 | Contributing to PACS System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+
+## Documents by Category
+
+### Architecture (3)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-ARCH-001 | 아키텍처 문서 - PACS 시스템 | [ARCHITECTURE.kr.md](./ARCHITECTURE.kr.md) | Released |
+| PAC-ARCH-002 | Architecture Documentation - PACS System | [ARCHITECTURE.md](./ARCHITECTURE.md) | Released |
+| PAC-ARCH-003 | Pipeline Design Documentation | [PIPELINE_DESIGN.md](./PIPELINE_DESIGN.md) | Released |
+
+### API Reference (5)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-API-001 | API 참조 - PACS 시스템 | [API_REFERENCE.kr.md](./API_REFERENCE.kr.md) | Released |
+| PAC-API-002 | API Reference - PACS System | [API_REFERENCE.md](./API_REFERENCE.md) | Released |
+| PAC-API-003 | CLI 레퍼런스 | [CLI_REFERENCE.kr.md](./CLI_REFERENCE.kr.md) | Released |
+| PAC-API-004 | CLI Reference | [CLI_REFERENCE.md](./CLI_REFERENCE.md) | Released |
+| PAC-API-005 | database_system API Reference | [API_REFERENCE.md](./database/API_REFERENCE.md) | Released |
+
+### Features (2)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-FEAT-001 | PACS 시스템 기능 | [FEATURES.kr.md](./FEATURES.kr.md) | Released |
+| PAC-FEAT-002 | PACS System Features | [FEATURES.md](./FEATURES.md) | Released |
+
+### Guides (33)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-GUID-001 | PACS 시스템 구현 분석 | [PACS_IMPLEMENTATION_ANALYSIS.kr.md](./PACS_IMPLEMENTATION_ANALYSIS.kr.md) | Released |
+| PAC-GUID-002 | PACS System Implementation Analysis | [PACS_IMPLEMENTATION_ANALYSIS.md](./PACS_IMPLEMENTATION_ANALYSIS.md) | Released |
+| PAC-GUID-003 | 제품 요구사항 정의서 - PACS 시스템 | [PRD.kr.md](./PRD.kr.md) | Released |
+| PAC-GUID-004 | Product Requirements Document - PACS System | [PRD.md](./PRD.md) | Released |
+| PAC-GUID-005 | Prefetch Queue Lock-free Analysis Report | [PREFETCH_QUEUE_ANALYSIS.md](./PREFETCH_QUEUE_ANALYSIS.md) | Released |
+| PAC-GUID-006 | 소프트웨어 설계 명세서 (SDS) - PACS 시스템 | [SDS.kr.md](./SDS.kr.md) | Released |
+| PAC-GUID-007 | Software Design Specification (SDS) - PACS System | [SDS.md](./SDS.md) | Released |
+| PAC-GUID-008 | SDS - AI Service Module | [SDS_AI.md](./SDS_AI.md) | Released |
+| PAC-GUID-009 | SDS - Client Module | [SDS_CLIENT.md](./SDS_CLIENT.md) | Released |
+| PAC-GUID-010 | SDS - Cloud Storage Backends Module | [SDS_CLOUD_STORAGE.md](./SDS_CLOUD_STORAGE.md) | Released |
+| PAC-GUID-011 | SDS - 컴포넌트 설계 명세 | [SDS_COMPONENTS.kr.md](./SDS_COMPONENTS.kr.md) | Released |
+| PAC-GUID-012 | SDS - Component Design Specifications | [SDS_COMPONENTS.md](./SDS_COMPONENTS.md) | Released |
+| PAC-GUID-013 | SDS - Compression Codecs Module | [SDS_COMPRESSION.md](./SDS_COMPRESSION.md) | Released |
+| PAC-GUID-014 | SDS - 데이터베이스 설계 | [SDS_DATABASE.kr.md](./SDS_DATABASE.kr.md) | Released |
+| PAC-GUID-015 | SDS - Database Design | [SDS_DATABASE.md](./SDS_DATABASE.md) | Released |
+| PAC-GUID-016 | SDS - Dependency Injection Module | [SDS_DI.md](./SDS_DI.md) | Released |
+| PAC-GUID-017 | SDS - 인터페이스 명세서 | [SDS_INTERFACES.kr.md](./SDS_INTERFACES.kr.md) | Released |
+| PAC-GUID-018 | SDS - Interface Specifications | [SDS_INTERFACES.md](./SDS_INTERFACES.md) | Released |
+| PAC-GUID-019 | SDS - Monitoring Collectors Module | [SDS_MONITORING_COLLECTORS.md](./SDS_MONITORING_COLLECTORS.md) | Released |
+| PAC-GUID-020 | SDS - Network V2 Module | [SDS_NETWORK_V2.md](./SDS_NETWORK_V2.md) | Released |
+| PAC-GUID-021 | SDS - 시퀀스 다이어그램 | [SDS_SEQUENCES.kr.md](./SDS_SEQUENCES.kr.md) | Released |
+| PAC-GUID-022 | SDS - Sequence Diagrams | [SDS_SEQUENCES.md](./SDS_SEQUENCES.md) | Released |
+| PAC-GUID-023 | SDS - Services Cache Module | [SDS_SERVICES_CACHE.md](./SDS_SERVICES_CACHE.md) | Released |
+| PAC-GUID-024 | SDS - 요구사항 추적성 매트릭스 | [SDS_TRACEABILITY.kr.md](./SDS_TRACEABILITY.kr.md) | Released |
+| PAC-GUID-025 | SDS - Requirements Traceability Matrix | [SDS_TRACEABILITY.md](./SDS_TRACEABILITY.md) | Released |
+| PAC-GUID-026 | SDS - Web/REST API Module Design Specification | [SDS_WEB_API.md](./SDS_WEB_API.md) | Released |
+| PAC-GUID-027 | SDS - Workflow Module | [SDS_WORKFLOW.md](./SDS_WORKFLOW.md) | Released |
+| PAC-GUID-028 | 소프트웨어 요구사항 명세서 - PACS System | [SRS.kr.md](./SRS.kr.md) | Released |
+| PAC-GUID-029 | Software Requirements Specification - PACS System | [SRS.md](./SRS.md) | Released |
+| PAC-GUID-030 | PACS System Advanced Topics | [README.md](./advanced/README.md) | Released |
+| PAC-GUID-031 | PACS System Documentation | [index.md](./index.md) | Released |
+| PAC-GUID-032 | PACS System Integration Guide | [README.md](./integration/README.md) | Released |
+| PAC-GUID-033 | PACS System Performance Documentation | [README.md](./performance/README.md) | Released |
+
+### Performance (5)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-PERF-001 | PACS System 성능 벤치마크 | [BENCHMARKS.kr.md](./BENCHMARKS.kr.md) | Released |
+| PAC-PERF-002 | PACS System Performance Benchmarks | [BENCHMARKS.md](./BENCHMARKS.md) | Released |
+| PAC-PERF-003 | Performance Baseline for Thread Migration | [PERFORMANCE_BASELINE.md](./PERFORMANCE_BASELINE.md) | Released |
+| PAC-PERF-004 | Performance Results After Thread Migration | [PERFORMANCE_RESULTS.md](./PERFORMANCE_RESULTS.md) | Released |
+| PAC-PERF-005 | database_system Performance Guide | [PERFORMANCE_GUIDE.md](./database/PERFORMANCE_GUIDE.md) | Released |
+
+### Migration (4)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-MIGR-001 | 스레드 시스템 마이그레이션 완료 | [MIGRATION_COMPLETE.kr.md](./MIGRATION_COMPLETE.kr.md) | Released |
+| PAC-MIGR-002 | Thread System Migration Complete | [MIGRATION_COMPLETE.md](./MIGRATION_COMPLETE.md) | Released |
+| PAC-MIGR-003 | Thread Pool Migration Guide | [THREAD_POOL_MIGRATION.md](./THREAD_POOL_MIGRATION.md) | Released |
+| PAC-MIGR-004 | database_system Migration Guide | [MIGRATION_GUIDE.md](./database/MIGRATION_GUIDE.md) | Released |
+
+### Integration (2)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-INTR-001 | DICOM Conformance Statement | [DICOM_CONFORMANCE_STATEMENT.md](./DICOM_CONFORMANCE_STATEMENT.md) | Released |
+| PAC-INTR-002 | IHE Integration Statement | [IHE_INTEGRATION_STATEMENT.md](./IHE_INTEGRATION_STATEMENT.md) | Released |
+
+### Quality (7)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-QUAL-001 | PACS System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
+| PAC-QUAL-002 | PACS System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
+| PAC-QUAL-003 | Thread System Stability Verification Report | [THREAD_SYSTEM_STABILITY_REPORT.md](./THREAD_SYSTEM_STABILITY_REPORT.md) | Released |
+| PAC-QUAL-004 | PACS 시스템 검증 보고서 (Validation Report) | [VALIDATION_REPORT.kr.md](./VALIDATION_REPORT.kr.md) | Released |
+| PAC-QUAL-005 | PACS System Validation Report | [VALIDATION_REPORT.md](./VALIDATION_REPORT.md) | Released |
+| PAC-QUAL-006 | PACS 시스템 검증 보고서 | [VERIFICATION_REPORT.kr.md](./VERIFICATION_REPORT.kr.md) | Released |
+| PAC-QUAL-007 | PACS System Verification Report | [VERIFICATION_REPORT.md](./VERIFICATION_REPORT.md) | Released |
+
+### Security (2)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-SECU-001 | SDS - Security Module | [SDS_SECURITY.md](./SDS_SECURITY.md) | Released |
+| PAC-SECU-002 | Security Module Documentation | [SECURITY.md](./SECURITY.md) | Released |
+
+### Architecture Decision Records (2)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-ADR-001 | ADR-001: Integrate database_system for Database Abstraction | [ADR-001-database-system-integration.md](./adr/ADR-001-database-system-integration.md) | Released |
+| PAC-ADR-002 | ADR-002: Define PACS Storage Port Segmentation | [ADR-002-pacs-storage-port-segmentation.md](./adr/ADR-002-pacs-storage-port-segmentation.md) | Released |
+
+### Project (7)
+
+| doc_id | Topic | Document | Status |
+|--------|-------|----------|--------|
+| PAC-PROJ-001 | 변경 이력 - PACS System | [CHANGELOG.kr.md](./CHANGELOG.kr.md) | Released |
+| PAC-PROJ-002 | Changelog - PACS System | [CHANGELOG.md](./CHANGELOG.md) | Released |
+| PAC-PROJ-003 | Documentation Statistics Automation | [DOCUMENTATION_STATISTICS.md](./DOCUMENTATION_STATISTICS.md) | Released |
+| PAC-PROJ-004 | 프로젝트 구조 - PACS 시스템 | [PROJECT_STRUCTURE.kr.md](./PROJECT_STRUCTURE.kr.md) | Released |
+| PAC-PROJ-005 | Project Structure - PACS System | [PROJECT_STRUCTURE.md](./PROJECT_STRUCTURE.md) | Released |
+| PAC-PROJ-006 | SOUP List &mdash; pacs_system | [SOUP.md](./SOUP.md) | Released |
+| PAC-PROJ-007 | Contributing to PACS System | [CONTRIBUTING.md](./contributing/CONTRIBUTING.md) | Released |
+
+---
+
+*Registry generated for issue [#563](https://github.com/kcenon/pacs_system/issues/563).*

--- a/docs/SDS.kr.md
+++ b/docs/SDS.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 소프트웨어 설계 명세서 (SDS) - PACS 시스템
 
+> **SSOT**: This document is the single source of truth for **소프트웨어 설계 명세서 (SDS) - PACS 시스템**.
+
 > **버전:** 0.2.0
 > **최종 수정일:** 2026-02-08
 > **언어:** [English](SDS.md) | **한국어**

--- a/docs/SDS.md
+++ b/docs/SDS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Software Design Specification (SDS) - PACS System
 
+> **SSOT**: This document is the single source of truth for **Software Design Specification (SDS) - PACS System**.
+
 > **Version:** 0.2.0
 > **Last Updated:** 2026-02-08
 > **Language:** **English** | [한국어](SDS.kr.md)

--- a/docs/SDS_AI.md
+++ b/docs/SDS_AI.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - AI Service Module
 
+> **SSOT**: This document is the single source of truth for **SDS - AI Service Module**.
+
 > **Version:** 2.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-05

--- a/docs/SDS_CLIENT.md
+++ b/docs/SDS_CLIENT.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Client Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Client Module**.
+
 > **Version:** 1.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-02-08

--- a/docs/SDS_CLOUD_STORAGE.md
+++ b/docs/SDS_CLOUD_STORAGE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Cloud Storage Backends Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Cloud Storage Backends Module**.
+
 > **Version:** 1.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-04

--- a/docs/SDS_COMPONENTS.kr.md
+++ b/docs/SDS_COMPONENTS.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - 컴포넌트 설계 명세
 
+> **SSOT**: This document is the single source of truth for **SDS - 컴포넌트 설계 명세**.
+
 > **버전:** 0.1.2
 > **상위 문서:** [SDS.kr.md](SDS.kr.md)
 > **최종 수정일:** 2025-12-07

--- a/docs/SDS_COMPONENTS.md
+++ b/docs/SDS_COMPONENTS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Component Design Specifications
 
+> **SSOT**: This document is the single source of truth for **SDS - Component Design Specifications**.
+
 > **Version:** 0.2.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-02-08

--- a/docs/SDS_COMPRESSION.md
+++ b/docs/SDS_COMPRESSION.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Compression Codecs Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Compression Codecs Module**.
+
 > **Version:** 1.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-03

--- a/docs/SDS_DATABASE.kr.md
+++ b/docs/SDS_DATABASE.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - 데이터베이스 설계
 
+> **SSOT**: This document is the single source of truth for **SDS - 데이터베이스 설계**.
+
 > **버전:** 0.1.1
 > **상위 문서:** [SDS.kr.md](SDS.kr.md)
 > **최종 수정일:** 2025-12-04

--- a/docs/SDS_DATABASE.md
+++ b/docs/SDS_DATABASE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Database Design
 
+> **SSOT**: This document is the single source of truth for **SDS - Database Design**.
+
 > **Version:** 0.2.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-02-08

--- a/docs/SDS_DI.md
+++ b/docs/SDS_DI.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Dependency Injection Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Dependency Injection Module**.
+
 > **Version:** 1.1.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-05

--- a/docs/SDS_INTERFACES.kr.md
+++ b/docs/SDS_INTERFACES.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - 인터페이스 명세서
 
+> **SSOT**: This document is the single source of truth for **SDS - 인터페이스 명세서**.
+
 > **버전:** 0.1.2
 > **상위 문서:** [SDS.kr.md](SDS.kr.md)
 > **최종 수정일:** 2025-12-07

--- a/docs/SDS_INTERFACES.md
+++ b/docs/SDS_INTERFACES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Interface Specifications
 
+> **SSOT**: This document is the single source of truth for **SDS - Interface Specifications**.
+
 > **Version:** 0.1.3
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2025-12-07

--- a/docs/SDS_MONITORING_COLLECTORS.md
+++ b/docs/SDS_MONITORING_COLLECTORS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Monitoring Collectors Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Monitoring Collectors Module**.
+
 > **Version:** 2.1.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-05

--- a/docs/SDS_NETWORK_V2.md
+++ b/docs/SDS_NETWORK_V2.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Network V2 Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Network V2 Module**.
+
 > **Version:** 2.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-05

--- a/docs/SDS_SECURITY.md
+++ b/docs/SDS_SECURITY.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # SDS - Security Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Security Module**.
+
 > **Version:** 1.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-03

--- a/docs/SDS_SEQUENCES.kr.md
+++ b/docs/SDS_SEQUENCES.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - 시퀀스 다이어그램
 
+> **SSOT**: This document is the single source of truth for **SDS - 시퀀스 다이어그램**.
+
 > **버전:** 0.1.1
 > **상위 문서:** [SDS.kr.md](SDS.kr.md)
 > **최종 수정일:** 2025-12-04

--- a/docs/SDS_SEQUENCES.md
+++ b/docs/SDS_SEQUENCES.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Sequence Diagrams
 
+> **SSOT**: This document is the single source of truth for **SDS - Sequence Diagrams**.
+
 > **Version:** 0.1.1
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2025-12-04

--- a/docs/SDS_SERVICES_CACHE.md
+++ b/docs/SDS_SERVICES_CACHE.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Services Cache Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Services Cache Module**.
+
 > **Version:** 1.1.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-05

--- a/docs/SDS_TRACEABILITY.kr.md
+++ b/docs/SDS_TRACEABILITY.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - 요구사항 추적성 매트릭스
 
+> **SSOT**: This document is the single source of truth for **SDS - 요구사항 추적성 매트릭스**.
+
 > **버전:** 0.1.3
 > **상위 문서:** [SDS.kr.md](SDS.kr.md)
 > **최종 수정일:** 2026-02-07

--- a/docs/SDS_TRACEABILITY.md
+++ b/docs/SDS_TRACEABILITY.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Requirements Traceability Matrix
 
+> **SSOT**: This document is the single source of truth for **SDS - Requirements Traceability Matrix**.
+
 > **Version:** 3.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-02-08

--- a/docs/SDS_WEB_API.md
+++ b/docs/SDS_WEB_API.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Web/REST API Module Design Specification
 
+> **SSOT**: This document is the single source of truth for **SDS - Web/REST API Module Design Specification**.
+
 > **Version:** 2.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-02-08

--- a/docs/SDS_WORKFLOW.md
+++ b/docs/SDS_WORKFLOW.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # SDS - Workflow Module
 
+> **SSOT**: This document is the single source of truth for **SDS - Workflow Module**.
+
 > **Version:** 1.0.0
 > **Parent Document:** [SDS.md](SDS.md)
 > **Last Updated:** 2026-01-04

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -10,6 +10,8 @@ category: "SECU"
 
 # Security Module Documentation
 
+> **SSOT**: This document is the single source of truth for **Security Module Documentation**.
+
 > **Version:** 0.1.1.0
 > **Last Updated:** 2025-12-11
 > **Language:** **English**

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # SOUP List &mdash; pacs_system
 
+> **SSOT**: This document is the single source of truth for **SOUP List &mdash; pacs_system**.
+
 > **Software of Unknown Provenance (SOUP) Register per IEC 62304:2006+AMD1:2015 &sect;8.1.2**
 >
 > This document is the authoritative reference for all external software dependencies.

--- a/docs/SRS.kr.md
+++ b/docs/SRS.kr.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # 소프트웨어 요구사항 명세서 - PACS System
 
+> **SSOT**: This document is the single source of truth for **소프트웨어 요구사항 명세서 - PACS System**.
+
 > **버전:** 0.1.3.2
 > **최종 수정:** 2026-02-09
 > **언어:** [English](SRS.md) | **한국어**

--- a/docs/SRS.md
+++ b/docs/SRS.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # Software Requirements Specification - PACS System
 
+> **SSOT**: This document is the single source of truth for **Software Requirements Specification - PACS System**.
+
 > **Version:** 0.1.3.2
 > **Last Updated:** 2026-02-09
 > **Language:** **English** | [한국어](SRS.kr.md)

--- a/docs/THREAD_POOL_MIGRATION.md
+++ b/docs/THREAD_POOL_MIGRATION.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # Thread Pool Migration Guide
 
+> **SSOT**: This document is the single source of truth for **Thread Pool Migration Guide**.
+
 This guide explains how to migrate from the deprecated `thread_adapter` singleton pattern to the new `thread_pool_adapter` with dependency injection.
 
 ## Overview

--- a/docs/THREAD_SYSTEM_STABILITY_REPORT.md
+++ b/docs/THREAD_SYSTEM_STABILITY_REPORT.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # Thread System Stability Verification Report
 
+> **SSOT**: This document is the single source of truth for **Thread System Stability Verification Report**.
+
 **Issue**: #155 - Verify thread_system stability and jthread support
 **Date**: 2024-12-04
 **Last Updated**: 2025-12-21 (Windows CI timeout fix for integration tests)

--- a/docs/VALIDATION_REPORT.kr.md
+++ b/docs/VALIDATION_REPORT.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # PACS 시스템 검증 보고서 (Validation Report)
 
+> **SSOT**: This document is the single source of truth for **PACS 시스템 검증 보고서 (Validation Report)**.
+
 > **보고서 버전:** 0.1.3.0
 > **보고서 일자:** 2026-02-08
 > **언어:** [English](VALIDATION_REPORT.md) | **한국어**

--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # PACS System Validation Report
 
+> **SSOT**: This document is the single source of truth for **PACS System Validation Report**.
+
 > **Report Version:** 0.1.3.0
 > **Report Date:** 2026-02-08
 > **Language:** **English** | [한국어](VALIDATION_REPORT.kr.md)

--- a/docs/VERIFICATION_REPORT.kr.md
+++ b/docs/VERIFICATION_REPORT.kr.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # PACS 시스템 검증 보고서
 
+> **SSOT**: This document is the single source of truth for **PACS 시스템 검증 보고서**.
+
 > **보고서 버전:** 0.1.6.0
 > **보고서 일자:** 2026-02-08
 > **언어:** [English](VERIFICATION_REPORT.md) | **한국어**

--- a/docs/VERIFICATION_REPORT.md
+++ b/docs/VERIFICATION_REPORT.md
@@ -10,6 +10,8 @@ category: "QUAL"
 
 # PACS System Verification Report
 
+> **SSOT**: This document is the single source of truth for **PACS System Verification Report**.
+
 > **Report Version:** 0.1.6.1
 > **Report Date:** 2026-02-12
 > **Language:** **English** | [한국어](VERIFICATION_REPORT.kr.md)

--- a/docs/adr/ADR-001-database-system-integration.md
+++ b/docs/adr/ADR-001-database-system-integration.md
@@ -10,6 +10,8 @@ category: "ADR"
 
 # ADR-001: Integrate database_system for Database Abstraction
 
+> **SSOT**: This document is the single source of truth for **ADR-001: Integrate database_system for Database Abstraction**.
+
 > **Status:** Accepted
 > **Date:** 2025-12-31
 > **Decision Makers:** pacs_system core team

--- a/docs/adr/ADR-002-pacs-storage-port-segmentation.md
+++ b/docs/adr/ADR-002-pacs-storage-port-segmentation.md
@@ -10,6 +10,8 @@ category: "ADR"
 
 # ADR-002: Define PACS Storage Port Segmentation
 
+> **SSOT**: This document is the single source of truth for **ADR-002: Define PACS Storage Port Segmentation**.
+
 > **Status:** Accepted
 > **Date:** 2026-03-10
 > **Decision Makers:** pacs_system core team

--- a/docs/advanced/README.md
+++ b/docs/advanced/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # PACS System Advanced Topics
 
+> **SSOT**: This document is the single source of truth for **PACS System Advanced Topics**.
+
 This directory contains advanced documentation for PACS System covering detailed design specifications and specialized topics.
 
 ## Software Design Specifications (SDS)

--- a/docs/contributing/CONTRIBUTING.md
+++ b/docs/contributing/CONTRIBUTING.md
@@ -10,6 +10,8 @@ category: "PROJ"
 
 # Contributing to PACS System
 
+> **SSOT**: This document is the single source of truth for **Contributing to PACS System**.
+
 **Version:** 0.1.0.0
 **Last Updated:** 2026-03-18
 

--- a/docs/database/API_REFERENCE.md
+++ b/docs/database/API_REFERENCE.md
@@ -10,6 +10,8 @@ category: "API"
 
 # database_system API Reference
 
+> **SSOT**: This document is the single source of truth for **database_system API Reference**.
+
 > **Version:** 1.0.0
 > **Last Updated:** 2025-12-31
 > **Context:** pacs_system integration

--- a/docs/database/MIGRATION_GUIDE.md
+++ b/docs/database/MIGRATION_GUIDE.md
@@ -10,6 +10,8 @@ category: "MIGR"
 
 # database_system Migration Guide
 
+> **SSOT**: This document is the single source of truth for **database_system Migration Guide**.
+
 > **Version:** 1.0.1
 > **Last Updated:** 2026-01-01
 > **Related Epic:** [#418](https://github.com/kcenon/pacs_system/issues/418)

--- a/docs/database/PERFORMANCE_GUIDE.md
+++ b/docs/database/PERFORMANCE_GUIDE.md
@@ -10,6 +10,8 @@ category: "PERF"
 
 # database_system Performance Guide
 
+> **SSOT**: This document is the single source of truth for **database_system Performance Guide**.
+
 > **Version:** 1.0.0
 > **Last Updated:** 2025-12-31
 > **Context:** pacs_system database optimization

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ category: "GUID"
 
 # PACS System Documentation
 
+> **SSOT**: This document is the single source of truth for **PACS System Documentation**.
+
 [![CI](https://github.com/kcenon/pacs_system/actions/workflows/ci.yml/badge.svg)](https://github.com/kcenon/pacs_system/actions/workflows/ci.yml)
 [![Integration Tests](https://github.com/kcenon/pacs_system/actions/workflows/integration-tests.yml/badge.svg)](https://github.com/kcenon/pacs_system/actions/workflows/integration-tests.yml)
 [![Code Coverage](https://github.com/kcenon/pacs_system/actions/workflows/coverage.yml/badge.svg)](https://github.com/kcenon/pacs_system/actions/workflows/coverage.yml)

--- a/docs/integration/README.md
+++ b/docs/integration/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # PACS System Integration Guide
 
+> **SSOT**: This document is the single source of truth for **PACS System Integration Guide**.
+
 This directory contains integration documentation for using PACS System with the kcenon ecosystem and external systems.
 
 ## Ecosystem Dependencies

--- a/docs/performance/README.md
+++ b/docs/performance/README.md
@@ -10,6 +10,8 @@ category: "GUID"
 
 # PACS System Performance Documentation
 
+> **SSOT**: This document is the single source of truth for **PACS System Performance Documentation**.
+
 This directory contains performance-related documentation for PACS System.
 
 ## Documents


### PR DESCRIPTION
## Summary

- Create `docs/README.md` as the single source of truth documentation index for pacs_system
- Add SSOT declarations (`> **SSOT**: ...`) to each authoritative document header
- Registry table lists all 72 documents with doc_id, topic, authority document link, and status
- Documents grouped by category (Architecture, API, Features, Guides, etc.)
- Verified no duplicate doc_id values and all file links are valid

## Test Plan

- [x] All 72 document entries have valid file links
- [x] No duplicate doc_id values within the project
- [x] SSOT declarations added to authoritative documents
- [x] Registry follows the format specified in kcenon/common_system#563

Closes kcenon/common_system#563