### PR TITLE
docs: fix traceability matrix doc_id collision with production quality

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@ Total documents: **74**
 | 54 | PAC-INTR-002 | IHE Integration Statement | [IHE_INTEGRATION_STATEMENT.md](./IHE_INTEGRATION_STATEMENT.md) | Released |
 | 55 | PAC-QUAL-001 | PACS System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | 56 | PAC-QUAL-002 | PACS System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| 57 | PAC-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| 57 | PAC-QUAL-008 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | 59 | PAC-QUAL-003 | Thread System Stability Verification Report | [THREAD_SYSTEM_STABILITY_REPORT.md](./THREAD_SYSTEM_STABILITY_REPORT.md) | Released |
 | 59 | PAC-QUAL-004 | PACS 시스템 검증 보고서 (Validation Report) | [VALIDATION_REPORT.kr.md](./VALIDATION_REPORT.kr.md) | Released |
 | 60 | PAC-QUAL-005 | PACS System Validation Report | [VALIDATION_REPORT.md](./VALIDATION_REPORT.md) | Released |
@@ -181,7 +181,7 @@ Total documents: **74**
 |--------|-------|----------|--------|
 | PAC-QUAL-001 | PACS System 프로덕션 품질 | [PRODUCTION_QUALITY.kr.md](./PRODUCTION_QUALITY.kr.md) | Released |
 | PAC-QUAL-002 | PACS System Production Quality | [PRODUCTION_QUALITY.md](./PRODUCTION_QUALITY.md) | Released |
-| PAC-QUAL-002 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
+| PAC-QUAL-008 | Feature-Test-Module Traceability Matrix | [TRACEABILITY.md](./TRACEABILITY.md) | Released |
 | PAC-QUAL-003 | Thread System Stability Verification Report | [THREAD_SYSTEM_STABILITY_REPORT.md](./THREAD_SYSTEM_STABILITY_REPORT.md) | Released |
 | PAC-QUAL-004 | PACS 시스템 검증 보고서 (Validation Report) | [VALIDATION_REPORT.kr.md](./VALIDATION_REPORT.kr.md) | Released |
 | PAC-QUAL-005 | PACS System Validation Report | [VALIDATION_REPORT.md](./VALIDATION_REPORT.md) | Released |

--- a/docs/TRACEABILITY.md
+++ b/docs/TRACEABILITY.md
@@ -1,5 +1,5 @@
 ---
-doc_id: "PAC-QUAL-002"
+doc_id: "PAC-QUAL-008"
 doc_title: "Feature-Test-Module Traceability Matrix"
 doc_version: "1.0.0"
 doc_date: "2026-04-04"


### PR DESCRIPTION
## Summary

- Fix doc_id collision: `TRACEABILITY.md` and `PRODUCTION_QUALITY.md` both used `PAC-QUAL-002`
- Assign unique `PAC-QUAL-008` to `TRACEABILITY.md` (next available QUAL number)
- Update SSOT registry (`docs/README.md`) to reflect the corrected doc_id

Related to kcenon/common_system#566

## What

The traceability matrix document (`docs/TRACEABILITY.md`) was sharing `PAC-QUAL-002` with `PRODUCTION_QUALITY.md`. Each document in the SSOT registry must have a unique `doc_id`. This PR assigns `PAC-QUAL-008` to the traceability matrix.

## How

- Updated `doc_id` in `docs/TRACEABILITY.md` YAML frontmatter from `PAC-QUAL-002` to `PAC-QUAL-008`
- Updated both entries in `docs/README.md` (numbered table and category index)

## Test Plan

- [x] Verify `PAC-QUAL-008` is not used by any other document
- [x] Verify TRACEABILITY.md YAML frontmatter matches README.md registry entry
- [x] Verify all feature-test mappings are accurate (test files exist)
- [x] Verify coverage summary totals match actual feature count (166)