### PR TITLE
docs(tutorials): add tutorials, FAQ and troubleshooting guide

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -116,6 +116,12 @@ INPUT                  = ./include \
                          ./src \
                          ./README.md \
                          ./docs/mainpage.dox \
+                         ./docs/tutorial_dicom_basics.dox \
+                         ./docs/tutorial_store_workflow.dox \
+                         ./docs/tutorial_query_retrieve.dox \
+                         ./docs/tutorial_cli_tools.dox \
+                         ./docs/faq.dox \
+                         ./docs/troubleshooting.dox \
                          ./examples
 INPUT_ENCODING         = UTF-8
 FILE_PATTERNS          = *.c \

--- a/docs/faq.dox
+++ b/docs/faq.dox
@@ -1,0 +1,91 @@
+/**
+@page faq Frequently Asked Questions
+
+@tableofcontents
+
+@section faq_sop SOP Class Support
+
+@subsection faq_supported_sop Which SOP classes are supported?
+
+27 SOP classes covering the major clinical workflows: CT, MR, US, XA, NM, PET, RT, SR (Structured Report), SEG (Segmentation), MG (Mammography), CR (Computed Radiography), SC (Secondary Capture), Patient/Study Root Q/R, Modality Worklist, MPPS, Storage Commitment, Print, UPS, PIR, XDS-I.b. See README for the full list.
+
+@subsection faq_add_sop How do I add a new SOP class?
+
+Derive from `services::sop_class_base`, register the UID with `sop_class_registry`, and implement the service callbacks. Existing SOP class implementations in `sources/services/` serve as templates.
+
+@section faq_ts Transfer Syntax Questions
+
+@subsection faq_ts_add How do I add a new transfer syntax?
+
+Implement a codec that satisfies the `codec_interface` — `encode()` produces encoded bytes from pixel data, `decode()` reverses it. Register via `codec_registry::add(uid, factory)`. The existing JPEG, JPEG 2000, HTJ2K, JPEG-LS, and RLE codecs show the pattern.
+
+@subsection faq_ts_compat What if the receiver doesn't support my transfer syntax?
+
+During association negotiation, the SCU proposes all supported transfer syntaxes per presentation context. The SCP picks one it can handle. If there's no overlap, the presentation context is rejected and the SCU must either convert on the fly (see `dcm_conv`) or abort.
+
+@section faq_security Security Questions
+
+@subsection faq_tls How do I enable TLS for DICOM connections?
+
+Set `tls_enabled = true` in the association config and provide certificate paths:
+
+@code{.cpp}
+config.tls_enabled = true;
+config.tls_cert = "/etc/pacs/cert.pem";
+config.tls_key = "/etc/pacs/key.pem";
+config.tls_ca = "/etc/pacs/ca.pem";
+@endcode
+
+See `examples/secure_dicom/` for a full working example.
+
+@subsection faq_audit Does pacs_system support audit logging?
+
+Yes — audit events are emitted via logger_system's structured log sinks. Every C-STORE, C-FIND, C-MOVE, and login event produces a structured record suitable for SIEM ingestion.
+
+@section faq_integration Integration Questions
+
+@subsection faq_hospital_pacs How do I integrate with a hospital PACS?
+
+1. Coordinate AE titles, IP, port with the hospital's imaging IT team.
+2. Register your AE at the hospital PACS and vice versa.
+3. Agree on SOP classes and transfer syntaxes.
+4. Test with `echo_scu` (simplest) before attempting store or query.
+5. Verify audit logs match the hospital's compliance requirements.
+
+@subsection faq_dicomweb DICOMweb services?
+
+Yes — pacs_system ships with `pacs_web` library supporting WADO-RS (retrieve), STOW-RS (store), and QIDO-RS (query) via the Crow REST framework. See the `pacs_web/` module.
+
+@section faq_storage Storage Questions
+
+@subsection faq_storage_backends What storage backends are available?
+
+- **File storage** — local filesystem, one file per object (default)
+- **SQLite indexing** — metadata index for fast Q/R
+- **AWS S3** — cloud blob storage (optional, `PACS_WITH_AWS_SDK`)
+- **Azure Blob** — cloud blob storage (optional, `PACS_WITH_AZURE_SDK`)
+- **HSM** — hierarchical storage management integration hooks
+
+@section faq_perf Performance Questions
+
+@subsection faq_perf_tuning How do I tune for high-throughput ingestion?
+
+1. Use async storage (`file_storage` with write-behind buffering).
+2. Increase the network thread pool (`network_system` settings).
+3. Enable pipeline mode in the DIMSE handler — multiple DIMSE commands per association.
+4. Use a lock-free job queue for incoming objects (default in release builds).
+5. See `docs/performance/` for benchmark data.
+
+@section faq_ai AI Integration
+
+@subsection faq_ai_service How does AI integration work?
+
+`pacs_ai` provides an `ai_service_connector` that forwards DICOM objects to an AI endpoint and receives results as SR (Structured Report) or SEG (Segmentation) objects. The results are then stored alongside the source objects and made retrievable via Q/R.
+
+@section faq_conformance Conformance Testing
+
+@subsection faq_conformance_test How do I run conformance tests?
+
+pacs_system's test suite includes DCMTK interop tests that verify wire-level compatibility with the reference DCMTK implementation. Run `ctest -R dcmtk` to execute them. For formal conformance, use a third-party validator like DVTk.
+
+*/

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -204,6 +204,17 @@ target_link_libraries(your_target PRIVATE kcenon::pacs_core)
 | find_scu | @ref find_scu | Query remote PACS with C-FIND |
 | pacs_server | @ref pacs_server | Full PACS server with SCP services |
 
+@section learning_resources Learning Resources
+
+New to pacs_system? Start here:
+
+- @ref tutorial_dicom_basics "Tutorial: DICOM Fundamentals"
+- @ref tutorial_store_workflow "Tutorial: C-STORE Workflow"
+- @ref tutorial_query_retrieve "Tutorial: Query/Retrieve"
+- @ref tutorial_cli_tools "Tutorial: CLI Tools"
+- @ref faq "Frequently Asked Questions"
+- @ref troubleshooting "Troubleshooting Guide"
+
 @section related Related Systems
 
 PACS System is the highest-level application (Tier 5) in the kcenon ecosystem.

--- a/docs/troubleshooting.dox
+++ b/docs/troubleshooting.dox
@@ -1,0 +1,78 @@
+/**
+@page troubleshooting Troubleshooting Guide
+
+@tableofcontents
+
+@section ts_association Association Rejection
+
+**Symptom**: SCU receives `A-ASSOCIATE-RJ` during connect, no DIMSE commands ever flow.
+
+**Common causes**:
+
+1. **Wrong Called AE Title.** The server checks the Called AE Title and rejects mismatches. Verify with the remote admin — the default AE title `ANY-SCP` is rarely valid in production.
+2. **Wrong Calling AE Title.** Many servers maintain an allowlist of known peers. Ask the remote to register your Calling AE Title.
+3. **No matching presentation contexts.** The SCU proposed SOP classes or transfer syntaxes the SCP doesn't accept. Use `dcmtk`'s `echoscu -v` or our `echo_scu --verbose` to see the negotiation details.
+4. **TLS mismatch.** If one side requires TLS and the other doesn't, you see a connection abort before DICOM-level association. Check TLS config on both ends.
+
+@section ts_ts_mismatch Transfer Syntax Mismatch
+
+**Symptom**: `dcm_info` shows one transfer syntax, but C-STORE fails with "no matching presentation context".
+
+**Cause**: The SCU proposed the file's actual transfer syntax, but the SCP only accepts a different one.
+
+**Fix**: Convert the file first with `dcm_conv --to explicit_vr_le input.dcm converted.dcm`, then send. Or configure the SCP to accept the original syntax.
+
+@section ts_incomplete Incomplete DICOM Files
+
+**Symptom**: `dcm_info` reports "unexpected end of file" or "invalid tag".
+
+**Causes**:
+
+1. **Transfer was aborted mid-stream** and the file is truncated. Compare file size with the expected size.
+2. **Missing File Meta Information header.** Part 10 files must start with a 128-byte preamble followed by "DICM" magic. Files without it aren't valid Part 10.
+3. **Implicit-VR data being read as Explicit-VR.** The transfer syntax in the File Meta header determines how the dataset is parsed. If the header lies about the syntax, parsing fails.
+
+Use `dcm_dump --raw` to inspect the first few tags without full parsing.
+
+@section ts_network Network Connectivity
+
+**Symptom**: `echo_scu` times out or connection refused.
+
+**Checks**:
+
+1. `telnet <host> <port>` — does the port even respond? If not, firewall or routing.
+2. Is the server actually listening? `netstat -an | grep <port>` on the server.
+3. Are you hitting the right port? DICOM commonly uses 104 (privileged) or 11112 (unprivileged).
+4. Is there a reverse proxy stripping DICOM traffic? Some SSL terminators corrupt DIMSE.
+5. On macOS, the firewall prompts for incoming connections on new listeners — click Allow.
+
+@section ts_storage_commit Storage Commitment Failures
+
+**Symptom**: Storage Commitment N-ACTION returns, but the subsequent N-EVENT-REPORT never arrives or reports failure.
+
+**Causes**:
+
+1. The destination AE for N-EVENT-REPORT is unreachable. The SCP tries to push the result back and fails silently.
+2. The SOP instances were never fully persisted before the commitment query ran.
+3. The SCU and SCP disagree on the list of objects being committed — ensure SOP instance UIDs match byte-for-byte.
+
+@section ts_build Build Issues
+
+**Symptom**: "ICU not found" or "SQLite not found" during CMake configuration.
+
+**Fix**: pacs_system requires ICU for charset encoding and SQLite3 ≥ 3.45.1 for the storage index. Install via your package manager:
+
+```
+# Ubuntu/Debian
+sudo apt install libicu-dev libsqlite3-dev
+
+# macOS
+brew install icu4c sqlite3
+
+# vcpkg
+vcpkg install icu sqlite3
+```
+
+Windows builds should use the vcpkg preset to ensure ICU and SQLite are available.
+
+*/

--- a/docs/tutorial_cli_tools.dox
+++ b/docs/tutorial_cli_tools.dox
@@ -1,0 +1,78 @@
+/**
+@page tutorial_cli_tools Tutorial: CLI Tools
+
+@tableofcontents
+
+@section cli_goal Goal
+
+Use pacs_system's bundled command-line tools for common DICOM operations without writing code: inspection, conversion, anonymization, and query/retrieve.
+
+@section cli_info dcm_info — Quick file summary
+
+```
+dcm_info patient001.dcm
+```
+
+Prints a human-readable summary: patient name, study date, modality, transfer syntax, and image dimensions. Use this for sanity-checking files.
+
+@section cli_dump dcm_dump — Full metadata dump
+
+```
+dcm_dump patient001.dcm > dump.txt
+```
+
+Dumps every tag and value to stdout. Useful for debugging vendor-specific quirks or verifying that private tags are being written correctly.
+
+@section cli_conv dcm_conv — Transfer syntax conversion
+
+```
+dcm_conv --to explicit_vr_le input.dcm output.dcm
+dcm_conv --to jpeg2000_lossless input.dcm output.dcm
+```
+
+Re-encodes the pixel data to a different transfer syntax without touching other metadata. Use for compatibility with older receivers or to save space via lossless compression.
+
+@section cli_anon dcm_anonymize — De-identification
+
+```
+dcm_anonymize --profile basic input.dcm output.dcm
+```
+
+Removes or replaces patient-identifying tags per DICOM PS3.15 profiles. The `basic` profile covers Safe Harbor de-identification; other profiles include retention options for research scenarios.
+
+@warning Always verify the output with `dcm_dump` before sharing anonymized files — misconfigured profiles may leave identifying information in private tags.
+
+@section cli_query query_scu — Remote query
+
+```
+query_scu --host pacs.example.com --port 11112 \
+          --called-ae REMOTE_PACS --calling-ae MY_TOOL \
+          --level study --patient-id 12345
+```
+
+Performs a C-FIND query against a remote PACS and prints matching studies. Handy for ad-hoc troubleshooting without writing a client.
+
+@section cli_more More tools
+
+pacs_system ships with 28+ CLI examples. See the `examples/` directory for the full list:
+
+- `dcm_extract` — extract pixel data to JPEG/PNG
+- `dcm_modify` — edit tags in place
+- `dcm_dir` — create DICOMDIR media
+- `dcm_to_json` / `json_to_dcm` — JSON round-trip
+- `echo_scu` / `echo_scp` — test connectivity
+- `store_scu` / `store_scp` — storage services
+- `worklist_scu` / `worklist_scp` — modality worklist
+
+@section cli_mistakes Common Mistakes
+
+- **Forgetting --called-ae.** Most servers reject associations with a default or empty called AE title. Always specify the expected AE title of the remote.
+- **Firewall blocks DICOM port.** Default DICOM port is 104 (privileged) or 11112 (unprivileged). Check both ends of the connection.
+- **Anonymization profile mismatch.** The `basic` profile is conservative; research studies often need the `retain-longitudinal-temporal-information` option to keep dates relative.
+
+@section cli_next Next Steps
+
+- @ref faq "FAQ"
+- @ref troubleshooting "Troubleshooting"
+
+*/

--- a/docs/tutorial_dicom_basics.dox
+++ b/docs/tutorial_dicom_basics.dox
@@ -1,0 +1,93 @@
+/**
+@page tutorial_dicom_basics Tutorial: DICOM Fundamentals
+
+@tableofcontents
+
+@section dicom_goal Goal
+
+Understand DICOM concepts well enough to navigate pacs_system's API: SOP classes, transfer syntaxes, UIDs, and the four-level hierarchy (Patient/Study/Series/Image).
+
+@section dicom_what What is DICOM?
+
+DICOM (Digital Imaging and Communications in Medicine) is the standard for medical imaging data exchange. Unlike JPEG or PNG, a DICOM file bundles the pixels with rich metadata: patient identity, modality (CT, MR, US, etc.), acquisition parameters, and administrative information.
+
+pacs_system implements the DICOM standard from scratch with no external DICOM library — every byte of the wire format and file format is handled by code you can read and modify.
+
+@section dicom_sop SOP Classes
+
+A SOP (Service-Object Pair) class combines an object type with a service operation. For example:
+
+- **CT Image Storage** — CT scan pixel data + C-STORE service = "I can send/receive CT images"
+- **Patient Root Query/Retrieve** — Patient hierarchy + C-FIND/C-MOVE = "I can search and fetch by patient"
+
+Each SOP class is identified by a unique UID (e.g., `1.2.840.10008.5.1.4.1.1.2` for CT Image Storage). pacs_system supports 27 SOP classes covering CT, MR, US, XA, NM, PET, RT, SR, SEG, MG, CR, SC storage plus Query/Retrieve, MWL, MPPS, Storage Commitment, Print, and UPS.
+
+@section dicom_ts Transfer Syntaxes
+
+A transfer syntax specifies how data is encoded on the wire: byte order, VR representation, and compression.
+
+- **Implicit VR Little Endian** (`1.2.840.10008.1.2`) — default, uncompressed
+- **Explicit VR Little Endian** (`1.2.840.10008.1.2.1`) — more robust, uncompressed
+- **JPEG Baseline** — lossy compression for 8-bit images
+- **JPEG Lossless** — lossless compression
+- **JPEG 2000** — modern lossless/lossy
+- **HTJ2K** — high-throughput JPEG 2000
+- **RLE Lossless** — simple lossless
+
+The receiver advertises which syntaxes it accepts during association negotiation; the sender picks one of the accepted syntaxes for each presentation context.
+
+@section dicom_uid UIDs
+
+A UID (Unique Identifier) is a globally unique dotted-numeric string. DICOM uses UIDs for:
+
+- **SOP Class UIDs** — identify what kind of object/service
+- **Transfer Syntax UIDs** — identify the encoding
+- **Study/Series/SOP Instance UIDs** — identify specific patient data
+
+pacs_system provides `uid_generator` to create valid UIDs rooted at your organization's prefix.
+
+@section dicom_hierarchy Patient/Study/Series/Image Hierarchy
+
+Every DICOM object belongs to a four-level hierarchy:
+
+@code
+Patient (John Smith)
+  └── Study (2026-04-01 abdominal CT)
+        └── Series (axial, 3mm slices)
+              └── Image (slice 1 of 64)
+              └── Image (slice 2 of 64)
+              └── ...
+@endcode
+
+Query/Retrieve services operate at any level: find all studies for a patient, retrieve all images in a series, etc.
+
+@section dicom_read Read your first DICOM file
+
+@code{.cpp}
+#include <pacs/core/dataset.h>
+#include <pacs/core/part10_reader.h>
+
+int main(int argc, char** argv) {
+    pacs::core::part10_reader reader;
+    auto result = reader.read(argv[1]);
+    if (result.is_error()) {
+        std::cerr << "Read failed: " << result.error().message << std::endl;
+        return 1;
+    }
+
+    auto dataset = result.value();
+    auto patient_name = dataset.get_string(pacs::tags::patient_name);
+    auto modality = dataset.get_string(pacs::tags::modality);
+
+    std::cout << "Patient: " << patient_name.value_or("UNKNOWN") << "\n"
+              << "Modality: " << modality.value_or("UNKNOWN") << std::endl;
+}
+@endcode
+
+@section dicom_next Next Steps
+
+- @ref tutorial_store_workflow "Tutorial: C-STORE Workflow"
+- @ref tutorial_query_retrieve "Tutorial: Query/Retrieve"
+- @ref tutorial_cli_tools "Tutorial: CLI Tools"
+
+*/

--- a/docs/tutorial_query_retrieve.dox
+++ b/docs/tutorial_query_retrieve.dox
@@ -1,0 +1,96 @@
+/**
+@page tutorial_query_retrieve Tutorial: Query/Retrieve
+
+@tableofcontents
+
+@section qr_goal Goal
+
+Query a remote PACS for studies matching criteria (C-FIND), then retrieve the matching objects (C-MOVE or C-GET).
+
+@section qr_find Step 1: C-FIND query
+
+C-FIND searches the remote PACS and returns matching records — not the pixel data. You specify the query level (Patient, Study, Series, or Image) and fill in tags you want to match and tags you want to receive.
+
+@code{.cpp}
+#include <pacs/services/find_scu.h>
+
+services::find_scu_config config;
+config.peer_ae_title = "REMOTE_PACS";
+config.peer_host = "pacs.example.com";
+config.peer_port = 11112;
+config.query_level = services::query_level::study;
+
+services::find_scu scu(config);
+
+core::dataset query;
+query.set(tags::patient_id, "12345");
+query.set(tags::study_date, "20260301-20260406");  // range
+query.set(tags::modalities_in_study, "CT");
+query.set(tags::study_instance_uid, "");  // wanted in response
+
+auto results = scu.query(query);
+for (const auto& match : results.value()) {
+    std::cout << "Study: " << match.get_string(tags::study_instance_uid).value()
+              << " Date: " << match.get_string(tags::study_date).value_or("?")
+              << std::endl;
+}
+@endcode
+
+@section qr_move Step 2: C-MOVE retrieval
+
+C-MOVE tells the remote PACS to push matched objects to a destination AE. The destination can be your local C-STORE SCP (see @ref tutorial_store_workflow) or any other registered SCP.
+
+@code{.cpp}
+#include <pacs/services/move_scu.h>
+
+services::move_scu_config config;
+config.peer_ae_title = "REMOTE_PACS";
+config.peer_host = "pacs.example.com";
+config.peer_port = 11112;
+config.destination_ae = "MY_LOCAL_STORE";
+
+services::move_scu scu(config);
+
+core::dataset request;
+request.set(tags::study_instance_uid, "1.2.3.4.5.6.7");
+
+auto result = scu.move(request);
+std::cout << "Moved " << result.value().completed << " objects" << std::endl;
+@endcode
+
+@section qr_get Step 3: C-GET alternative
+
+C-GET fetches objects back over the same association — no separate C-STORE SCP required. Simpler for one-off retrievals, but not all servers support it.
+
+@code{.cpp}
+#include <pacs/services/get_scu.h>
+
+services::get_scu scu(config);
+scu.set_on_received([](const core::dataset& ds) {
+    // Handle each incoming object
+    save_to_disk(ds);
+});
+auto result = scu.get(request);
+@endcode
+
+@section qr_levels Query Hierarchy Levels
+
+Query level determines what unit is returned:
+
+- **Patient**: one row per patient
+- **Study**: one row per study (typical for worklists)
+- **Series**: one row per series (drill-down)
+- **Image**: one row per image/instance (rarely used due to volume)
+
+@section qr_mistakes Common Mistakes
+
+- **Missing required tags.** Each query level has required matching keys. Omitting `patient_root_q_r` patient-level's `patient_id` causes the query to be rejected.
+- **Wildcard in wrong place.** `*` matches anything; `?` matches one character. But date/time fields don't support wildcards — use ranges like `20260301-20260406`.
+- **C-MOVE destination unknown.** The remote PACS must have your destination AE registered, or the move fails with "unknown move destination".
+
+@section qr_next Next Steps
+
+- @ref tutorial_cli_tools "Tutorial: CLI Tools" — one-liner queries via `query_scu`
+- `examples/find_scu/` and `examples/move_scu/`
+
+*/

--- a/docs/tutorial_store_workflow.dox
+++ b/docs/tutorial_store_workflow.dox
@@ -1,0 +1,80 @@
+/**
+@page tutorial_store_workflow Tutorial: C-STORE Workflow
+
+@tableofcontents
+
+@section store_goal Goal
+
+Set up a minimal DICOM store server (SCP) and a matching client (SCU) that sends a DICOM file to it.
+
+@section store_scp Step 1: Run a C-STORE SCP (Storage Provider)
+
+The SCP listens on a TCP port, accepts DICOM associations, receives incoming objects, and writes them to storage.
+
+@code{.cpp}
+#include <pacs/services/store_scp.h>
+#include <pacs/storage/file_storage.h>
+
+using namespace pacs;
+
+int main() {
+    auto storage = std::make_shared<storage::file_storage>("./dicom_store");
+
+    services::store_scp_config config;
+    config.ae_title = "PACS_STORE";
+    config.port = 11112;
+
+    services::store_scp scp(config, storage);
+    scp.set_on_received([](const core::dataset& ds) {
+        auto sop_uid = ds.get_string(tags::sop_instance_uid);
+        std::cout << "Received: " << sop_uid.value_or("?") << std::endl;
+    });
+
+    scp.run();  // blocks, listening
+}
+@endcode
+
+@section store_scu Step 2: Send a file from a C-STORE SCU (Storage User)
+
+@code{.cpp}
+#include <pacs/services/store_scu.h>
+#include <pacs/core/part10_reader.h>
+
+int main(int argc, char** argv) {
+    core::part10_reader reader;
+    auto dataset = reader.read(argv[1]).value();
+
+    services::store_scu_config config;
+    config.peer_ae_title = "PACS_STORE";
+    config.peer_host = "localhost";
+    config.peer_port = 11112;
+    config.calling_ae_title = "MY_WORKSTATION";
+
+    services::store_scu scu(config);
+    auto result = scu.send(dataset);
+    if (result.is_ok()) {
+        std::cout << "Stored successfully\n";
+    } else {
+        std::cerr << "Store failed: " << result.error().message << "\n";
+    }
+}
+@endcode
+
+@section store_negotiation Association Negotiation
+
+Before any DIMSE command flows, the SCU and SCP negotiate an association. The SCU proposes presentation contexts (SOP class + acceptable transfer syntaxes), and the SCP accepts or rejects each.
+
+pacs_system's association state machine handles this automatically. You only interact with it if you need to debug failures (see @ref troubleshooting "Troubleshooting").
+
+@section store_mistakes Common Mistakes
+
+- **Wrong AE title.** The SCP rejects associations with an unexpected Called AE Title.
+- **SOP class not supported.** The SCP's presentation context list must include the SOP class of the object being sent.
+- **Transfer syntax mismatch.** If the SCU proposes only JPEG 2000 and the SCP supports only Implicit VR, negotiation fails.
+
+@section store_next Next Steps
+
+- @ref tutorial_query_retrieve "Tutorial: Query/Retrieve"
+- `examples/store_scp/` and `examples/store_scu/` for runnable demos
+
+*/


### PR DESCRIPTION
Closes #1072

## Summary
- Add 4 tutorials: DICOM fundamentals, C-STORE workflow, Query/Retrieve, CLI tools
- Add FAQ page covering SOP classes, transfer syntaxes, security, integration, storage, performance, AI, conformance
- Add troubleshooting guide for association rejection, TS mismatch, incomplete files, network, storage commitment, build issues
- Update mainpage.dox with Learning Resources section
- Update Doxyfile INPUT paths

## Test Plan
- Verify Doxygen CI build passes
- Verify @ref cross-links resolve correctly