### PR TITLE
docs(vcpkg): document all 12 exported targets in usage file

### DIFF
--- a/vcpkg-ports/kcenon-pacs-system/usage
+++ b/vcpkg-ports/kcenon-pacs-system/usage
@@ -1,13 +1,23 @@
 The package kcenon-pacs-system provides CMake targets:
 
     find_package(pacs_system CONFIG REQUIRED)
+
+    # Core targets (always available)
     target_link_libraries(main PRIVATE
-        pacs_system::core
-        pacs_system::encoding
-        pacs_system::network
-        pacs_system::client
-        pacs_system::services
-        pacs_system::security
+        pacs_system::core           # Tags, elements, datasets, Part 10 file I/O, dictionary
+        pacs_system::encoding       # VR types, transfer syntaxes, compression codecs
+        pacs_system::network        # PDU encode/decode, association state machine, DIMSE
+        pacs_system::client         # Job/routing/sync/prefetch/remote node management
+        pacs_system::services       # SCP/SCU implementations, SOP class registry
+        pacs_system::security       # RBAC, anonymization, digital signatures, TLS
+        pacs_system::integration    # Adapters to kcenon ecosystem (container, logger, network)
     )
 
-Available features: storage, codecs, ssl, aws, azure, rest-api
+    # Optional targets (require enabling the corresponding vcpkg feature)
+    target_link_libraries(main PRIVATE
+        pacs_system::storage        # [storage]  SQLite3-based PACS storage and indexing
+        pacs_system::ai             # [storage]  AI service connector, result handler (SR/SEG)
+        pacs_system::monitoring     # [storage]  Health checks, Prometheus metrics
+        pacs_system::workflow       # [storage]  Auto prefetch, task scheduler, study lock
+        pacs_system::web            # [rest-api] DICOMweb REST API (WADO/STOW/QIDO) via Crow
+    )


### PR DESCRIPTION
## What

### Summary
The vcpkg usage file only documented 6 core targets out of the 12 that pacs_system exports. This PR adds the missing 6 optional targets with feature annotations so consumers know which vcpkg feature to enable for each target.

### Change Type
- [x] Documentation

## Why

### Related Issues
- Closes #1079

### Motivation
Users installing `kcenon-pacs-system` via vcpkg had no documentation for the `integration`, `storage`, `ai`, `monitoring`, `workflow`, and `web` targets. This made it difficult to discover and use the full set of available libraries.

## Where

### Files Changed
| File | Change |
|------|--------|
| `vcpkg-ports/kcenon-pacs-system/usage` | Added 6 missing targets with feature annotations |

### Targets Added

| Target | Category | Enabling Feature |
|--------|----------|-----------------|
| `pacs_system::integration` | Core (always available) | — |
| `pacs_system::storage` | Optional | `storage` |
| `pacs_system::ai` | Optional | `storage` |
| `pacs_system::monitoring` | Optional | `storage` |
| `pacs_system::workflow` | Optional | `storage` |
| `pacs_system::web` | Optional | `rest-api` |

## How

### Implementation Details
- Reorganized the usage file into "Core targets" and "Optional targets" sections
- Added inline comments describing each target's purpose
- Added `[feature]` annotations showing which vcpkg feature enables each optional target
- Moved `pacs_system::integration` to core targets since it only requires the mandatory kcenon ecosystem dependencies

### Test Plan
- Verify the usage file renders correctly when running `vcpkg install kcenon-pacs-system`
- Cross-reference target names against `cmake/install.cmake` and `cmake/targets.cmake`