### PR TITLE
fix(cmake): gate JPEG codec compilation with PACS_BUILD_CODECS flag

### DIFF
--- a/src/encoding/compression/jpeg_baseline_codec.cpp
+++ b/src/encoding/compression/jpeg_baseline_codec.cpp
@@ -7,17 +7,21 @@
 #include <kcenon/pacs/core/result.h>
 
 #include <algorithm>
-#include <csetjmp>
-#include <cstdio>
 #include <stdexcept>
 
-// libjpeg-turbo headers
+// libjpeg-turbo headers (only when JPEG codec is enabled)
+#ifdef PACS_WITH_JPEG_CODEC
+#include <csetjmp>
+#include <cstdio>
 #include <jpeglib.h>
 #include <jerror.h>
+#endif
 
 namespace kcenon::pacs::encoding::compression {
 
 namespace {
+
+#ifdef PACS_WITH_JPEG_CODEC
 
 /**
  * @brief Custom error handler for libjpeg that uses exceptions.
@@ -111,7 +115,7 @@ private:
     jpeg_error_handler jerr_{};
 };
 
-// Helper function for creating codec errors
+// Helper function for creating codec results
 codec_result make_compression_error(const std::string& message) {
     return kcenon::pacs::pacs_error<compression_result>(
         kcenon::pacs::error_codes::compression_error, message);
@@ -125,6 +129,8 @@ codec_result make_decompression_error(const std::string& message) {
 codec_result make_compression_ok(std::vector<uint8_t> data, const image_params& params) {
     return kcenon::pacs::ok<compression_result>(compression_result{std::move(data), params});
 }
+
+#endif  // PACS_WITH_JPEG_CODEC
 
 }  // namespace
 
@@ -142,7 +148,14 @@ public:
         std::span<const uint8_t> pixel_data,
         const image_params& params,
         const compression_options& options) const {
-
+#ifndef PACS_WITH_JPEG_CODEC
+        (void)pixel_data;
+        (void)params;
+        (void)options;
+        return kcenon::pacs::pacs_error<compression_result>(
+            kcenon::pacs::error_codes::compression_error,
+            "JPEG Baseline codec not available: libjpeg-turbo not found at build time");
+#else
         if (pixel_data.empty()) {
             return make_compression_error("Empty pixel data");
         }
@@ -250,12 +263,19 @@ public:
         image_params output_params = params;
 
         return make_compression_ok(std::move(result), output_params);
+#endif  // PACS_WITH_JPEG_CODEC
     }
 
     [[nodiscard]] codec_result decode(
         std::span<const uint8_t> compressed_data,
         const image_params& params) const {
-
+#ifndef PACS_WITH_JPEG_CODEC
+        (void)compressed_data;
+        (void)params;
+        return kcenon::pacs::pacs_error<compression_result>(
+            kcenon::pacs::error_codes::decompression_error,
+            "JPEG Baseline codec not available: libjpeg-turbo not found at build time");
+#else
         if (compressed_data.empty()) {
             return make_decompression_error("Empty compressed data");
         }
@@ -336,6 +356,7 @@ public:
         }
 
         return make_compression_ok(std::move(output), output_params);
+#endif  // PACS_WITH_JPEG_CODEC
     }
 };
 


### PR DESCRIPTION
## What

### Summary
Add `#ifdef PACS_WITH_JPEG_CODEC` preprocessor guards to `jpeg_baseline_codec.cpp` so that
libjpeg-turbo headers are not included when codecs are disabled (`PACS_BUILD_CODECS=OFF`).

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/encoding/compression/jpeg_baseline_codec.cpp`

## Why

### Problem Solved
When `kcenon-pacs-system` is installed via vcpkg WITHOUT the `codecs` feature, the vcpkg portfile
correctly sets `PACS_BUILD_CODECS=OFF`, which prevents `find_package(JPEG)` from running and leaves
`PACS_WITH_JPEG_CODEC` undefined. However, `jpeg_baseline_codec.cpp` unconditionally includes
`<jpeglib.h>`, causing a fatal compilation error:

```
jpeg_baseline_codec.cpp:40:10: fatal error: jpeglib.h: No such file or directory
```

This was worked around in port-version 8 by making `libjpeg-turbo` a core dependency, but that
defeats the purpose of the `codecs` feature toggle.

### Related Issues
- Closes #1081

### Alternative Approaches Considered
1. Exclude codec source files from `pacs_encoding` target in CMakeLists.txt when `PACS_BUILD_CODECS=OFF`
   - Rejected: would require significant CMake refactoring and could break module exports
2. Preprocessor guards in source file (chosen approach)
   - Matches the existing pattern already used by `jpeg2000_codec.cpp`, `jpeg_ls_codec.cpp`, and `htj2k_codec.cpp`

## Where

### Files Changed
| File | Type of Change |
|------|----------------|
| `src/encoding/compression/jpeg_baseline_codec.cpp` | Add preprocessor guards |

## How

### Implementation Details
1. Wrapped `#include <jpeglib.h>`, `#include <jerror.h>`, `#include <csetjmp>`, `#include <cstdio>` in `#ifdef PACS_WITH_JPEG_CODEC`
2. Wrapped all libjpeg-dependent code in the anonymous namespace (error handler, RAII wrappers, helpers) in `#ifdef PACS_WITH_JPEG_CODEC`
3. Added `#ifndef PACS_WITH_JPEG_CODEC` stub implementations for `encode()` and `decode()` that return descriptive errors
4. Follows the exact same pattern as `jpeg2000_codec.cpp`, `jpeg_ls_codec.cpp`, and `htj2k_codec.cpp`

### Testing
- When `PACS_BUILD_CODECS=ON` and libjpeg-turbo is found: `PACS_WITH_JPEG_CODEC` is defined, full implementation used (no behavior change)
- When `PACS_BUILD_CODECS=ON` and libjpeg-turbo is NOT found: `PACS_WITH_JPEG_CODEC` is not defined, stub returns error (no behavior change)
- When `PACS_BUILD_CODECS=OFF`: `PACS_WITH_JPEG_CODEC` is not defined, file compiles without libjpeg headers (fixes the bug)

### Breaking Changes
None