### PR TITLE
chore(vcpkg): sync port-version with registry

### DIFF
--- a/vcpkg-ports/kcenon-pacs-system/vcpkg.json
+++ b/vcpkg-ports/kcenon-pacs-system/vcpkg.json
@@ -1,7 +1,7 @@
 {
   "name": "kcenon-pacs-system",
   "version-semver": "0.1.0",
-  "port-version": 6,
+  "port-version": 9,
   "description": "Modern C++20 PACS (Picture Archiving and Communication System) built on the kcenon ecosystem",
   "homepage": "https://github.com/kcenon/pacs_system",
   "license": "BSD-3-Clause",
@@ -9,9 +9,14 @@
   "dependencies": [
     "kcenon-common-system",
     "kcenon-container-system",
+    "kcenon-logger-system",
     "kcenon-network-system",
     "kcenon-thread-system",
     "icu",
+    {
+      "name": "libjpeg-turbo",
+      "version>=": "3.0.2"
+    },
     {
       "name": "vcpkg-cmake",
       "host": true


### PR DESCRIPTION
Part of kcenon/vcpkg-registry#77

## Summary
- Update port-version from 6 to 9 to match registry
- Add missing `kcenon-logger-system` dependency
- Add missing `libjpeg-turbo` dependency (version >= 3.0.2)

## Test Plan
- [ ] vcpkg install --overlay-ports=vcpkg-ports kcenon-pacs-system succeeds