### PR TITLE
security(web): refresh lockfile to fix ReDoS CVEs

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2157,9 +2157,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.3.tgz",
+      "integrity": "sha512-MCV/fYJEbqx68aE58kv2cA/kiky1G8vux3OR6/jbS+jIMe/6fJWa0DTzJU7dqijOWYwHi1t29FlfYI9uytqlpA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2282,9 +2282,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2394,9 +2394,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary

Bumps three dev-only transitive dependencies past their patched versions to clear three open osv-scanner code-scanning alerts on `web/package-lock.json`.

| Alert | CVE | Package | Before | After |
|-------|-----|---------|--------|-------|
| #9 | CVE-2026-33750 | brace-expansion | 1.1.12 | **1.1.13** |
| #10 | CVE-2026-33750 | brace-expansion | 2.0.2 | **2.0.3** |
| #6 | CVE-2025-69873 | ajv | 6.12.6 | **6.14.0** |

## Why

- **CVE-2026-33750 (brace-expansion)** — a `{1..2..0}` zero-step pattern hangs the sequence-generation loop for ~3.5 s and allocates ~1.9 GB before throwing `RangeError`. Any `expand()` caller (minimatch, glob, downstream eslint tooling) is exposed to a build-time DoS via untrusted glob patterns.
- **CVE-2025-69873 (ajv)** — with `$data: true`, the `pattern` keyword passes runtime data straight to `RegExp()`, enabling catastrophic backtracking (44 s CPU on a 31-byte payload).

Both packages live exclusively in the dev tree (`eslint → @eslint/eslintrc`, `eslint → minimatch@3.x`, `typescript-eslint → minimatch@9.x`), so production bundles produced by `vite build` are unaffected. End-user PACS runtime is not exposed — this PR exists to clear CI signal noise and harden the local build environment.

## Where

| File | Change |
|------|--------|
| `web/package-lock.json` | 9 insertions / 9 deletions — only the three transitive entries above |
| `web/package.json` | **Unchanged** (transitive refresh only) |

## How

```bash
cd web
npm update brace-expansion ajv
```

Direct dependencies (`web/package.json`) untouched. The lockfile diff is symmetric (9+/9-) and contains no other version drift.

## Test Plan

- [x] `npm ls brace-expansion` shows only `1.1.13` and `2.0.3`
- [x] `npm ls ajv` shows only `6.14.0` (deduped)
- [x] `npm audit` reports `0 vulnerabilities`
- [x] `npm run build` succeeds (5.29 s, 2527 modules transformed)
- [ ] After merge: code-scanning alerts #6, #9, #10 transition to `fixed`
- [ ] After merge: no new Critical/High Dependabot alerts introduced

### Note on `npm run lint`

Running `npm run lint` reports 3 errors and 3 warnings, **all of which exist on `main` prior to this PR**. They originate from `src/components/ui/{input,textarea,toast}.tsx` and `src/pages/{ConfigPage,PatientsPage}.tsx` — files this PR does not touch. Per the project's "Surgical Precision" principle, fixing them is out of scope and will be tracked in a separate follow-up issue.

CI does not currently run `npm run lint` for `web/` (verified via `.github/workflows`), which is why pre-existing lint debt has not been gating merges.

## Risk & Rollback

- **Risk**: Very low. Patch-level transitive bumps in dev-only packages, lockfile-only diff.
- **Rollback**: `git revert <merge-commit>` and `npm install`.

Closes #1090