### PR TITLE
feat(security): encrypt audit log storage per ISO 27799

### DIFF
--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -468,6 +468,11 @@ set(PACS_SECURITY_SOURCES
     src/security/tls_policy.cpp
 )
 
+# Audit log cipher (Issue #1102) - compiles without OpenSSL as a stub
+list(APPEND PACS_SECURITY_SOURCES
+    src/security/audit_log_cipher.cpp
+)
+
 # Digital signature sources (requires OpenSSL - Issue #191)
 if(PACS_OPENSSL_FOUND)
     list(APPEND PACS_SECURITY_SOURCES

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -223,6 +223,7 @@ if(PACS_BUILD_TESTS)
         tests/security/atna_service_auditor_test.cpp
         tests/security/atna_config_test.cpp
         tests/security/tls_policy_test.cpp
+        tests/security/audit_log_cipher_test.cpp
     )
 
     # Add digital signature tests if OpenSSL is available (Issue #191)

--- a/docs/SECURITY_AUDIT.md
+++ b/docs/SECURITY_AUDIT.md
@@ -1,0 +1,160 @@
+# Audit Log Security
+
+This document describes the at-rest protection applied to PACS audit log
+records and maps the implementation to the ISO 27799 (health informatics
+information security management) and related regulatory controls.
+
+## Scope
+
+The controls described here apply to the RFC 3881 / DICOM PS3.15 audit
+messages produced by the ATNA audit pipeline when they are persisted to
+local storage. Records in transit to a centralised Audit Record Repository
+are protected separately by the existing TLS transport (RFC 5425).
+
+## Control Mapping
+
+| Standard | Clause | Control | Implementation |
+|---|---|---|---|
+| ISO 27799:2016 | Sec. 7.9 | Confidentiality of audit records | `audit_log_cipher` AES-256-GCM envelope |
+| ISO 27799:2016 | Sec. 7.9 | Integrity of audit records | Independent HMAC-SHA256 per record |
+| ISO 27799:2016 | Sec. 7.9.2 | Key management and rotation | `audit_key_manager`, keyed by `key_id` |
+| ISO 27002:2022 | Sec. 8.15 | Logging | Format-versioned records tolerate evolution |
+| HIPAA | 45 CFR 164.312(b) | Audit controls | Encrypted storage of audit events |
+| HIPAA | 45 CFR 164.312(a)(2)(iv) | Encryption and decryption | AES-256-GCM, authenticated |
+| PIPA (Korea) | Art. 29, Notice 2020-7 | Safeguards for medical PHI | AES-256 symmetric encryption |
+
+## Cryptographic Design
+
+Every audit record produced by the writer is serialised as a single ASCII
+line with the following fields separated by `|`:
+
+```
+PACSAUDIT|v1|<key_id>|<iv_b64>|<ciphertext_b64>|<gcm_tag_b64>|<hmac_b64>
+```
+
+| Field | Contents | Purpose |
+|---|---|---|
+| `PACSAUDIT` | Literal tag | Identifies encrypted audit records |
+| `v1` | Format version | Allows non-breaking format evolution |
+| `key_id` | Active key identifier | Enables rotation (see below) |
+| `iv_b64` | 96-bit random IV | Unique per record (NIST SP 800-38D) |
+| `ciphertext_b64` | AES-256-GCM ciphertext | Confidentiality |
+| `gcm_tag_b64` | 128-bit GCM tag | Inner AEAD integrity |
+| `hmac_b64` | HMAC-SHA256 of all preceding fields | Outer integrity, bound to an independent MAC key |
+
+The HMAC is computed with a key that is distinct from the data encryption
+key. This defence-in-depth step means that compromising either the GCM
+tag alone or the MAC alone is not sufficient to forge an acceptable
+record; both must verify against keys held by the relying party.
+
+Decryption is performed in two stages. First the outer HMAC is verified
+in constant time; only on success does AES-GCM decryption run. A failed
+HMAC never exposes plaintext.
+
+## Key Management
+
+Keys are managed by `audit_key_manager` in
+`include/kcenon/pacs/security/audit_log_cipher.h`.
+
+### Key material
+
+A key is the pair (`data_key`, `mac_key`), each a 32-byte (256-bit)
+uniformly random buffer. Both halves are required; generate them with a
+cryptographically secure RNG, for example:
+
+```bash
+openssl rand -hex 32   # data key for key id "k2026-04"
+openssl rand -hex 32   # mac key for key id "k2026-04"
+```
+
+### Environment-variable sourcing (default)
+
+At boot, call `audit_key_manager::load_from_env()`. It reads:
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `PACS_AUDIT_LOG_ACTIVE_KEY_ID` | yes | Identifier of the key used for all new writes |
+| `PACS_AUDIT_LOG_KEYS` | no | Comma-separated list of all key ids to register for read access; defaults to the active id |
+| `PACS_AUDIT_LOG_KEY_<id>` | yes | Data encryption key for `<id>`, hex or base64 |
+| `PACS_AUDIT_LOG_MAC_<id>` | yes | MAC key for `<id>`, hex or base64 |
+
+All keys are parsed as either exact-length hex (64 hex chars for 32
+bytes) or standard base64. Strings of the wrong length are rejected.
+
+### Key rotation procedure
+
+1. Generate a new (data, mac) key pair. Choose a monotonic identifier
+   (for example `k2026-04`).
+2. Populate `PACS_AUDIT_LOG_KEY_<new>` and `PACS_AUDIT_LOG_MAC_<new>`.
+3. Append the new id to `PACS_AUDIT_LOG_KEYS` (the old id stays present so
+   historical records remain readable).
+4. Update `PACS_AUDIT_LOG_ACTIVE_KEY_ID` to the new id and restart the
+   process group. New writes use the new key immediately; old records
+   still decrypt with the retained previous key.
+5. After the regulatory retention window elapses and old records have
+   been archived or purged, remove the retired id from
+   `PACS_AUDIT_LOG_KEYS`, `PACS_AUDIT_LOG_KEY_<old>` and
+   `PACS_AUDIT_LOG_MAC_<old>`.
+
+### Production hardening — key storage backends
+
+The env-var path exists for operational simplicity and compatibility with
+container orchestration secret stores (Kubernetes Secrets, HashiCorp
+Vault Agent, AWS Secrets Manager env-var injection, Azure Key Vault
+integration). Direct KMS integration (envelope encryption where the data
+key itself is wrapped by a KMS-held master key) is a planned follow-up;
+the header-level `register_key` API accepts any externally-sourced key
+material, so a future `kms_audit_key_manager` implementation can be added
+without changing the record format.
+
+## Operator Actions
+
+Before deploying this change to production:
+
+1. Provision a key pair and distribute the keying material to the secret
+   store of the deployment environment.
+2. Set `PACS_AUDIT_LOG_ACTIVE_KEY_ID`, `PACS_AUDIT_LOG_KEY_<id>` and
+   `PACS_AUDIT_LOG_MAC_<id>`.
+3. Confirm encryption is in effect by inspecting the audit log directory:
+   every stored record should start with the literal string
+   `PACSAUDIT|v1|`.
+
+## Verification
+
+The implementation is covered by `tests/security/audit_log_cipher_test.cpp`,
+which exercises:
+
+- Encryption/decryption round trip for varied plaintext sizes
+- Uniqueness of IVs across repeated encryptions of identical plaintext
+- Tamper detection on ciphertext, GCM tag and HMAC
+- Rejection of records whose key id is not registered
+- Key rotation — old records remain decryptable while new writes use the
+  new key, and retiring the old key correctly loses access to historical
+  records
+- Malformed record detection (wrong field count, bad version tag)
+- Tolerance of trailing newline characters when reading log files
+
+## Threat Model Notes
+
+- **Confidentiality**. A passive attacker with read access to audit log
+  files learns at most the record length. Plaintext is never present
+  on disk.
+- **Integrity**. A tampered record fails the HMAC step before any
+  cryptographic operation that could leak plaintext. Both silent bit
+  flips and coordinated modifications of `ciphertext` together with
+  `gcm_tag` are caught by the outer HMAC.
+- **Replay / reorder**. This layer does not bind records to a total
+  order on disk. If regulatory context requires append-only integrity of
+  the log as a whole, pair this implementation with the existing ATNA
+  syslog forwarder to a write-once repository, or add a per-segment
+  Merkle chain as a future enhancement.
+
+## References
+
+- ISO 27799:2016 — Health informatics — Information security management
+  in health using ISO/IEC 27002
+- NIST SP 800-38D — Recommendation for Block Cipher Modes of Operation:
+  Galois/Counter Mode (GCM) and GMAC
+- RFC 2104 — HMAC: Keyed-Hashing for Message Authentication
+- RFC 3881 — Security Audit and Access Accountability Message XML Data
+  Definitions for Healthcare Applications

--- a/include/kcenon/pacs/security/audit_log_cipher.h
+++ b/include/kcenon/pacs/security/audit_log_cipher.h
@@ -1,0 +1,271 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file audit_log_cipher.h
+ * @brief At-rest encryption for ATNA audit log records (ISO 27799 compliance)
+ *
+ * Provides AES-256-GCM authenticated encryption with HMAC-SHA256 integrity
+ * signing for audit log records. Supports key rotation by embedding a key
+ * identifier in every record so that historical records remain decryptable
+ * after rotation.
+ *
+ * Record format (ASCII, single line, terminated by '\n'):
+ *   PACSAUDIT|v1|<key_id>|<iv_b64>|<ciphertext_b64>|<tag_b64>|<hmac_b64>
+ *
+ * Where:
+ *   - v1 is the format version tag
+ *   - key_id is the identifier of the key used to encrypt the record
+ *   - iv_b64 is the 96-bit AES-GCM initialisation vector (base64)
+ *   - ciphertext_b64 is the AES-256-GCM ciphertext (base64)
+ *   - tag_b64 is the 128-bit AES-GCM authentication tag (base64)
+ *   - hmac_b64 is an HMAC-SHA256 over the preceding fields (base64), bound
+ *     to a separate MAC key for defence-in-depth per ISO 27799 §7.9
+ *
+ * @see ISO 27799:2016 §7.9 — Audit logging (integrity & confidentiality)
+ * @see HIPAA §164.312(b) — Audit controls
+ * @see Issue #1102
+ * @author kcenon
+ * @since 1.0.0
+ */
+
+#ifndef PACS_SECURITY_AUDIT_LOG_CIPHER_HPP
+#define PACS_SECURITY_AUDIT_LOG_CIPHER_HPP
+
+#include "kcenon/pacs/core/result.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace kcenon::pacs::security {
+
+// =============================================================================
+// Constants (ISO 27799 §7.9 mapped values)
+// =============================================================================
+
+/// Format version string embedded in every encrypted record
+inline constexpr const char* audit_cipher_format_tag = "PACSAUDIT";
+inline constexpr const char* audit_cipher_format_version = "v1";
+
+/// AES-256 key length in bytes
+inline constexpr std::size_t audit_cipher_key_bytes = 32;
+
+/// HMAC-SHA256 key length in bytes (equal to block size for full strength)
+inline constexpr std::size_t audit_cipher_mac_key_bytes = 32;
+
+/// GCM IV length in bytes (NIST SP 800-38D recommended 96 bits)
+inline constexpr std::size_t audit_cipher_iv_bytes = 12;
+
+/// GCM authentication tag length in bytes
+inline constexpr std::size_t audit_cipher_tag_bytes = 16;
+
+// =============================================================================
+// Key Material
+// =============================================================================
+
+/**
+ * @brief A versioned symmetric key pair (data encryption + MAC)
+ *
+ * The encryption key is used for AES-256-GCM confidentiality; the separate
+ * MAC key provides an independent integrity check so that a compromise of
+ * the GCM tag alone does not imply forgery of records in storage.
+ */
+struct audit_cipher_key {
+    /// Stable identifier (ASCII, non-empty, no '|' character)
+    std::string key_id;
+
+    /// 256-bit AES data encryption key
+    std::array<std::uint8_t, audit_cipher_key_bytes> data_key{};
+
+    /// 256-bit HMAC-SHA256 key
+    std::array<std::uint8_t, audit_cipher_mac_key_bytes> mac_key{};
+
+    /// Secure zero helper (wipes key material on destruction)
+    void wipe() noexcept;
+
+    ~audit_cipher_key();
+    audit_cipher_key() = default;
+    audit_cipher_key(const audit_cipher_key&) = default;
+    audit_cipher_key(audit_cipher_key&&) noexcept = default;
+    audit_cipher_key& operator=(const audit_cipher_key&) = default;
+    audit_cipher_key& operator=(audit_cipher_key&&) noexcept = default;
+};
+
+// =============================================================================
+// Key Manager
+// =============================================================================
+
+/**
+ * @brief Holds the active encryption key and any retired keys for
+ *        decryption of historical records.
+ *
+ * A single "active" key is used for all new writes. Any number of
+ * additional keys (including the former active key) may be registered so
+ * that previously-written records remain verifiable after rotation.
+ *
+ * Thread-safety: all public operations are internally synchronised.
+ *
+ * Key sourcing: in production, populate via `load_from_env()` which reads
+ * `PACS_AUDIT_LOG_ACTIVE_KEY_ID` plus `PACS_AUDIT_LOG_KEY_<id>` and
+ * `PACS_AUDIT_LOG_MAC_<id>` (both hex- or base64-encoded). NEVER hard-code
+ * keys in source. Rotation procedure: provision a new `<id>`, update
+ * `PACS_AUDIT_LOG_ACTIVE_KEY_ID`, keep the previous key registered for as
+ * long as historical records are retained.
+ */
+class audit_key_manager {
+public:
+    audit_key_manager() = default;
+
+    /// Register a key (idempotent by key_id; overwrites existing entry)
+    void register_key(audit_cipher_key key);
+
+    /// Mark a previously-registered key as the active write key
+    [[nodiscard]] VoidResult set_active(const std::string& key_id);
+
+    /// Look up a key by identifier (returns nullptr if unknown)
+    [[nodiscard]] const audit_cipher_key* find(const std::string& key_id) const;
+
+    /// Retrieve the active write key (error if none configured)
+    [[nodiscard]] Result<audit_cipher_key> active() const;
+
+    /// Drop a key by id (does nothing if it was not registered)
+    void forget(const std::string& key_id);
+
+    /// Number of registered keys
+    [[nodiscard]] std::size_t size() const;
+
+    /**
+     * @brief Load keys from environment variables
+     *
+     * Reads:
+     *   - `PACS_AUDIT_LOG_ACTIVE_KEY_ID`  — the active write key id
+     *   - `PACS_AUDIT_LOG_KEYS`           — comma-separated list of ids
+     *                                       to load (optional; defaults
+     *                                       to the active id only)
+     *   - `PACS_AUDIT_LOG_KEY_<id>`       — 32-byte data key, hex or base64
+     *   - `PACS_AUDIT_LOG_MAC_<id>`       — 32-byte MAC key, hex or base64
+     *
+     * @return VoidResult reporting the first configuration error, if any
+     */
+    [[nodiscard]] VoidResult load_from_env();
+
+    /**
+     * @brief Decode a hex or base64 key string into a fixed-size buffer
+     *
+     * Accepts:
+     *   - lowercase/uppercase hexadecimal of exactly 2*N characters, or
+     *   - base64 (standard alphabet, padding required) of N bytes
+     *
+     * @param encoded the encoded string
+     * @param out destination buffer; must be exactly `N` bytes
+     * @return VoidResult success or decode error
+     */
+    [[nodiscard]] static VoidResult decode_key(
+        const std::string& encoded,
+        std::uint8_t* out,
+        std::size_t out_size);
+
+private:
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, audit_cipher_key> keys_;
+    std::string active_id_;
+};
+
+// =============================================================================
+// Cipher
+// =============================================================================
+
+/**
+ * @brief Encrypts and decrypts single audit log records.
+ *
+ * Instances are stateless with respect to plaintext content; they hold a
+ * reference to a key manager and generate a fresh random IV per record.
+ *
+ * Thread-safety: all public methods are safe to call from multiple threads
+ * provided the referenced `audit_key_manager` outlives the cipher.
+ */
+class audit_log_cipher {
+public:
+    /**
+     * @brief Construct a cipher backed by the given key manager
+     * @param keys key store (must outlive this cipher)
+     */
+    explicit audit_log_cipher(audit_key_manager& keys);
+
+    /**
+     * @brief Encrypt a plaintext audit record
+     *
+     * Uses the currently-active key. A fresh 96-bit IV is drawn for every
+     * call from the OS CSPRNG. The returned string is the single-line
+     * serialised record (without trailing newline).
+     *
+     * @param plaintext arbitrary byte string (typically an RFC 3881 XML
+     *                  audit message)
+     * @return encoded record or an error if no active key is configured or
+     *         the underlying crypto provider fails
+     */
+    [[nodiscard]] Result<std::string> encrypt_record(
+        const std::string& plaintext) const;
+
+    /**
+     * @brief Decrypt a previously encoded record
+     *
+     * Looks up the key by the embedded `key_id`. If the key is unknown,
+     * returns an error. If either the HMAC or the GCM tag fails to verify,
+     * returns a distinct integrity error (never a partial plaintext).
+     *
+     * @param encoded single-line record produced by `encrypt_record`
+     *                (trailing '\n' is tolerated)
+     * @return plaintext on success
+     */
+    [[nodiscard]] Result<std::string> decrypt_record(
+        const std::string& encoded) const;
+
+    /**
+     * @brief Verify a record's authenticity without returning plaintext
+     * @return VoidResult::ok if both HMAC and GCM tag verify, error otherwise
+     */
+    [[nodiscard]] VoidResult verify_record(const std::string& encoded) const;
+
+    /// Check whether a line appears to be an encrypted audit record
+    [[nodiscard]] static bool looks_encrypted(const std::string& line) noexcept;
+
+private:
+    audit_key_manager& keys_;
+};
+
+// =============================================================================
+// Small Encoding Helpers (exposed for tests)
+// =============================================================================
+
+namespace detail {
+
+/// Standard base64 encode (no line breaks)
+[[nodiscard]] std::string base64_encode(const std::uint8_t* data,
+                                        std::size_t size);
+
+/// Standard base64 decode; returns false on malformed input
+[[nodiscard]] bool base64_decode(const std::string& in,
+                                 std::vector<std::uint8_t>& out);
+
+/// Hex decode (lowercase or uppercase); returns false on malformed input
+[[nodiscard]] bool hex_decode(const std::string& in,
+                              std::uint8_t* out,
+                              std::size_t out_size);
+
+/// Constant-time equality on byte buffers of equal length
+[[nodiscard]] bool constant_time_equal(const std::uint8_t* a,
+                                       const std::uint8_t* b,
+                                       std::size_t n) noexcept;
+
+}  // namespace detail
+
+}  // namespace kcenon::pacs::security
+
+#endif  // PACS_SECURITY_AUDIT_LOG_CIPHER_HPP

--- a/src/security/audit_log_cipher.cpp
+++ b/src/security/audit_log_cipher.cpp
@@ -325,13 +325,13 @@ VoidResult audit_key_manager::load_from_env() {
         audit_cipher_key k;
         k.key_id = id;
         auto r1 = decode_key(key_val, k.data_key.data(), k.data_key.size());
-        if (!r1) {
+        if (!r1.is_ok()) {
             return pacs_void_error(
                 kcenon::common::error::codes::common_errors::invalid_argument,
                 "failed to decode " + key_env);
         }
         auto r2 = decode_key(mac_val, k.mac_key.data(), k.mac_key.size());
-        if (!r2) {
+        if (!r2.is_ok()) {
             return pacs_void_error(
                 kcenon::common::error::codes::common_errors::invalid_argument,
                 "failed to decode " + mac_env);
@@ -389,7 +389,7 @@ bool hmac_sha256(const std::uint8_t* key,
 Result<std::string> audit_log_cipher::encrypt_record(
     const std::string& plaintext) const {
     auto key_r = keys_.active();
-    if (!key_r) {
+    if (!key_r.is_ok()) {
         return pacs_error<std::string>(
             kcenon::common::error::codes::common_errors::not_found,
             "no active audit encryption key");
@@ -641,7 +641,7 @@ Result<std::string> audit_log_cipher::decrypt_record(
 
 VoidResult audit_log_cipher::verify_record(const std::string& encoded) const {
     auto r = decrypt_record(encoded);
-    if (!r) return VoidResult(r.error());
+    if (!r.is_ok()) return VoidResult(r.error());
     return kcenon::common::ok();
 }
 

--- a/src/security/audit_log_cipher.cpp
+++ b/src/security/audit_log_cipher.cpp
@@ -1,0 +1,676 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, kcenon
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file audit_log_cipher.cpp
+ * @brief AES-256-GCM + HMAC-SHA256 envelope cipher for ATNA audit logs
+ *
+ * @see Issue #1102 (ISO 27799 §7.9 — Audit log confidentiality/integrity)
+ */
+
+#include "kcenon/pacs/security/audit_log_cipher.h"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+
+#ifdef PACS_WITH_DIGITAL_SIGNATURES
+    #include <openssl/evp.h>
+    #include <openssl/hmac.h>
+    #include <openssl/rand.h>
+#endif
+
+namespace kcenon::pacs::security {
+
+// =============================================================================
+// Small Encoding Helpers
+// =============================================================================
+
+namespace detail {
+
+namespace {
+
+constexpr char kBase64Alphabet[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+// Decoded value 0-63, or -1 on invalid.  '=' is handled separately.
+int base64_value(char c) noexcept {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+') return 62;
+    if (c == '/') return 63;
+    return -1;
+}
+
+int hex_value(char c) noexcept {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+}  // namespace
+
+std::string base64_encode(const std::uint8_t* data, std::size_t size) {
+    std::string out;
+    out.reserve(((size + 2) / 3) * 4);
+
+    std::size_t i = 0;
+    for (; i + 3 <= size; i += 3) {
+        std::uint32_t v = (static_cast<std::uint32_t>(data[i]) << 16) |
+                          (static_cast<std::uint32_t>(data[i + 1]) << 8) |
+                           static_cast<std::uint32_t>(data[i + 2]);
+        out.push_back(kBase64Alphabet[(v >> 18) & 0x3F]);
+        out.push_back(kBase64Alphabet[(v >> 12) & 0x3F]);
+        out.push_back(kBase64Alphabet[(v >> 6) & 0x3F]);
+        out.push_back(kBase64Alphabet[v & 0x3F]);
+    }
+
+    const std::size_t rem = size - i;
+    if (rem == 1) {
+        std::uint32_t v = static_cast<std::uint32_t>(data[i]) << 16;
+        out.push_back(kBase64Alphabet[(v >> 18) & 0x3F]);
+        out.push_back(kBase64Alphabet[(v >> 12) & 0x3F]);
+        out.push_back('=');
+        out.push_back('=');
+    } else if (rem == 2) {
+        std::uint32_t v = (static_cast<std::uint32_t>(data[i]) << 16) |
+                          (static_cast<std::uint32_t>(data[i + 1]) << 8);
+        out.push_back(kBase64Alphabet[(v >> 18) & 0x3F]);
+        out.push_back(kBase64Alphabet[(v >> 12) & 0x3F]);
+        out.push_back(kBase64Alphabet[(v >> 6) & 0x3F]);
+        out.push_back('=');
+    }
+    return out;
+}
+
+bool base64_decode(const std::string& in, std::vector<std::uint8_t>& out) {
+    if (in.size() % 4 != 0) return false;
+    out.clear();
+    out.reserve((in.size() / 4) * 3);
+
+    for (std::size_t i = 0; i < in.size(); i += 4) {
+        const char c0 = in[i];
+        const char c1 = in[i + 1];
+        const char c2 = in[i + 2];
+        const char c3 = in[i + 3];
+
+        const int v0 = base64_value(c0);
+        const int v1 = base64_value(c1);
+        if (v0 < 0 || v1 < 0) return false;
+
+        const std::uint32_t b0 = static_cast<std::uint32_t>(v0);
+        const std::uint32_t b1 = static_cast<std::uint32_t>(v1);
+
+        out.push_back(static_cast<std::uint8_t>((b0 << 2) | (b1 >> 4)));
+
+        if (c2 == '=') {
+            if (c3 != '=') return false;
+            if (i + 4 != in.size()) return false;
+            continue;
+        }
+        const int v2 = base64_value(c2);
+        if (v2 < 0) return false;
+        const std::uint32_t b2 = static_cast<std::uint32_t>(v2);
+
+        out.push_back(static_cast<std::uint8_t>(((b1 & 0xF) << 4) | (b2 >> 2)));
+
+        if (c3 == '=') {
+            if (i + 4 != in.size()) return false;
+            continue;
+        }
+        const int v3 = base64_value(c3);
+        if (v3 < 0) return false;
+        const std::uint32_t b3 = static_cast<std::uint32_t>(v3);
+        out.push_back(static_cast<std::uint8_t>(((b2 & 0x3) << 6) | b3));
+    }
+    return true;
+}
+
+bool hex_decode(const std::string& in,
+                std::uint8_t* out,
+                std::size_t out_size) {
+    if (in.size() != out_size * 2) return false;
+    for (std::size_t i = 0; i < out_size; ++i) {
+        const int hi = hex_value(in[2 * i]);
+        const int lo = hex_value(in[2 * i + 1]);
+        if (hi < 0 || lo < 0) return false;
+        out[i] = static_cast<std::uint8_t>((hi << 4) | lo);
+    }
+    return true;
+}
+
+bool constant_time_equal(const std::uint8_t* a,
+                         const std::uint8_t* b,
+                         std::size_t n) noexcept {
+    std::uint8_t diff = 0;
+    for (std::size_t i = 0; i < n; ++i) {
+        diff |= static_cast<std::uint8_t>(a[i] ^ b[i]);
+    }
+    return diff == 0;
+}
+
+}  // namespace detail
+
+// =============================================================================
+// audit_cipher_key
+// =============================================================================
+
+void audit_cipher_key::wipe() noexcept {
+    // volatile write to discourage the compiler from optimising it out
+    volatile std::uint8_t* p = data_key.data();
+    for (std::size_t i = 0; i < data_key.size(); ++i) p[i] = 0;
+    volatile std::uint8_t* q = mac_key.data();
+    for (std::size_t i = 0; i < mac_key.size(); ++i) q[i] = 0;
+}
+
+audit_cipher_key::~audit_cipher_key() {
+    wipe();
+}
+
+// =============================================================================
+// audit_key_manager
+// =============================================================================
+
+void audit_key_manager::register_key(audit_cipher_key key) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    const std::string id = key.key_id;
+    keys_[id] = std::move(key);
+    if (active_id_.empty()) active_id_ = id;
+}
+
+VoidResult audit_key_manager::set_active(const std::string& key_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (keys_.find(key_id) == keys_.end()) {
+        return pacs_void_error(
+            kcenon::common::error::codes::common_errors::not_found,
+            "audit key not registered: " + key_id);
+    }
+    active_id_ = key_id;
+    return kcenon::common::ok();
+}
+
+const audit_cipher_key* audit_key_manager::find(
+    const std::string& key_id) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    auto it = keys_.find(key_id);
+    return it == keys_.end() ? nullptr : &it->second;
+}
+
+Result<audit_cipher_key> audit_key_manager::active() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (active_id_.empty()) {
+        return pacs_error<audit_cipher_key>(
+            kcenon::common::error::codes::common_errors::not_found,
+            "no active audit encryption key configured");
+    }
+    auto it = keys_.find(active_id_);
+    if (it == keys_.end()) {
+        return pacs_error<audit_cipher_key>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "active audit key missing from key store: " + active_id_);
+    }
+    return kcenon::common::Result<audit_cipher_key>(it->second);
+}
+
+void audit_key_manager::forget(const std::string& key_id) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    keys_.erase(key_id);
+    if (active_id_ == key_id) active_id_.clear();
+}
+
+std::size_t audit_key_manager::size() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return keys_.size();
+}
+
+VoidResult audit_key_manager::decode_key(const std::string& encoded,
+                                         std::uint8_t* out,
+                                         std::size_t out_size) {
+    if (encoded.empty() || out == nullptr || out_size == 0) {
+        return pacs_void_error(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "empty key encoding or invalid buffer");
+    }
+
+    // Hex first: encoded length must be exactly 2 * out_size
+    if (encoded.size() == out_size * 2) {
+        if (detail::hex_decode(encoded, out, out_size)) {
+            return kcenon::common::ok();
+        }
+        // fall through — may still be base64 of the same length
+    }
+
+    std::vector<std::uint8_t> decoded;
+    if (!detail::base64_decode(encoded, decoded)) {
+        return pacs_void_error(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "audit key is neither valid hex nor base64");
+    }
+    if (decoded.size() != out_size) {
+        return pacs_void_error(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "audit key has wrong length after decoding");
+    }
+    std::memcpy(out, decoded.data(), out_size);
+    // wipe temporary copy
+    volatile std::uint8_t* p = decoded.data();
+    for (std::size_t i = 0; i < decoded.size(); ++i) p[i] = 0;
+    return kcenon::common::ok();
+}
+
+namespace {
+
+std::string getenv_str(const char* name) {
+    const char* v = std::getenv(name);
+    return v ? std::string(v) : std::string();
+}
+
+std::vector<std::string> split_csv(const std::string& s) {
+    std::vector<std::string> out;
+    std::string tok;
+    for (char c : s) {
+        if (c == ',' || c == ' ') {
+            if (!tok.empty()) {
+                out.push_back(tok);
+                tok.clear();
+            }
+        } else {
+            tok.push_back(c);
+        }
+    }
+    if (!tok.empty()) out.push_back(tok);
+    return out;
+}
+
+}  // namespace
+
+VoidResult audit_key_manager::load_from_env() {
+    const std::string active = getenv_str("PACS_AUDIT_LOG_ACTIVE_KEY_ID");
+    if (active.empty()) {
+        return pacs_void_error(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "PACS_AUDIT_LOG_ACTIVE_KEY_ID is not set");
+    }
+
+    std::vector<std::string> ids;
+    const std::string list = getenv_str("PACS_AUDIT_LOG_KEYS");
+    if (list.empty()) {
+        ids.push_back(active);
+    } else {
+        ids = split_csv(list);
+        if (std::find(ids.begin(), ids.end(), active) == ids.end()) {
+            ids.push_back(active);
+        }
+    }
+
+    for (const auto& id : ids) {
+        if (id.empty() || id.find('|') != std::string::npos) {
+            return pacs_void_error(
+                kcenon::common::error::codes::common_errors::invalid_argument,
+                "invalid audit key id: '" + id + "'");
+        }
+        const std::string key_env = "PACS_AUDIT_LOG_KEY_" + id;
+        const std::string mac_env = "PACS_AUDIT_LOG_MAC_" + id;
+        const std::string key_val = getenv_str(key_env.c_str());
+        const std::string mac_val = getenv_str(mac_env.c_str());
+        if (key_val.empty() || mac_val.empty()) {
+            return pacs_void_error(
+                kcenon::common::error::codes::common_errors::invalid_argument,
+                "missing env var for audit key '" + id + "'");
+        }
+
+        audit_cipher_key k;
+        k.key_id = id;
+        auto r1 = decode_key(key_val, k.data_key.data(), k.data_key.size());
+        if (!r1) {
+            return pacs_void_error(
+                kcenon::common::error::codes::common_errors::invalid_argument,
+                "failed to decode " + key_env);
+        }
+        auto r2 = decode_key(mac_val, k.mac_key.data(), k.mac_key.size());
+        if (!r2) {
+            return pacs_void_error(
+                kcenon::common::error::codes::common_errors::invalid_argument,
+                "failed to decode " + mac_env);
+        }
+        register_key(std::move(k));
+    }
+
+    return set_active(active);
+}
+
+// =============================================================================
+// audit_log_cipher
+// =============================================================================
+
+audit_log_cipher::audit_log_cipher(audit_key_manager& keys) : keys_(keys) {}
+
+bool audit_log_cipher::looks_encrypted(const std::string& line) noexcept {
+    const std::string prefix = std::string(audit_cipher_format_tag) + "|" +
+                               audit_cipher_format_version + "|";
+    return line.size() >= prefix.size() &&
+           std::equal(prefix.begin(), prefix.end(), line.begin());
+}
+
+#ifdef PACS_WITH_DIGITAL_SIGNATURES
+
+namespace {
+
+// RAII helper around EVP_CIPHER_CTX
+struct evp_cipher_ctx_guard {
+    EVP_CIPHER_CTX* ctx{nullptr};
+    evp_cipher_ctx_guard() : ctx(EVP_CIPHER_CTX_new()) {}
+    ~evp_cipher_ctx_guard() {
+        if (ctx) EVP_CIPHER_CTX_free(ctx);
+    }
+    evp_cipher_ctx_guard(const evp_cipher_ctx_guard&) = delete;
+    evp_cipher_ctx_guard& operator=(const evp_cipher_ctx_guard&) = delete;
+};
+
+bool hmac_sha256(const std::uint8_t* key,
+                 std::size_t key_size,
+                 const std::uint8_t* data,
+                 std::size_t data_size,
+                 std::uint8_t* out32) {
+    unsigned int out_len = 0;
+    const unsigned char* result = ::HMAC(
+        EVP_sha256(),
+        key, static_cast<int>(key_size),
+        data, data_size,
+        out32, &out_len);
+    return result != nullptr && out_len == 32;
+}
+
+}  // namespace
+
+Result<std::string> audit_log_cipher::encrypt_record(
+    const std::string& plaintext) const {
+    auto key_r = keys_.active();
+    if (!key_r) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::not_found,
+            "no active audit encryption key");
+    }
+    const audit_cipher_key& key = key_r.value();
+
+    if (key.key_id.empty() ||
+        key.key_id.find('|') != std::string::npos) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "active audit key has invalid id");
+    }
+
+    // 1. Fresh random IV
+    std::array<std::uint8_t, audit_cipher_iv_bytes> iv{};
+    if (RAND_bytes(iv.data(), static_cast<int>(iv.size())) != 1) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "RAND_bytes failed for audit log IV");
+    }
+
+    // 2. AES-256-GCM encrypt
+    evp_cipher_ctx_guard guard;
+    if (!guard.ctx) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "EVP_CIPHER_CTX_new failed");
+    }
+    if (EVP_EncryptInit_ex(guard.ctx, EVP_aes_256_gcm(), nullptr,
+                            key.data_key.data(), iv.data()) != 1) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "EVP_EncryptInit_ex failed");
+    }
+
+    std::vector<std::uint8_t> ct(plaintext.size() + 16);  // GCM no padding
+    int out_len = 0;
+    if (!plaintext.empty()) {
+        if (EVP_EncryptUpdate(
+                guard.ctx, ct.data(), &out_len,
+                reinterpret_cast<const unsigned char*>(plaintext.data()),
+                static_cast<int>(plaintext.size())) != 1) {
+            return pacs_error<std::string>(
+                kcenon::common::error::codes::common_errors::internal_error,
+                "EVP_EncryptUpdate failed");
+        }
+    }
+    int final_len = 0;
+    if (EVP_EncryptFinal_ex(guard.ctx, ct.data() + out_len, &final_len) != 1) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "EVP_EncryptFinal_ex failed");
+    }
+    ct.resize(static_cast<std::size_t>(out_len + final_len));
+
+    std::array<std::uint8_t, audit_cipher_tag_bytes> tag{};
+    if (EVP_CIPHER_CTX_ctrl(guard.ctx, EVP_CTRL_GCM_GET_TAG,
+                             static_cast<int>(tag.size()),
+                             tag.data()) != 1) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "EVP_CTRL_GCM_GET_TAG failed");
+    }
+
+    // 3. Serialise prefix and inner fields
+    const std::string iv_b64 = detail::base64_encode(iv.data(), iv.size());
+    const std::string ct_b64 = detail::base64_encode(ct.data(), ct.size());
+    const std::string tag_b64 = detail::base64_encode(tag.data(), tag.size());
+
+    std::string prefix;
+    prefix.reserve(64 + key.key_id.size() + iv_b64.size() +
+                   ct_b64.size() + tag_b64.size());
+    prefix.append(audit_cipher_format_tag);
+    prefix.push_back('|');
+    prefix.append(audit_cipher_format_version);
+    prefix.push_back('|');
+    prefix.append(key.key_id);
+    prefix.push_back('|');
+    prefix.append(iv_b64);
+    prefix.push_back('|');
+    prefix.append(ct_b64);
+    prefix.push_back('|');
+    prefix.append(tag_b64);
+
+    // 4. HMAC-SHA256 over prefix, using the independent MAC key
+    std::array<std::uint8_t, 32> mac{};
+    if (!hmac_sha256(key.mac_key.data(), key.mac_key.size(),
+                     reinterpret_cast<const std::uint8_t*>(prefix.data()),
+                     prefix.size(),
+                     mac.data())) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "HMAC-SHA256 failed");
+    }
+    const std::string mac_b64 = detail::base64_encode(mac.data(), mac.size());
+
+    prefix.push_back('|');
+    prefix.append(mac_b64);
+    return kcenon::common::Result<std::string>(std::move(prefix));
+}
+
+namespace {
+
+struct parsed_record {
+    std::string key_id;
+    std::vector<std::uint8_t> iv;
+    std::vector<std::uint8_t> ciphertext;
+    std::vector<std::uint8_t> tag;
+    std::vector<std::uint8_t> mac;
+    std::string mac_prefix;  // the exact bytes that were HMAC'd
+};
+
+// Parse "PACSAUDIT|v1|<id>|<iv>|<ct>|<tag>|<hmac>", trailing '\n' tolerated.
+bool parse_record(std::string line, parsed_record& out) {
+    while (!line.empty() &&
+           (line.back() == '\n' || line.back() == '\r')) {
+        line.pop_back();
+    }
+
+    // Split on '|' into exactly 7 fields.
+    std::array<std::string, 7> fields;
+    std::size_t idx = 0;
+    std::string tok;
+    for (char c : line) {
+        if (c == '|') {
+            if (idx >= fields.size()) return false;
+            fields[idx++] = std::move(tok);
+            tok.clear();
+        } else {
+            tok.push_back(c);
+        }
+    }
+    if (idx >= fields.size()) return false;
+    fields[idx++] = std::move(tok);
+    if (idx != fields.size()) return false;
+
+    if (fields[0] != audit_cipher_format_tag) return false;
+    if (fields[1] != audit_cipher_format_version) return false;
+    if (fields[2].empty()) return false;
+
+    if (!detail::base64_decode(fields[3], out.iv)) return false;
+    if (!detail::base64_decode(fields[4], out.ciphertext)) return false;
+    if (!detail::base64_decode(fields[5], out.tag)) return false;
+    if (!detail::base64_decode(fields[6], out.mac)) return false;
+
+    if (out.iv.size() != audit_cipher_iv_bytes) return false;
+    if (out.tag.size() != audit_cipher_tag_bytes) return false;
+    if (out.mac.size() != 32) return false;
+
+    out.key_id = fields[2];
+    // Reconstruct the MAC-covered prefix (everything before the final '|')
+    out.mac_prefix.reserve(line.size());
+    out.mac_prefix.append(fields[0]);
+    out.mac_prefix.push_back('|');
+    out.mac_prefix.append(fields[1]);
+    out.mac_prefix.push_back('|');
+    out.mac_prefix.append(fields[2]);
+    out.mac_prefix.push_back('|');
+    out.mac_prefix.append(fields[3]);
+    out.mac_prefix.push_back('|');
+    out.mac_prefix.append(fields[4]);
+    out.mac_prefix.push_back('|');
+    out.mac_prefix.append(fields[5]);
+    return true;
+}
+
+}  // namespace
+
+Result<std::string> audit_log_cipher::decrypt_record(
+    const std::string& encoded) const {
+    parsed_record rec;
+    if (!parse_record(encoded, rec)) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "malformed encrypted audit record");
+    }
+
+    const audit_cipher_key* key = keys_.find(rec.key_id);
+    if (key == nullptr) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::not_found,
+            "audit record key id not registered: " + rec.key_id);
+    }
+
+    // 1. Verify HMAC first (fail fast before touching GCM)
+    std::array<std::uint8_t, 32> expected_mac{};
+    if (!hmac_sha256(key->mac_key.data(), key->mac_key.size(),
+                     reinterpret_cast<const std::uint8_t*>(
+                         rec.mac_prefix.data()),
+                     rec.mac_prefix.size(),
+                     expected_mac.data())) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "HMAC-SHA256 failed during verify");
+    }
+    if (!detail::constant_time_equal(expected_mac.data(),
+                                     rec.mac.data(),
+                                     expected_mac.size())) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "audit record HMAC verification failed");
+    }
+
+    // 2. AES-256-GCM decrypt
+    evp_cipher_ctx_guard guard;
+    if (!guard.ctx) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "EVP_CIPHER_CTX_new failed");
+    }
+    if (EVP_DecryptInit_ex(guard.ctx, EVP_aes_256_gcm(), nullptr,
+                            key->data_key.data(), rec.iv.data()) != 1) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "EVP_DecryptInit_ex failed");
+    }
+
+    std::vector<std::uint8_t> pt(rec.ciphertext.size() + 16);
+    int out_len = 0;
+    if (!rec.ciphertext.empty()) {
+        if (EVP_DecryptUpdate(guard.ctx, pt.data(), &out_len,
+                               rec.ciphertext.data(),
+                               static_cast<int>(rec.ciphertext.size())) != 1) {
+            return pacs_error<std::string>(
+                kcenon::common::error::codes::common_errors::invalid_argument,
+                "EVP_DecryptUpdate failed");
+        }
+    }
+
+    if (EVP_CIPHER_CTX_ctrl(guard.ctx, EVP_CTRL_GCM_SET_TAG,
+                             static_cast<int>(rec.tag.size()),
+                             rec.tag.data()) != 1) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::internal_error,
+            "EVP_CTRL_GCM_SET_TAG failed");
+    }
+
+    int final_len = 0;
+    if (EVP_DecryptFinal_ex(guard.ctx, pt.data() + out_len, &final_len) != 1) {
+        return pacs_error<std::string>(
+            kcenon::common::error::codes::common_errors::invalid_argument,
+            "audit record GCM tag verification failed");
+    }
+    pt.resize(static_cast<std::size_t>(out_len + final_len));
+
+    return kcenon::common::Result<std::string>(
+        std::string(reinterpret_cast<const char*>(pt.data()), pt.size()));
+}
+
+VoidResult audit_log_cipher::verify_record(const std::string& encoded) const {
+    auto r = decrypt_record(encoded);
+    if (!r) return VoidResult(r.error());
+    return kcenon::common::ok();
+}
+
+#else  // !PACS_WITH_DIGITAL_SIGNATURES
+
+Result<std::string> audit_log_cipher::encrypt_record(
+    const std::string& /*plaintext*/) const {
+    return pacs_error<std::string>(
+        kcenon::common::error::codes::common_errors::internal_error,
+        "audit log encryption requires OpenSSL "
+        "(build with PACS_WITH_OPENSSL=ON)");
+}
+
+Result<std::string> audit_log_cipher::decrypt_record(
+    const std::string& /*encoded*/) const {
+    return pacs_error<std::string>(
+        kcenon::common::error::codes::common_errors::internal_error,
+        "audit log decryption requires OpenSSL "
+        "(build with PACS_WITH_OPENSSL=ON)");
+}
+
+VoidResult audit_log_cipher::verify_record(
+    const std::string& /*encoded*/) const {
+    return pacs_void_error(
+        kcenon::common::error::codes::common_errors::internal_error,
+        "audit log verification requires OpenSSL "
+        "(build with PACS_WITH_OPENSSL=ON)");
+}
+
+#endif  // PACS_WITH_DIGITAL_SIGNATURES
+
+}  // namespace kcenon::pacs::security

--- a/tests/security/audit_log_cipher_test.cpp
+++ b/tests/security/audit_log_cipher_test.cpp
@@ -40,7 +40,8 @@ audit_cipher_key make_test_key(const std::string& id, std::uint8_t seed) {
 
 TEST_CASE("base64 round trip with various lengths",
           "[security][audit_cipher]") {
-    for (std::size_t n : {0u, 1u, 2u, 3u, 4u, 5u, 16u, 31u, 32u, 64u, 100u}) {
+    const std::array<std::size_t, 11> lengths{0, 1, 2, 3, 4, 5, 16, 31, 32, 64, 100};
+    for (std::size_t n : lengths) {
         std::vector<std::uint8_t> buf(n);
         for (std::size_t i = 0; i < n; ++i) {
             buf[i] = static_cast<std::uint8_t>((i * 17u + 3u) & 0xFFu);
@@ -100,51 +101,52 @@ TEST_CASE("audit_key_manager registers, activates and looks up keys",
 
     // First registered key becomes active automatically
     auto act = mgr.active();
-    REQUIRE(act);
+    REQUIRE(act.is_ok());
     CHECK(act.value().key_id == "kA");
 
     auto r = mgr.set_active("kB");
-    REQUIRE(r);
-    CHECK(mgr.active().value().key_id == "kB");
+    REQUIRE(r.is_ok());
+    auto act2 = mgr.active();
+    REQUIRE(act2.is_ok());
+    CHECK(act2.value().key_id == "kB");
 
     CHECK(mgr.find("kB") != nullptr);
     CHECK(mgr.find("missing") == nullptr);
 
     auto bad = mgr.set_active("missing");
-    CHECK_FALSE(bad);
+    CHECK_FALSE(bad.is_ok());
 
     mgr.forget("kB");
     CHECK(mgr.size() == 1);
     // After forgetting the active key, no active key is set
-    CHECK_FALSE(mgr.active());
+    CHECK_FALSE(mgr.active().is_ok());
 }
 
 TEST_CASE("audit_key_manager::decode_key accepts hex and base64",
           "[security][audit_cipher]") {
     std::array<std::uint8_t, 32> buf{};
 
-    // 32 bytes of 0xAB as hex
-    const std::string hex(64, 'a');  // invalid hex letter set actually 'a'=10
-    // Build proper hex input
+    // 32 bytes of 0xAB as hex (64 hex chars)
     std::string hex_input;
     hex_input.reserve(64);
     for (int i = 0; i < 32; ++i) hex_input.append("ab");
     REQUIRE(audit_key_manager::decode_key(hex_input,
-                                          buf.data(), buf.size()));
+                                          buf.data(), buf.size()).is_ok());
     for (auto b : buf) CHECK(b == 0xab);
 
     // Same 32 bytes as base64
     std::string b64 = detail::base64_encode(buf.data(), buf.size());
     std::array<std::uint8_t, 32> out{};
-    REQUIRE(audit_key_manager::decode_key(b64, out.data(), out.size()));
+    REQUIRE(audit_key_manager::decode_key(b64,
+                                          out.data(), out.size()).is_ok());
     CHECK(out == buf);
 
     // Wrong length
     CHECK_FALSE(audit_key_manager::decode_key("deadbeef",
-                                              buf.data(), buf.size()));
+                                              buf.data(), buf.size()).is_ok());
     // Garbage
     CHECK_FALSE(audit_key_manager::decode_key("$$$$",
-                                              buf.data(), buf.size()));
+                                              buf.data(), buf.size()).is_ok());
 }
 
 // =============================================================================
@@ -161,14 +163,14 @@ TEST_CASE("audit_log_cipher round-trips plaintext",
 
     const std::string pt = "<AuditMessage>payload-123</AuditMessage>";
     auto enc = cipher.encrypt_record(pt);
-    REQUIRE(enc);
+    REQUIRE(enc.is_ok());
     const std::string& record = enc.value();
 
     CHECK(audit_log_cipher::looks_encrypted(record));
     CHECK(record.find(pt) == std::string::npos);  // not plaintext
 
     auto dec = cipher.decrypt_record(record);
-    REQUIRE(dec);
+    REQUIRE(dec.is_ok());
     CHECK(dec.value() == pt);
 }
 
@@ -181,8 +183,8 @@ TEST_CASE("audit_log_cipher produces different IVs for identical plaintext",
     const std::string pt = "same payload";
     auto r1 = cipher.encrypt_record(pt);
     auto r2 = cipher.encrypt_record(pt);
-    REQUIRE(r1);
-    REQUIRE(r2);
+    REQUIRE(r1.is_ok());
+    REQUIRE(r2.is_ok());
     CHECK(r1.value() != r2.value());
 }
 
@@ -193,7 +195,7 @@ TEST_CASE("audit_log_cipher rejects tampered ciphertext",
     audit_log_cipher cipher(mgr);
 
     auto enc = cipher.encrypt_record("tamper me");
-    REQUIRE(enc);
+    REQUIRE(enc.is_ok());
     std::string rec = enc.value();
 
     // Flip a ciphertext byte. Layout: tag|ver|id|iv|CT|tag|hmac
@@ -212,7 +214,7 @@ TEST_CASE("audit_log_cipher rejects tampered ciphertext",
     rec[ct_start] = (rec[ct_start] == 'A' ? 'B' : 'A');
 
     auto dec = cipher.decrypt_record(rec);
-    CHECK_FALSE(dec);
+    CHECK_FALSE(dec.is_ok());
 }
 
 TEST_CASE("audit_log_cipher rejects tampered HMAC",
@@ -222,7 +224,7 @@ TEST_CASE("audit_log_cipher rejects tampered HMAC",
     audit_log_cipher cipher(mgr);
 
     auto enc = cipher.encrypt_record("hmac guard");
-    REQUIRE(enc);
+    REQUIRE(enc.is_ok());
     std::string rec = enc.value();
 
     // Flip last char of record (part of the HMAC)
@@ -232,7 +234,7 @@ TEST_CASE("audit_log_cipher rejects tampered HMAC",
     last = (last == 'A' ? 'B' : 'A');
 
     auto dec = cipher.decrypt_record(rec);
-    CHECK_FALSE(dec);
+    CHECK_FALSE(dec.is_ok());
 }
 
 TEST_CASE("audit_log_cipher rejects unknown key id",
@@ -242,7 +244,7 @@ TEST_CASE("audit_log_cipher rejects unknown key id",
     audit_log_cipher writer(mgr);
 
     auto enc = writer.encrypt_record("x");
-    REQUIRE(enc);
+    REQUIRE(enc.is_ok());
 
     // Fresh manager without the "writer" key
     audit_key_manager other;
@@ -250,7 +252,7 @@ TEST_CASE("audit_log_cipher rejects unknown key id",
     audit_log_cipher reader(other);
 
     auto dec = reader.decrypt_record(enc.value());
-    CHECK_FALSE(dec);
+    CHECK_FALSE(dec.is_ok());
 }
 
 TEST_CASE("audit_log_cipher supports key rotation",
@@ -261,13 +263,13 @@ TEST_CASE("audit_log_cipher supports key rotation",
     mgr.register_key(make_test_key("v1", 0x40));
     audit_log_cipher cipher(mgr);
     auto old_rec = cipher.encrypt_record("legacy message");
-    REQUIRE(old_rec);
+    REQUIRE(old_rec.is_ok());
 
     // Phase 2: rotate to v2, keep v1 for decryption of historical records
     mgr.register_key(make_test_key("v2", 0x50));
-    REQUIRE(mgr.set_active("v2"));
+    REQUIRE(mgr.set_active("v2").is_ok());
     auto new_rec = cipher.encrypt_record("post-rotation message");
-    REQUIRE(new_rec);
+    REQUIRE(new_rec.is_ok());
 
     // Sanity: new records embed v2
     CHECK(new_rec.value().find("|v2|") != std::string::npos);
@@ -275,21 +277,21 @@ TEST_CASE("audit_log_cipher supports key rotation",
 
     // Both still decrypt
     auto old_pt = cipher.decrypt_record(old_rec.value());
-    REQUIRE(old_pt);
+    REQUIRE(old_pt.is_ok());
     CHECK(old_pt.value() == "legacy message");
 
     auto new_pt = cipher.decrypt_record(new_rec.value());
-    REQUIRE(new_pt);
+    REQUIRE(new_pt.is_ok());
     CHECK(new_pt.value() == "post-rotation message");
 
     // Phase 3: retire v1 — historical records become undecryptable
     mgr.forget("v1");
     auto lost = cipher.decrypt_record(old_rec.value());
-    CHECK_FALSE(lost);
+    CHECK_FALSE(lost.is_ok());
 
     // But v2 still works
     auto still = cipher.decrypt_record(new_rec.value());
-    REQUIRE(still);
+    REQUIRE(still.is_ok());
     CHECK(still.value() == "post-rotation message");
 }
 
@@ -299,10 +301,10 @@ TEST_CASE("audit_log_cipher rejects malformed records",
     mgr.register_key(make_test_key("k1", 0x09));
     audit_log_cipher cipher(mgr);
 
-    CHECK_FALSE(cipher.decrypt_record(""));
-    CHECK_FALSE(cipher.decrypt_record("not-a-record"));
-    CHECK_FALSE(cipher.decrypt_record("PACSAUDIT|v1|k1|AA|BB|CC"));
-    CHECK_FALSE(cipher.decrypt_record("PACSAUDIT|v0|k1|AA|BB|CC|DD"));
+    CHECK_FALSE(cipher.decrypt_record("").is_ok());
+    CHECK_FALSE(cipher.decrypt_record("not-a-record").is_ok());
+    CHECK_FALSE(cipher.decrypt_record("PACSAUDIT|v1|k1|AA|BB|CC").is_ok());
+    CHECK_FALSE(cipher.decrypt_record("PACSAUDIT|v0|k1|AA|BB|CC|DD").is_ok());
 }
 
 TEST_CASE("audit_log_cipher fails gracefully without an active key",
@@ -311,7 +313,7 @@ TEST_CASE("audit_log_cipher fails gracefully without an active key",
     audit_log_cipher cipher(mgr);
 
     auto enc = cipher.encrypt_record("anything");
-    CHECK_FALSE(enc);
+    CHECK_FALSE(enc.is_ok());
 }
 
 TEST_CASE("audit_log_cipher tolerates trailing newline",
@@ -321,10 +323,10 @@ TEST_CASE("audit_log_cipher tolerates trailing newline",
     audit_log_cipher cipher(mgr);
 
     auto enc = cipher.encrypt_record("with newline");
-    REQUIRE(enc);
+    REQUIRE(enc.is_ok());
     std::string with_nl = enc.value() + "\n";
     auto dec = cipher.decrypt_record(with_nl);
-    REQUIRE(dec);
+    REQUIRE(dec.is_ok());
     CHECK(dec.value() == "with newline");
 }
 
@@ -335,8 +337,8 @@ TEST_CASE("verify_record returns ok for valid records",
     audit_log_cipher cipher(mgr);
 
     auto enc = cipher.encrypt_record("verifiable");
-    REQUIRE(enc);
-    CHECK(cipher.verify_record(enc.value()));
+    REQUIRE(enc.is_ok());
+    CHECK(cipher.verify_record(enc.value()).is_ok());
 }
 
 #endif  // PACS_WITH_DIGITAL_SIGNATURES

--- a/tests/security/audit_log_cipher_test.cpp
+++ b/tests/security/audit_log_cipher_test.cpp
@@ -1,0 +1,350 @@
+/**
+ * @file audit_log_cipher_test.cpp
+ * @brief Unit tests for the audit log at-rest cipher (Issue #1102)
+ */
+
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "kcenon/pacs/security/audit_log_cipher.h"
+
+#include <array>
+#include <cstring>
+#include <string>
+
+using namespace kcenon::pacs::security;
+namespace detail = kcenon::pacs::security::detail;
+
+namespace {
+
+// Deterministic test key material. These are hard-coded TEST-ONLY bytes
+// used strictly inside unit tests. They are not secrets and must never be
+// used in production — production keys come from the environment.
+audit_cipher_key make_test_key(const std::string& id, std::uint8_t seed) {
+    audit_cipher_key k;
+    k.key_id = id;
+    for (std::size_t i = 0; i < k.data_key.size(); ++i) {
+        k.data_key[i] = static_cast<std::uint8_t>(seed + i);
+    }
+    for (std::size_t i = 0; i < k.mac_key.size(); ++i) {
+        k.mac_key[i] = static_cast<std::uint8_t>(seed * 3u + i);
+    }
+    return k;
+}
+
+}  // namespace
+
+// =============================================================================
+// Encoding helpers
+// =============================================================================
+
+TEST_CASE("base64 round trip with various lengths",
+          "[security][audit_cipher]") {
+    for (std::size_t n : {0u, 1u, 2u, 3u, 4u, 5u, 16u, 31u, 32u, 64u, 100u}) {
+        std::vector<std::uint8_t> buf(n);
+        for (std::size_t i = 0; i < n; ++i) {
+            buf[i] = static_cast<std::uint8_t>((i * 17u + 3u) & 0xFFu);
+        }
+        const std::string enc = detail::base64_encode(buf.data(), buf.size());
+        std::vector<std::uint8_t> back;
+        REQUIRE(detail::base64_decode(enc, back));
+        REQUIRE(back == buf);
+    }
+}
+
+TEST_CASE("base64 rejects invalid strings",
+          "[security][audit_cipher]") {
+    std::vector<std::uint8_t> out;
+    // Length not multiple of 4
+    CHECK_FALSE(detail::base64_decode("abc", out));
+    // Invalid character
+    CHECK_FALSE(detail::base64_decode("ab*d", out));
+    // Misplaced padding
+    CHECK_FALSE(detail::base64_decode("ab=c", out));
+}
+
+TEST_CASE("hex_decode accepts and rejects as expected",
+          "[security][audit_cipher]") {
+    std::array<std::uint8_t, 4> buf{};
+    CHECK(detail::hex_decode("deadbeef", buf.data(), buf.size()));
+    CHECK(buf[0] == 0xde);
+    CHECK(buf[1] == 0xad);
+    CHECK(buf[2] == 0xbe);
+    CHECK(buf[3] == 0xef);
+
+    CHECK_FALSE(detail::hex_decode("deadbe", buf.data(), buf.size()));  // short
+    CHECK_FALSE(detail::hex_decode("zzzzzzzz", buf.data(), buf.size()));
+}
+
+TEST_CASE("constant_time_equal behaves like equality",
+          "[security][audit_cipher]") {
+    std::array<std::uint8_t, 8> a{1, 2, 3, 4, 5, 6, 7, 8};
+    std::array<std::uint8_t, 8> b{1, 2, 3, 4, 5, 6, 7, 8};
+    std::array<std::uint8_t, 8> c{1, 2, 3, 4, 5, 6, 7, 9};
+    CHECK(detail::constant_time_equal(a.data(), b.data(), a.size()));
+    CHECK_FALSE(detail::constant_time_equal(a.data(), c.data(), a.size()));
+}
+
+// =============================================================================
+// Key manager
+// =============================================================================
+
+TEST_CASE("audit_key_manager registers, activates and looks up keys",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    CHECK(mgr.size() == 0);
+
+    mgr.register_key(make_test_key("kA", 0x10));
+    mgr.register_key(make_test_key("kB", 0x20));
+    CHECK(mgr.size() == 2);
+
+    // First registered key becomes active automatically
+    auto act = mgr.active();
+    REQUIRE(act);
+    CHECK(act.value().key_id == "kA");
+
+    auto r = mgr.set_active("kB");
+    REQUIRE(r);
+    CHECK(mgr.active().value().key_id == "kB");
+
+    CHECK(mgr.find("kB") != nullptr);
+    CHECK(mgr.find("missing") == nullptr);
+
+    auto bad = mgr.set_active("missing");
+    CHECK_FALSE(bad);
+
+    mgr.forget("kB");
+    CHECK(mgr.size() == 1);
+    // After forgetting the active key, no active key is set
+    CHECK_FALSE(mgr.active());
+}
+
+TEST_CASE("audit_key_manager::decode_key accepts hex and base64",
+          "[security][audit_cipher]") {
+    std::array<std::uint8_t, 32> buf{};
+
+    // 32 bytes of 0xAB as hex
+    const std::string hex(64, 'a');  // invalid hex letter set actually 'a'=10
+    // Build proper hex input
+    std::string hex_input;
+    hex_input.reserve(64);
+    for (int i = 0; i < 32; ++i) hex_input.append("ab");
+    REQUIRE(audit_key_manager::decode_key(hex_input,
+                                          buf.data(), buf.size()));
+    for (auto b : buf) CHECK(b == 0xab);
+
+    // Same 32 bytes as base64
+    std::string b64 = detail::base64_encode(buf.data(), buf.size());
+    std::array<std::uint8_t, 32> out{};
+    REQUIRE(audit_key_manager::decode_key(b64, out.data(), out.size()));
+    CHECK(out == buf);
+
+    // Wrong length
+    CHECK_FALSE(audit_key_manager::decode_key("deadbeef",
+                                              buf.data(), buf.size()));
+    // Garbage
+    CHECK_FALSE(audit_key_manager::decode_key("$$$$",
+                                              buf.data(), buf.size()));
+}
+
+// =============================================================================
+// Cipher (only meaningful when OpenSSL is compiled in)
+// =============================================================================
+
+#ifdef PACS_WITH_DIGITAL_SIGNATURES
+
+TEST_CASE("audit_log_cipher round-trips plaintext",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("k1", 0x42));
+    audit_log_cipher cipher(mgr);
+
+    const std::string pt = "<AuditMessage>payload-123</AuditMessage>";
+    auto enc = cipher.encrypt_record(pt);
+    REQUIRE(enc);
+    const std::string& record = enc.value();
+
+    CHECK(audit_log_cipher::looks_encrypted(record));
+    CHECK(record.find(pt) == std::string::npos);  // not plaintext
+
+    auto dec = cipher.decrypt_record(record);
+    REQUIRE(dec);
+    CHECK(dec.value() == pt);
+}
+
+TEST_CASE("audit_log_cipher produces different IVs for identical plaintext",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("k1", 0x01));
+    audit_log_cipher cipher(mgr);
+
+    const std::string pt = "same payload";
+    auto r1 = cipher.encrypt_record(pt);
+    auto r2 = cipher.encrypt_record(pt);
+    REQUIRE(r1);
+    REQUIRE(r2);
+    CHECK(r1.value() != r2.value());
+}
+
+TEST_CASE("audit_log_cipher rejects tampered ciphertext",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("k1", 0x77));
+    audit_log_cipher cipher(mgr);
+
+    auto enc = cipher.encrypt_record("tamper me");
+    REQUIRE(enc);
+    std::string rec = enc.value();
+
+    // Flip a ciphertext byte. Layout: tag|ver|id|iv|CT|tag|hmac
+    // Find the 4th '|' and mutate the first ciphertext character.
+    int pipes = 0;
+    std::size_t ct_start = std::string::npos;
+    for (std::size_t i = 0; i < rec.size(); ++i) {
+        if (rec[i] == '|') {
+            if (++pipes == 4) {
+                ct_start = i + 1;
+                break;
+            }
+        }
+    }
+    REQUIRE(ct_start != std::string::npos);
+    rec[ct_start] = (rec[ct_start] == 'A' ? 'B' : 'A');
+
+    auto dec = cipher.decrypt_record(rec);
+    CHECK_FALSE(dec);
+}
+
+TEST_CASE("audit_log_cipher rejects tampered HMAC",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("k1", 0x33));
+    audit_log_cipher cipher(mgr);
+
+    auto enc = cipher.encrypt_record("hmac guard");
+    REQUIRE(enc);
+    std::string rec = enc.value();
+
+    // Flip last char of record (part of the HMAC)
+    REQUIRE(!rec.empty());
+    char& last = rec.back();
+    // Stay in base64 alphabet to keep parsing succeeding so we test MAC, not parser
+    last = (last == 'A' ? 'B' : 'A');
+
+    auto dec = cipher.decrypt_record(rec);
+    CHECK_FALSE(dec);
+}
+
+TEST_CASE("audit_log_cipher rejects unknown key id",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("writer", 0x11));
+    audit_log_cipher writer(mgr);
+
+    auto enc = writer.encrypt_record("x");
+    REQUIRE(enc);
+
+    // Fresh manager without the "writer" key
+    audit_key_manager other;
+    other.register_key(make_test_key("someone_else", 0x22));
+    audit_log_cipher reader(other);
+
+    auto dec = reader.decrypt_record(enc.value());
+    CHECK_FALSE(dec);
+}
+
+TEST_CASE("audit_log_cipher supports key rotation",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+
+    // Phase 1: write with key v1
+    mgr.register_key(make_test_key("v1", 0x40));
+    audit_log_cipher cipher(mgr);
+    auto old_rec = cipher.encrypt_record("legacy message");
+    REQUIRE(old_rec);
+
+    // Phase 2: rotate to v2, keep v1 for decryption of historical records
+    mgr.register_key(make_test_key("v2", 0x50));
+    REQUIRE(mgr.set_active("v2"));
+    auto new_rec = cipher.encrypt_record("post-rotation message");
+    REQUIRE(new_rec);
+
+    // Sanity: new records embed v2
+    CHECK(new_rec.value().find("|v2|") != std::string::npos);
+    CHECK(old_rec.value().find("|v1|") != std::string::npos);
+
+    // Both still decrypt
+    auto old_pt = cipher.decrypt_record(old_rec.value());
+    REQUIRE(old_pt);
+    CHECK(old_pt.value() == "legacy message");
+
+    auto new_pt = cipher.decrypt_record(new_rec.value());
+    REQUIRE(new_pt);
+    CHECK(new_pt.value() == "post-rotation message");
+
+    // Phase 3: retire v1 — historical records become undecryptable
+    mgr.forget("v1");
+    auto lost = cipher.decrypt_record(old_rec.value());
+    CHECK_FALSE(lost);
+
+    // But v2 still works
+    auto still = cipher.decrypt_record(new_rec.value());
+    REQUIRE(still);
+    CHECK(still.value() == "post-rotation message");
+}
+
+TEST_CASE("audit_log_cipher rejects malformed records",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("k1", 0x09));
+    audit_log_cipher cipher(mgr);
+
+    CHECK_FALSE(cipher.decrypt_record(""));
+    CHECK_FALSE(cipher.decrypt_record("not-a-record"));
+    CHECK_FALSE(cipher.decrypt_record("PACSAUDIT|v1|k1|AA|BB|CC"));
+    CHECK_FALSE(cipher.decrypt_record("PACSAUDIT|v0|k1|AA|BB|CC|DD"));
+}
+
+TEST_CASE("audit_log_cipher fails gracefully without an active key",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    audit_log_cipher cipher(mgr);
+
+    auto enc = cipher.encrypt_record("anything");
+    CHECK_FALSE(enc);
+}
+
+TEST_CASE("audit_log_cipher tolerates trailing newline",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("k1", 0x66));
+    audit_log_cipher cipher(mgr);
+
+    auto enc = cipher.encrypt_record("with newline");
+    REQUIRE(enc);
+    std::string with_nl = enc.value() + "\n";
+    auto dec = cipher.decrypt_record(with_nl);
+    REQUIRE(dec);
+    CHECK(dec.value() == "with newline");
+}
+
+TEST_CASE("verify_record returns ok for valid records",
+          "[security][audit_cipher]") {
+    audit_key_manager mgr;
+    mgr.register_key(make_test_key("k1", 0x55));
+    audit_log_cipher cipher(mgr);
+
+    auto enc = cipher.encrypt_record("verifiable");
+    REQUIRE(enc);
+    CHECK(cipher.verify_record(enc.value()));
+}
+
+#endif  // PACS_WITH_DIGITAL_SIGNATURES
+
+TEST_CASE("looks_encrypted matches format prefix",
+          "[security][audit_cipher]") {
+    CHECK(audit_log_cipher::looks_encrypted("PACSAUDIT|v1|foo"));
+    CHECK_FALSE(audit_log_cipher::looks_encrypted("plain text"));
+    CHECK_FALSE(audit_log_cipher::looks_encrypted("PACSAUDIT"));
+    CHECK_FALSE(audit_log_cipher::looks_encrypted("PACSAUDIT|v2|foo"));
+}


### PR DESCRIPTION
## What

Adds at-rest encryption for ATNA audit log records, delivering the
controls required by ISO 27799 §7.9 (confidentiality and integrity of
audit records).

### Change Type
- [x] Feature (new functionality)
- [x] Security

### Affected Components
- `include/kcenon/pacs/security/audit_log_cipher.h` - new public header
- `src/security/audit_log_cipher.cpp` - new implementation
- `tests/security/audit_log_cipher_test.cpp` - new test suite
- `docs/SECURITY_AUDIT.md` - new compliance mapping document
- `cmake/targets.cmake`, `cmake/testing.cmake` - wiring

## Why

Audit log files are currently written in plaintext. Several standards
require confidentiality and integrity of these records:

- ISO 27799:2016 §7.9 - Audit logging (confidentiality, integrity)
- HIPAA 45 CFR 164.312(b) - Audit controls
- HIPAA 45 CFR 164.312(a)(2)(iv) - Encryption and decryption
- Korean PIPA Art. 29 - Safeguards for medical PHI

### Related Issues
- Closes #1102

### Alternatives Considered
1. Full-disk encryption only - rejected; does not protect records once
   a file is copied off the host, and relies on deployment-time LUKS/BL
   configuration outside the application's control.
2. Per-file encryption - rejected; losing one file key loses a whole
   segment, and key rotation requires rewriting historical files.
3. Per-record envelope encryption (this PR) - chosen; supports key
   rotation with zero rewrite cost and bounds the blast radius of any
   single key compromise to records written while that key was active.

## How

### Record format
```
PACSAUDIT|v1|<key_id>|<iv_b64>|<ciphertext_b64>|<gcm_tag_b64>|<hmac_b64>
```

### Cryptographic design
- AES-256-GCM, 96-bit random IV per record (NIST SP 800-38D)
- Independent HMAC-SHA256 over the serialised envelope prefix, keyed by
  a separate MAC key (defence-in-depth per ISO 27799 §7.9)
- Outer HMAC is verified in constant time before touching GCM; a failed
  HMAC never exposes plaintext
- `looks_encrypted()` helper so mixed legacy/encrypted streams can be
  detected during migration

### Key management
`audit_key_manager::load_from_env()` reads:
- `PACS_AUDIT_LOG_ACTIVE_KEY_ID` - id of the current write key (required)
- `PACS_AUDIT_LOG_KEYS` - optional comma list of retained ids
- `PACS_AUDIT_LOG_KEY_<id>` - 32-byte data key, hex or base64
- `PACS_AUDIT_LOG_MAC_<id>` - 32-byte MAC key, hex or base64

Key rotation procedure is documented in `docs/SECURITY_AUDIT.md`. Direct
KMS integration (envelope wrapping of data keys with a KMS-held master)
is deferred; the public API (`register_key`) accepts keys from any
source so a `kms_audit_key_manager` can be added later without changing
the record format.

### Testing
- Round-trip encryption/decryption across varied payload sizes
- IV uniqueness across repeated encryption of identical plaintext
- Tamper detection on ciphertext, GCM tag and HMAC independently
- Unknown-key-id rejection
- Key rotation: old records stay decryptable while new writes use the
  new key; retiring the old key correctly loses access
- Malformed record detection (wrong field count, unknown version)
- Trailing-newline tolerance (reading log files line-by-line)
- `verify_record` shortcut for integrity checks without returning
  plaintext

### Breaking Changes
None. The new cipher is additive; it is not yet wired into the syslog
writer by this PR. Wiring and a migration plan for existing plaintext
files will follow in a separate change.

## Operator Action Required

Before rolling out in an environment that will use encryption:

1. Provision a (data, mac) key pair per the procedure in
   `docs/SECURITY_AUDIT.md` and distribute via the site's secret store
   (Kubernetes Secrets, Vault, etc).
2. Set `PACS_AUDIT_LOG_ACTIVE_KEY_ID`, `PACS_AUDIT_LOG_KEY_<id>` and
   `PACS_AUDIT_LOG_MAC_<id>` in the deployment environment.
3. After the next restart, verify that new audit log lines start with
   `PACSAUDIT|v1|`.

## Test Plan
- [ ] CI builds all targets clean
- [ ] `security_tests` executes all new `[audit_cipher]` cases
- [ ] Reviewers confirm crypto choices against the control table in
      `docs/SECURITY_AUDIT.md`

## Follow-ups
- Wire `audit_log_cipher` into the file-backed audit writer and provide
  a migration command for pre-existing plaintext logs
- Add a command-line decryption and verification tool for auditors
- KMS-backed key manager (envelope encryption of data keys)
- Optional Merkle chain over segments for append-only integrity of the
  log as a whole