### PR TITLE
fix(tests): avoid unnecessary seeded fixture in streaming_query_handler config test

### DIFF
--- a/tests/services/cache/streaming_query_test.cpp
+++ b/tests/services/cache/streaming_query_test.cpp
@@ -155,6 +155,33 @@ private:
     std::unique_ptr<index_database> db_;
 };
 
+/**
+ * @brief Minimal database fixture without seeded data
+ *
+ * Opens an in-memory database but skips the ~400-row test data insertion.
+ * Use for tests that only need a valid index_database pointer for constructor
+ * injection but do not query any records.
+ *
+ * Motivation: the full test_database_fixture performs 400 upsert operations,
+ * which on Windows CI runners has exceeded the per-test ctest timeout of 60s
+ * when Catch2 re-runs the fixture for each SECTION. See issue #1105.
+ */
+class empty_database_fixture {
+public:
+    empty_database_fixture() {
+        auto result = index_database::open(":memory:");
+        REQUIRE(result.is_ok());
+        db_ = std::move(result.value());
+    }
+
+    [[nodiscard]] auto db() const -> index_database* {
+        return db_.get();
+    }
+
+private:
+    std::unique_ptr<index_database> db_;
+};
+
 }  // namespace
 
 // ============================================================================
@@ -461,7 +488,11 @@ TEST_CASE("query_result_stream study level", "[services][streaming]") {
 // ============================================================================
 
 TEST_CASE("streaming_query_handler configuration", "[services][streaming]") {
-    test_database_fixture fixture;
+    // Use empty_database_fixture: configuration accessors (page_size,
+    // max_results) do not touch the database, so the full 400-row seed
+    // in test_database_fixture is unnecessary and caused Windows CI
+    // timeouts (see issue #1105).
+    empty_database_fixture fixture;
     streaming_query_handler handler(fixture.db());
 
     SECTION("default page size is 100") {


### PR DESCRIPTION
## What

Replace the full ~400-row seeded fixture with a minimal database-only fixture in the `streaming_query_handler configuration` test case.

- Added `empty_database_fixture` helper in `tests/services/cache/streaming_query_test.cpp` that opens an in-memory `index_database` without inserting test data.
- Switched the `streaming_query_handler configuration` `TEST_CASE` to use the new fixture. All other tests in the file are unchanged.

## Why

The `streaming_query_handler configuration` test case has been timing out on `windows-2022` CI runners (per-test ctest timeout is 60 s), blocking every PR targeting `develop` (most recently PR #1104). Per project CI policy, any failing check must be fixed before merging, so `develop` is effectively gated on this test.

### Root Cause

1. `test_database_fixture` performs ~400 `upsert_*` calls during construction (10 patients + 30 studies + 60 series + 300 instances).
2. Catch2 re-executes the enclosing `TEST_CASE` body for every `SECTION`. The configuration test has four sections -> roughly 1600 SQLite INSERTs per run.
3. When built with `PACS_WITH_DATABASE_SYSTEM`, `index_database::open(":memory:")` silently redirects to a temporary file on disk so that the `database_system` adapter can share the connection. The `PRAGMA journal_mode = WAL` is only applied when the caller-supplied path is not `":memory:"`, so the test falls back to the default rollback-journal mode.
4. On Windows the combination (file-backed SQLite + rollback journal + many small transactions) crosses the 60 s per-test budget under CI load. Linux / macOS runners handle the same work well within budget, which is why the failure is Windows-specific.

The configuration accessors (`page_size`, `set_page_size`, `max_results`, `set_max_results`) are trivial integer getters/setters and do not touch the database, so the seeded data is unnecessary.

### Why Not Other Approaches

- **Raise the ctest timeout** (60 -> 120 s): Treats the symptom. The test does not need the data, so spending time inserting it is pure waste, and the root-cause fragility (slow Windows disk path under fixture re-entry) would remain for future tests.
- **Fix the `":memory:"` -> temp-file redirect in `index_database`**: Production-scoped change for a test-scoped problem. The redirect exists for valid reasons (database_system adapter compatibility) and is out of scope for this issue.
- **Apply WAL mode for the redirected temp-file path**: Same reasoning - larger production-surface change, higher risk, and still leaves 1600 INSERTs happening for no reason.
- **Switch Catch2 to `TEST_CASE_METHOD` with a shared fixture across sections**: Would change semantics of every other fixture user and invites state leakage between sections. Too broad for a P1 hotfix.

A minimal, fixture-local fix is the cleanest option: the configuration tests get exactly the setup they need, the behaviour of every other test is unchanged, and Linux / macOS CI runtimes for this case drop from hundreds of milliseconds to effectively zero.

## Who

- Requested review: @kcenon

## When

- Priority: P1 - unblocks develop CI (and PR #1104).
- No deployment dependencies.

## Where

- `tests/services/cache/streaming_query_test.cpp` (test-only change)

## How

### Implementation

- Added `empty_database_fixture` alongside the existing `test_database_fixture` in the anonymous namespace.
- Changed the `streaming_query_handler configuration` test case to use `empty_database_fixture`.
- Added a comment at both sites explaining the motivation and cross-referencing this issue.

### Testing

- Local build/test was skipped because the failure is Windows-specific and no matching toolchain is provisioned on this machine (per project `ci-resilience.md` missing-toolchain fallback).
- CI will validate on Ubuntu / macOS / Windows unit test matrices. The configuration test used to run the full seed four times; after the change it runs an empty open four times.

### Breaking Changes

None. Test-only change.

### Rollback

Revert the commit. No data or schema impact.

Closes #1105