### PR TITLE
fix(integration): correct secure_tcp_socket.h include path (#1097)

### DIFF
--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -866,6 +866,17 @@ if(TARGET container_system AND COMMON_SYSTEM_FOUND AND TARGET network_system)
             $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>
     )
+    # Issue #1097: network_system's public header secure_session.h includes
+    # "kcenon/network/internal/tcp/secure_tcp_socket.h", which resolves via a
+    # build-time symlink at ${network_system_BINARY_DIR}/internal_include. That
+    # directory is only attached as PRIVATE to network_system's own target, so
+    # dicom_session.cpp fails to compile without it being exposed here too.
+    if(TARGET network_system)
+        target_include_directories(pacs_integration
+            PRIVATE
+                $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/network_system_build/internal_include>
+        )
+    endif()
     # Suppress deprecated warnings from thread_system headers (logger_interface is deprecated)
     target_compile_options(pacs_integration PRIVATE
         $<$<CXX_COMPILER_ID:Clang,AppleClang,GNU>:-Wno-deprecated-declarations>


### PR DESCRIPTION
## What

### Summary
Fix P1 build break where `pacs_integration` cannot locate `kcenon/network/internal/tcp/secure_tcp_socket.h` via transitive include of `secure_session.h`.

### Change Type
- [x] Bugfix

### Affected Components
- `cmake/targets.cmake` (+11 lines)

## Why

### Related Issues
- Closes #1097

### Problem
`network_system` exposes a public header `secure_session.h` that includes `kcenon/network/internal/tcp/secure_tcp_socket.h`. That path resolves only through a build-time symlink at `${network_system_BINARY_DIR}/internal_include/kcenon/network/internal` → `src/internal`. `network_system`'s own CMakeLists attaches this directory **PRIVATE** to its own target, so transitive consumers (like `pacs_integration`) fail to find the header, breaking builds on all three CI platforms.

## Where
- `cmake/targets.cmake`

## How

### Fix
Add the same internal-include directory to `pacs_integration` as a PRIVATE, `$<BUILD_INTERFACE:...>`-guarded include, gated by `if(TARGET network_system)` so vcpkg / `find_package` consumers are unaffected.

### Test Plan
- Verify `dicom_session.cpp` compiles on all three CI platforms (ubuntu, macos, windows).
- No source/header changes, so runtime behavior unchanged.

### Rollback
Revert the cmake/targets.cmake change.

## Adjacent (not fixed here)
- #1096 (`network_adapter.cpp Result<> misuse`) is a separate source-level bug — kept out of this surgical fix; should be its own PR.