### PR TITLE
fix(integration): correct Result<> usage in network_adapter

### DIFF
--- a/src/integration/network_adapter.cpp
+++ b/src/integration/network_adapter.cpp
@@ -79,7 +79,12 @@ network_adapter::connect(const connection_config& config) {
         }
         client_cfg.verify_certificate = config.tls.verify_peer;
 
-        auto client = facade.create_client(client_cfg);
+        auto client_result = facade.create_client(client_cfg);
+        if (client_result.is_err()) {
+            return Result<session_ptr>(error_info(
+                "Connection failed: " + client_result.error().message));
+        }
+        auto client = client_result.value();
         if (!client) {
             return Result<session_ptr>(error_info("Connection failed: unable to create client"));
         }


### PR DESCRIPTION
## What

### Summary
`src/integration/network_adapter.cpp` used `->` directly on a `Result<std::shared_ptr<i_protocol_client>>` returned from `facade.create_client`. This fails to compile on all three CI platforms (ubuntu-24.04, macos-14, windows-2022) with `base operand of '->' has non-pointer type`.

### Change Type
- [x] Bugfix (fixes an issue)

### Affected Components
- `src/integration/network_adapter.cpp`

## Why

### Problem Solved
Integration Tests workflow fails on every PR due to this compile error, blocking unrelated work. Root cause: `Result<T>` is a wrapper, not a pointer — must unwrap via `.value()` after an `is_err()` check.

### Related Issues
- Closes #1096

## Who

### Reviewers
- @kcenon

## When

### Urgency
- [x] High Priority — unblocks CI on every PR

## Where

### Files Changed
| File | Change |
|------|--------|
| `src/integration/network_adapter.cpp` | Added `is_err()` check + `.value()` extraction for the Result returned by `facade.create_client` |

## How

### Implementation
Replaced the direct `->` calls on the Result wrapper with an explicit `is_err()` check and `.value()` extraction, matching the pattern already used elsewhere in the same file for `start_result.is_err()`. The surrounding null-check on the extracted `shared_ptr` is preserved as defense-in-depth.

### Testing Done
- Local build not run — system CMake/Ninja toolchain not confirmed installed; relying on CI.
- The change is mechanically identical to the "Proposed Fix" snippet in issue #1096.

### Breaking Changes
- None.

### Rollback Plan
Revert this PR; the compile failure returns but otherwise no state changes.