### PR TITLE
fix(integration): unwrap create_client Result

### DIFF
--- a/src/integration/network_adapter.cpp
+++ b/src/integration/network_adapter.cpp
@@ -79,10 +79,11 @@ network_adapter::connect(const connection_config& config) {
         }
         client_cfg.verify_certificate = config.tls.verify_peer;
 
-        auto client = facade.create_client(client_cfg);
-        if (!client) {
+        auto client_result = facade.create_client(client_cfg);
+        if (client_result.is_err()) {
             return Result<session_ptr>(error_info("Connection failed: unable to create client"));
         }
+        auto client = client_result.value();
 
         // Set up promise/future for synchronous connection
         std::promise<std::error_code> connect_promise;


### PR DESCRIPTION
## What

Fixes a pre-existing compile error on `develop` where
`src/integration/network_adapter.cpp` used `->` directly on the
`Result<std::shared_ptr<i_protocol_client>>` returned by
`facade.create_client(client_cfg)`.

### Change Type
- [x] Bugfix (Integration Tests workflow now compiles)

### Affected Components
- `src/integration/network_adapter.cpp` (connect path, lines ~82-87)

## Why

Closes #1096

`kcenon::common::Result<T>` is an either/optional wrapper, not a
pointer, so `->` on it fails with
`base operand of '->' has non-pointer type`. This blocks the
`Integration Tests` workflow on every PR that builds against the
current `network_system` dependency — including unrelated PRs such
as the cert-exclusion work in #1094.

## Where

- File: `src/integration/network_adapter.cpp`
- Function: `network_adapter::connect(const connection_config&)`
- Lines: `auto client = facade.create_client(...)` + subsequent `client->` calls

## How

### Implementation
Extract the `shared_ptr` from the `Result` before use:

```cpp
auto client_result = facade.create_client(client_cfg);
if (client_result.is_err()) {
    return Result<session_ptr>(error_info("Connection failed: unable to create client"));
}
auto client = client_result.value();   // shared_ptr — subsequent -> is valid
client->set_connected_callback(...);
```

Downstream uses of `client->` (`set_connected_callback`,
`set_error_callback`, `start`, `stop`) now operate on the
unwrapped `shared_ptr` and compile cleanly.

### Acceptance Criteria
- [x] `create_client` return value is unwrapped via `.value()` before use
- [x] `.is_err()` check precedes unwrap to preserve error path
- [x] No other `Result<shared_ptr<...>>->` patterns in `src/integration/` (grep confirmed)
- [ ] `Integration Tests / Build & Unit Tests` passes on ubuntu-24.04, macos-14, windows-2022 (CI to verify)

### Out of Scope
- `src/network/v2/dicom_server_v2.cpp:139` has a similar pattern on
  `create_server`, but it sits under `#ifdef PACS_WITH_NETWORK_SYSTEM`
  and outside the integration library. Track separately if it fails
  in other CI paths.

## Test Plan
- CI: Integration Tests workflow on all three platforms must pass
- Local reproduction no longer possible without full ecosystem
  toolchain — relying on CI