### PR TITLE
fix(storage): enable WAL on :memory: redirect

### DIFF
--- a/include/kcenon/pacs/storage/index_database.h
+++ b/include/kcenon/pacs/storage/index_database.h
@@ -141,7 +141,12 @@ public:
      * Opens an existing database or creates a new one at the specified path.
      * Automatically runs pending migrations.
      *
-     * @param db_path Path to the database file, or ":memory:" for in-memory DB
+     * @param db_path Path to the database file, or ":memory:" for in-memory DB.
+     *                When compiled with PACS_WITH_DATABASE_SYSTEM, ":memory:"
+     *                is silently redirected to a unique temporary file so the
+     *                database_system SQLite backend can attach to it; WAL mode
+     *                (if requested via @p config.wal_mode) is enabled on that
+     *                rewritten path, and the temp file is removed on close.
      * @param config Configuration options for database behavior
      * @return Result containing the database instance or error
      */

--- a/src/storage/index_database.cpp
+++ b/src/storage/index_database.cpp
@@ -200,8 +200,12 @@ auto index_database::open(std::string_view db_path, const index_config& config)
             rc, "Failed to enable foreign keys", "storage");
     }
 
-    // Configure WAL mode for better concurrency (except for in-memory DB)
-    if (config.wal_mode && db_path != ":memory:") {
+    // Configure WAL mode for better concurrency (except for in-memory DB).
+    // Gate on effective_path, not the caller-supplied db_path: under
+    // PACS_WITH_DATABASE_SYSTEM, ":memory:" is rewritten to a temp file so
+    // database_system's SQLite backend can attach, and that rewritten file
+    // both needs and benefits from WAL.
+    if (config.wal_mode && effective_path != ":memory:") {
         rc = sqlite3_exec(db, "PRAGMA journal_mode = WAL;", nullptr, nullptr,
                           nullptr);
         if (rc != SQLITE_OK) {
@@ -221,8 +225,9 @@ auto index_database::open(std::string_view db_path, const index_config& config)
             rc, "Failed to set cache size", "storage");
     }
 
-    // Configure memory-mapped I/O
-    if (config.mmap_enabled && db_path != ":memory:") {
+    // Configure memory-mapped I/O. Use effective_path for the same reason
+    // as the WAL gate above.
+    if (config.mmap_enabled && effective_path != ":memory:") {
         auto mmap_sql = kcenon::pacs::compat::format("PRAGMA mmap_size = {};", config.mmap_size);
         rc = sqlite3_exec(db, mmap_sql.c_str(), nullptr, nullptr, nullptr);
         if (rc != SQLITE_OK) {

--- a/tests/storage/index_database_test.cpp
+++ b/tests/storage/index_database_test.cpp
@@ -71,6 +71,29 @@ TEST_CASE("index_database: create file-based database",
     std::filesystem::remove(test_path);
 }
 
+#ifdef PACS_WITH_DATABASE_SYSTEM
+TEST_CASE("index_database: :memory: redirect yields a real filesystem path "
+          "under PACS_WITH_DATABASE_SYSTEM (regression for #1107)",
+          "[storage][database]") {
+    // Under PACS_WITH_DATABASE_SYSTEM, ":memory:" is rewritten to a unique
+    // temp file so database_system's SQLite backend can attach. The WAL
+    // gate in open() must check the rewritten effective path (not the
+    // caller-supplied ":memory:" literal) so WAL is actually enabled on
+    // the temp file, avoiding the slow rollback-journal path that bit
+    // the Windows CI (#1105).
+
+    auto result = index_database::open(":memory:");
+    REQUIRE(result.is_ok());
+    auto db = std::move(result.value());
+    REQUIRE(db->is_open());
+
+    const auto effective = std::string{db->path()};
+    CHECK(effective != ":memory:");
+    CHECK(std::filesystem::exists(effective));
+    CHECK(effective.find("pacs_index_memory_") != std::string::npos);
+}
+#endif  // PACS_WITH_DATABASE_SYSTEM
+
 // ============================================================================
 // Patient Insert Tests
 // ============================================================================


### PR DESCRIPTION
## What

When compiled with `PACS_WITH_DATABASE_SYSTEM`, `index_database::open(\":memory:\")`
is silently rewritten to a unique temp file (so the database_system SQLite
backend can attach). The WAL and mmap configuration gates, however, compared
against the *original* caller-supplied `db_path` — still `\":memory:\"` at
that point — so WAL was never enabled on the rewritten file.

### Change Type
- [x] Bugfix (latent performance quirk)

### Affected Components
- `src/storage/index_database.cpp` — two gate conditions
- `include/kcenon/pacs/storage/index_database.h` — contract documentation
- `tests/storage/index_database_test.cpp` — regression test

## Why

Closes #1107 — the silent redirect + stale WAL gate manifested as the slow
rollback-journal path in #1105 (~1600 inserts timing out the Windows 60s
per-test budget, PR #1106 worked around the symptom on the test side, but
the underlying quirk remained for any future caller).

Chose option **B** from the issue (\"enable WAL consistently on the rewritten
path\"): preserves the existing compatibility shim for `database_system`'s
SQLite backend while closing the performance gap.

## Where

- `src/storage/index_database.cpp:204,225` — gate now uses `effective_path`
- `include/kcenon/pacs/storage/index_database.h:141-147` — documents the redirect contract
- `tests/storage/index_database_test.cpp` — new test case guarded by `#ifdef PACS_WITH_DATABASE_SYSTEM`

## How

### Implementation
```cpp
// Before
if (config.wal_mode && db_path != \":memory:\") { /* never true when redirect happens */ }

// After
if (config.wal_mode && effective_path != \":memory:\") { /* true whenever a real file is in use */ }
```

Same change applied to the mmap gate a few lines below.

### Acceptance Criteria (from #1107)
- [x] Option B chosen: WAL is enabled consistently on the rewritten path
- [x] Behavior documented in the `index_database` header
- [x] Regression test added under `PACS_WITH_DATABASE_SYSTEM` verifying
      `path()` returns a real temp file (not `\":memory:\"`) and the file exists

### Test Plan
- CI: `Build & Unit Tests` on ubuntu-24.04 / macos-14 / windows-2022 must pass
- CI: new test case runs only under `PACS_WITH_DATABASE_SYSTEM` builds

Not reproducing locally: full ecosystem toolchain unavailable; relying on CI.

### Rollback
Revert of a single commit. No data migration, no lockfile changes.