### PR TITLE
docs: expand Doxygen API coverage and fix warnings

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -278,7 +278,8 @@ SKIP_FUNCTION_MACROS   = YES
 # Configuration options related to external references
 #---------------------------------------------------------------------------
 ALIASES                = "thread_safety=@par Thread Safety:^^" \
-                         "performance=@par Performance:^^"
+                         "performance=@par Performance:^^" \
+                         "license=@par License:^^"
 TAGFILES               =
 GENERATE_TAGFILE       =
 ALLEXTERNALS           = NO

--- a/Doxyfile
+++ b/Doxyfile
@@ -116,6 +116,7 @@ INPUT                  = ./include \
                          ./src \
                          ./README.md \
                          ./docs/mainpage.dox \
+                         ./docs/groups.dox \
                          ./docs/tutorial_dicom_basics.dox \
                          ./docs/tutorial_store_workflow.dox \
                          ./docs/tutorial_query_retrieve.dox \

--- a/README.md
+++ b/README.md
@@ -467,12 +467,13 @@ int main() {
 
 ## Documentation
 
+- 🌐 [API Reference (Doxygen)](https://kcenon.github.io/pacs_system/) — Hosted Doxygen output (generated from `include/kcenon/pacs/**`)
 - 📋 [Implementation Analysis](docs/PACS_IMPLEMENTATION_ANALYSIS.md) - Detailed implementation strategy
 - 📋 [Product Requirements](docs/PRD.md) - Product Requirements Document
 - 🏗️ [Architecture Guide](docs/ARCHITECTURE.md) - System architecture
 - ⚡ [Features](docs/FEATURES.md) - Feature specifications
 - 📁 [Project Structure](docs/PROJECT_STRUCTURE.md) - Directory structure
-- 🔧 [API Reference](docs/API_REFERENCE.md) - API documentation
+- 🔧 [API Reference (narrative)](docs/API_REFERENCE.md) - High-level API walkthrough
 - 🖥️ [CLI Reference](docs/CLI_REFERENCE.md) - CLI tools documentation
 - 📄 [DICOM Conformance Statement](docs/DICOM_CONFORMANCE_STATEMENT.md) - DICOM conformance
 - 🏥 [IHE Integration Statement](docs/IHE_INTEGRATION_STATEMENT.md) - IHE profile conformance (XDS-I.b, AIRA, PIR)

--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -1,0 +1,80 @@
+/**
+ * @defgroup core Core
+ * @brief DICOM primitives: tags, elements, datasets, Part 10 file I/O, dictionary.
+ *
+ * The `pacs_core` module is the foundation of the library. It owns the in-memory
+ * representation of DICOM data (dicom_dataset, dicom_element, dicom_tag) and
+ * the Part 10 file format reader/writer. Every higher-level module consumes
+ * types defined here.
+ *
+ * Header prefix: `kcenon/pacs/core/`
+ *
+ * Key entry points:
+ *   - @ref kcenon::pacs::core::dicom_dataset — DICOM Information Object
+ *   - @ref kcenon::pacs::core::dicom_element — Single tag/VR/value triple
+ *   - @ref kcenon::pacs::core::dicom_file    — Part 10 file reader/writer
+ */
+
+/**
+ * @defgroup network Network
+ * @brief DICOM Upper Layer: association state machine, PDU codec, DIMSE pipeline.
+ *
+ * The `pacs_network` module implements the TCP/TLS transport and DICOM
+ * protocol layers: Upper Layer state machine, PDU encoding/decoding,
+ * DIMSE command dispatch, and the networking pipeline that hands off
+ * requests to SCP service implementations in `pacs_services`.
+ *
+ * Header prefix: `kcenon/pacs/network/`
+ *
+ * Key entry points:
+ *   - @ref kcenon::pacs::network::association — Association state machine
+ *   - @ref kcenon::pacs::network::dicom_server — Server acceptor
+ */
+
+/**
+ * @defgroup security Security
+ * @brief Authentication, authorization, anonymization, TLS, and audit logging.
+ *
+ * The `pacs_security` module covers PS3.15 anonymization, RBAC, digital
+ * signatures, TLS configuration (BCP 195), and the at-rest encrypted
+ * audit log (ISO 27799, HIPAA §164.312(b)).
+ *
+ * Header prefix: `kcenon/pacs/security/`
+ *
+ * Key entry points:
+ *   - @ref kcenon::pacs::security::audit_key_manager — Audit log key management
+ *   - @ref kcenon::pacs::security::uid_mapping — UID pseudonymization
+ */
+
+/**
+ * @defgroup storage Storage
+ * @brief File/cloud storage back-ends and SQLite index database.
+ *
+ * The `pacs_storage` module manages where DICOM instances live on disk or
+ * in cloud object stores (file, S3, Azure Blob, HSM), and the SQLite-backed
+ * index that supports Query/Retrieve workloads.
+ *
+ * Header prefix: `kcenon/pacs/storage/`
+ *
+ * Key entry points:
+ *   - @ref kcenon::pacs::storage::storage_interface — Back-end abstraction
+ *   - @ref kcenon::pacs::storage::index_database    — SQLite index
+ *   - @ref kcenon::pacs::storage::file_storage      — Local file backend
+ */
+
+/**
+ * @defgroup web Web
+ * @brief REST, DICOMweb (WADO/STOW/QIDO), OAuth2, and metadata endpoints.
+ *
+ * The `pacs_web` module exposes the HTTP surface of the system: the
+ * DICOMweb services (WADO-RS, STOW-RS, QIDO-RS, WADO-URI) built on top of
+ * the Crow framework, JWT/OAuth2 authentication middleware, and
+ * administrative REST endpoints.
+ *
+ * Header prefix: `kcenon/pacs/web/`
+ *
+ * Key entry points:
+ *   - @ref kcenon::pacs::web::rest_server      — Main REST server
+ *   - @ref kcenon::pacs::web::metadata_service — DICOMweb metadata
+ *   - @ref kcenon::pacs::web::jwt_validator    — JWT signature validation
+ */

--- a/docs/groups.dox
+++ b/docs/groups.dox
@@ -76,5 +76,5 @@
  * Key entry points:
  *   - @ref kcenon::pacs::web::rest_server      — Main REST server
  *   - @ref kcenon::pacs::web::metadata_service — DICOMweb metadata
- *   - @ref kcenon::pacs::web::jwt_validator    — JWT signature validation
+ *   - @ref kcenon::pacs::web::auth::jwt_validator — JWT signature validation
  */

--- a/include/kcenon/pacs/ai/ai_result_handler.h
+++ b/include/kcenon/pacs/ai/ai_result_handler.h
@@ -232,7 +232,7 @@ using pre_store_validator = std::function<bool(
  * Thread Safety: This class is NOT thread-safe. External synchronization
  * is required for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * // Create handler with storage and database
  * auto handler = ai_result_handler::create(storage, database);

--- a/include/kcenon/pacs/ai/ai_service_connector.h
+++ b/include/kcenon/pacs/ai/ai_service_connector.h
@@ -397,7 +397,7 @@ public:
      *
      * @param job_id The job identifier to wait for
      * @param timeout Maximum time to wait
-     * @param status_callback Optional callback for status updates
+     * @param callback Optional status_callback for status updates
      * @return Result containing final status on completion
      */
     [[nodiscard]] static auto wait_for_completion(

--- a/include/kcenon/pacs/ai/ai_service_connector.h
+++ b/include/kcenon/pacs/ai/ai_service_connector.h
@@ -276,7 +276,7 @@ struct model_info {
  *
  * Thread Safety: All methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Initialize the connector
  * ai_service_config config;

--- a/include/kcenon/pacs/ai/aira_assessment.h
+++ b/include/kcenon/pacs/ai/aira_assessment.h
@@ -192,7 +192,7 @@ struct assessment_info {
  * 2. Call create_assessment() to generate the SR document
  * 3. Store the resulting dataset using a storage backend
  *
- * @example
+ * @par Example:
  * @code
  * assessment_creator creator;
  *

--- a/include/kcenon/pacs/ai/aira_assessment_manager.h
+++ b/include/kcenon/pacs/ai/aira_assessment_manager.h
@@ -39,7 +39,7 @@ namespace kcenon::pacs::ai {
  * retrieval capabilities. Assessments are stored in-memory and
  * can be queried by AI result UID, assessor, or assessment type.
  *
- * @example
+ * @par Example:
  * @code
  * assessment_manager manager;
  *

--- a/include/kcenon/pacs/client/job_manager.h
+++ b/include/kcenon/pacs/client/job_manager.h
@@ -62,7 +62,7 @@ class remote_node_manager;
  * - All public methods are thread-safe
  * - Callbacks are invoked from worker threads
  *
- * @example
+ * @par Example:
  * @code
  * // Create manager with dependencies
  * auto job_repo = std::make_shared<job_repository>(db);

--- a/include/kcenon/pacs/client/prefetch_manager.h
+++ b/include/kcenon/pacs/client/prefetch_manager.h
@@ -80,7 +80,7 @@ struct prefetch_repositories {
  * - All public methods are thread-safe
  * - Background threads handle monitoring and scheduling
  *
- * @example
+ * @par Example:
  * @code
  * // Create manager with dependencies
  * auto prefetch_repo = std::make_shared<prefetch_repository>(db);

--- a/include/kcenon/pacs/client/remote_node.h
+++ b/include/kcenon/pacs/client/remote_node.h
@@ -117,7 +117,7 @@ struct tls_config {
  * operations. Includes connection parameters, supported services, and
  * runtime status information.
  *
- * @example
+ * @par Example:
  * @code
  * remote_node node;
  * node.node_id = "external-pacs-1";

--- a/include/kcenon/pacs/client/remote_node_manager.h
+++ b/include/kcenon/pacs/client/remote_node_manager.h
@@ -61,7 +61,7 @@ namespace kcenon::pacs::client {
  * - All public methods are thread-safe
  * - Status callbacks are invoked from worker threads
  *
- * @example
+ * @par Example:
  * @code
  * // Create manager with repository
  * auto repo = std::make_shared<node_repository>(db);

--- a/include/kcenon/pacs/client/routing_manager.h
+++ b/include/kcenon/pacs/client/routing_manager.h
@@ -65,7 +65,7 @@ class job_manager;
  * - All public methods are thread-safe
  * - Uses shared_mutex for rule access
  *
- * @example
+ * @par Example:
  * @code
  * // Create manager with dependencies
  * auto routing_repo = std::make_shared<routing_repository>(db);

--- a/include/kcenon/pacs/client/sync_manager.h
+++ b/include/kcenon/pacs/client/sync_manager.h
@@ -71,7 +71,7 @@ struct sync_repositories {
  * - All public methods are thread-safe
  * - Uses shared_mutex for config access
  *
- * @example
+ * @par Example:
  * @code
  * // Create manager with dependencies
  * auto sync_repo = std::make_shared<sync_repository>(db);

--- a/include/kcenon/pacs/compat/format.h
+++ b/include/kcenon/pacs/compat/format.h
@@ -11,8 +11,10 @@
  * so existing call sites continue to work without modification.
  *
  * Usage:
- *   #include <kcenon/pacs/compat/format.h>
- *   auto s = kcenon::pacs::compat::format("Hello, {}!", name);
+ * @code
+ * #include <kcenon/pacs/compat/format.h>
+ * auto s = kcenon::pacs::compat::format("Hello, {}!", name);
+ * @endcode
  *
  * @author kcenon
  * @since 1.0.0

--- a/include/kcenon/pacs/compat/time.h
+++ b/include/kcenon/pacs/compat/time.h
@@ -14,9 +14,12 @@
  * - Windows uses localtime_s(tm*, time_t*) - thread-safe, tm pointer first
  *
  * Usage:
- *   #include <kcenon/pacs/compat/time.h>
- *   std::tm tm{};
- *   kcenon::pacs::compat::localtime_safe(&time_val, &tm);
+ * @code
+ * #include <kcenon/pacs/compat/time.h>
+ * std::tm tm{};
+ * kcenon::pacs::compat::localtime_safe(&time_val, &tm);
+ * @endcode
+ *
  * @author kcenon
  * @since 1.0.0
  */

--- a/include/kcenon/pacs/core/dicom_dataset.h
+++ b/include/kcenon/pacs/core/dicom_dataset.h
@@ -41,7 +41,7 @@ namespace kcenon::pacs::core {
  * Thread Safety: This class is NOT thread-safe. External synchronization
  * is required for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * dicom_dataset ds;
  *
@@ -172,7 +172,7 @@ public:
      * @param tag The DICOM tag of the sequence element
      * @return Pointer to the sequence items vector, or nullptr if not found or not a sequence
      *
-     * @example
+     * @par Example:
      * @code
      * // Access Performed Series Sequence (0040,0340)
      * if (const auto* series = dataset.get_sequence(tags::performed_series_sequence)) {

--- a/include/kcenon/pacs/core/dicom_dictionary.h
+++ b/include/kcenon/pacs/core/dicom_dictionary.h
@@ -42,7 +42,7 @@ namespace kcenon::pacs::core {
  * - Read operations (lookup) are thread-safe and can be concurrent
  * - Write operations (register_private_tag) are serialized
  *
- * @example
+ * @par Example:
  * @code
  * auto& dict = dicom_dictionary::instance();
  *

--- a/include/kcenon/pacs/core/dicom_element.h
+++ b/include/kcenon/pacs/core/dicom_element.h
@@ -330,6 +330,8 @@ private:
     /**
      * @brief Remove DICOM padding from a string value
      * @param str The padded string
+     * @param vr Value Representation of the source element, used to select
+     *           the trim policy (trailing-space vs trailing-NUL)
      * @return String with padding removed
      */
     [[nodiscard]] static auto remove_padding(std::string_view str,

--- a/include/kcenon/pacs/core/dicom_element.h
+++ b/include/kcenon/pacs/core/dicom_element.h
@@ -51,7 +51,7 @@ class dicom_dataset;
  * - Sequences (SQ) containing nested datasets
  * - Value Multiplicity (VM > 1) with backslash-separated values
  *
- * @example
+ * @par Example:
  * @code
  * // Create from string
  * auto name = dicom_element::from_string(tags::patient_name, vr_type::PN, "DOE^JOHN");

--- a/include/kcenon/pacs/core/dicom_file.h
+++ b/include/kcenon/pacs/core/dicom_file.h
@@ -43,7 +43,7 @@ namespace kcenon::pacs::core {
  * This class supports reading and writing DICOM files with automatic
  * handling of the file structure and Transfer Syntax negotiation.
  *
- * @example
+ * @par Example:
  * @code
  * // Reading a DICOM file
  * auto result = dicom_file::open("image.dcm");

--- a/include/kcenon/pacs/core/dicom_tag.h
+++ b/include/kcenon/pacs/core/dicom_tag.h
@@ -36,7 +36,7 @@ namespace kcenon::pacs::core {
  * Memory layout: Stored as a single uint32_t for optimal memory usage
  * and comparison performance: (group << 16) | element
  *
- * @example
+ * @par Example:
  * @code
  * // Create Patient Name tag
  * dicom_tag tag{0x0010, 0x0010};

--- a/include/kcenon/pacs/core/memory_mapped_file.h
+++ b/include/kcenon/pacs/core/memory_mapped_file.h
@@ -29,7 +29,7 @@ namespace kcenon::pacs::core {
  * Maps a file into the process address space for zero-copy reading.
  * Move-only; unmaps automatically on destruction.
  *
- * @example
+ * @par Example:
  * @code
  * auto result = memory_mapped_file::open("image.dcm");
  * if (result.is_ok()) {

--- a/include/kcenon/pacs/core/pool_manager.h
+++ b/include/kcenon/pacs/core/pool_manager.h
@@ -142,7 +142,7 @@ private:
  * Uses a thread-local instance per thread to eliminate contention,
  * with each thread maintaining its own independent pool.
  *
- * @example
+ * @par Example:
  * @code
  * // Acquire a pooled element
  * auto elem = pool_manager::get().acquire_element(tag, vr);

--- a/include/kcenon/pacs/core/private_tag_registry.h
+++ b/include/kcenon/pacs/core/private_tag_registry.h
@@ -55,7 +55,7 @@ struct private_tag_definition {
  * - Read operations (find) are thread-safe and can be concurrent
  * - Write operations (register_tag, register_vendor) are serialized
  *
- * @example
+ * @par Example:
  * @code
  * auto& registry = private_tag_registry::instance();
  *

--- a/include/kcenon/pacs/core/tag_info.h
+++ b/include/kcenon/pacs/core/tag_info.h
@@ -123,7 +123,7 @@ struct value_multiplicity {
  * This includes the tag itself, its VR, VM, keyword, descriptive name,
  * and whether the tag has been retired from the standard.
  *
- * @example
+ * @par Example:
  * @code
  * tag_info info{
  *     dicom_tag{0x0010, 0x0010},

--- a/include/kcenon/pacs/di/service_registration.h
+++ b/include/kcenon/pacs/di/service_registration.h
@@ -82,7 +82,7 @@ struct registration_config {
  * @param config Optional registration configuration
  * @return VoidResult indicating success or registration error
  *
- * @example
+ * @par Example:
  * @code
  * kcenon::common::di::service_container container;
  * auto result = kcenon::pacs::di::register_services(container);
@@ -287,7 +287,7 @@ template<typename TLogger>
  * @param config Optional registration configuration
  * @return Shared pointer to configured service container
  *
- * @example
+ * @par Example:
  * @code
  * auto container = kcenon::pacs::di::create_container();
  * auto storage = container->resolve<kcenon::pacs::di::IDicomStorage>().value();

--- a/include/kcenon/pacs/di/test_support.h
+++ b/include/kcenon/pacs/di/test_support.h
@@ -47,7 +47,7 @@ namespace kcenon::pacs::di::test {
  *
  * Thread Safety: All methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * auto mock_storage = std::make_shared<MockStorage>();
  *
@@ -266,7 +266,7 @@ private:
  * Provides a fluent interface for constructing service containers
  * configured with mock implementations for testing.
  *
- * @example
+ * @par Example:
  * @code
  * auto mock_storage = std::make_shared<MockStorage>();
  * auto container = TestContainerBuilder()

--- a/include/kcenon/pacs/encoding/simd/simd_photometric.h
+++ b/include/kcenon/pacs/encoding/simd/simd_photometric.h
@@ -56,6 +56,9 @@ inline void invert_monochrome_8bit_scalar(const uint8_t* src, uint8_t* dst,
 
 /**
  * @brief Scalar 16-bit monochrome inversion
+ * @param src Source pixel buffer (must not alias @p dst)
+ * @param dst Destination pixel buffer of length @p pixel_count
+ * @param pixel_count Number of pixels to invert
  * @param max_value Maximum pixel value (e.g., 4095 for 12-bit, 65535 for 16-bit)
  */
 inline void invert_monochrome_16bit_scalar(const uint16_t* src, uint16_t* dst,

--- a/include/kcenon/pacs/integration/container_adapter.h
+++ b/include/kcenon/pacs/integration/container_adapter.h
@@ -51,7 +51,7 @@ namespace kcenon::pacs::integration {
  *
  * Thread Safety: All methods are thread-safe as they use only local state.
  *
- * @example
+ * @par Example:
  * @code
  * // Convert element to container value
  * auto element = dicom_element::from_string(tags::patient_name, vr_type::PN, "Doe^John");

--- a/include/kcenon/pacs/integration/dicom_session.h
+++ b/include/kcenon/pacs/integration/dicom_session.h
@@ -147,7 +147,7 @@ struct pdu_data {
  * Thread Safety: All public methods are thread-safe. The underlying
  * network operations are serialized through network_system's I/O context.
  *
- * @example
+ * @par Example:
  * @code
  * // Sending an A-ASSOCIATE-RQ
  * std::vector<uint8_t> associate_rq_data = encode_associate_rq(rq);

--- a/include/kcenon/pacs/integration/executor_adapter.h
+++ b/include/kcenon/pacs/integration/executor_adapter.h
@@ -49,7 +49,7 @@ class thread_pool_interface;
  * This class adapts a std::function to the IJob interface, allowing
  * lambda expressions and other callables to be used with IExecutor.
  *
- * @example
+ * @par Example:
  * @code
  * auto job = std::make_unique<lambda_job>(
  *     []() -> kcenon::common::VoidResult {
@@ -124,7 +124,7 @@ private:
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Create executor with thread pool
  * auto pool = std::make_shared<kcenon::thread::thread_pool>(4);

--- a/include/kcenon/pacs/integration/logger_adapter.h
+++ b/include/kcenon/pacs/integration/logger_adapter.h
@@ -161,7 +161,7 @@ struct logger_config {
  *
  * Thread Safety: All methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Initialize the logger
  * logger_config config;

--- a/include/kcenon/pacs/integration/monitoring_adapter.h
+++ b/include/kcenon/pacs/integration/monitoring_adapter.h
@@ -94,7 +94,7 @@ struct monitoring_config {
  *
  * Thread Safety: All methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Initialize the monitoring adapter
  * monitoring_config config;

--- a/include/kcenon/pacs/integration/network_adapter.h
+++ b/include/kcenon/pacs/integration/network_adapter.h
@@ -197,7 +197,7 @@ struct connection_config {
  * Thread Safety: All public methods are thread-safe and can be called
  * from any thread.
  *
- * @example
+ * @par Example:
  * @code
  * // Create a DICOM server
  * network::server_config config;
@@ -271,7 +271,7 @@ public:
      * @param config Connection configuration
      * @return Result containing session on success, or error message
      *
-     * @example
+     * @par Example:
      * @code
      * connection_config config{"192.168.1.100", 104};
      * config.timeout = std::chrono::seconds{5};
@@ -313,7 +313,7 @@ public:
      * @param config TLS configuration to validate and apply
      * @return Result indicating success or validation error
      *
-     * @example
+     * @par Example:
      * @code
      * tls_config tls;
      * tls.enabled = true;

--- a/include/kcenon/pacs/integration/thread_pool_adapter.h
+++ b/include/kcenon/pacs/integration/thread_pool_adapter.h
@@ -45,7 +45,7 @@ namespace kcenon::pacs::integration {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Create adapter with configuration
  * thread_pool_config config;

--- a/include/kcenon/pacs/integration/thread_pool_interface.h
+++ b/include/kcenon/pacs/integration/thread_pool_interface.h
@@ -84,7 +84,7 @@ struct thread_pool_config {
  * - All methods must be thread-safe in concrete implementations
  * - Concurrent task submission is allowed
  *
- * @example
+ * @par Example:
  * @code
  * // Using dependency injection
  * class my_service {

--- a/include/kcenon/pacs/monitoring/collectors/dicom_association_collector.h
+++ b/include/kcenon/pacs/monitoring/collectors/dicom_association_collector.h
@@ -64,7 +64,7 @@ struct association_metric {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * dicom_association_collector collector;
  * collector.initialize({});

--- a/include/kcenon/pacs/monitoring/collectors/dicom_metrics_collector.h
+++ b/include/kcenon/pacs/monitoring/collectors/dicom_metrics_collector.h
@@ -89,7 +89,7 @@ struct dicom_metrics_snapshot {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * dicom_metrics_collector collector;
  * collector.initialize({{"ae_title", "MY_PACS"}});

--- a/include/kcenon/pacs/monitoring/collectors/dicom_service_collector.h
+++ b/include/kcenon/pacs/monitoring/collectors/dicom_service_collector.h
@@ -72,7 +72,7 @@ struct service_metric {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * dicom_service_collector collector;
  * collector.initialize({});

--- a/include/kcenon/pacs/monitoring/collectors/dicom_storage_collector.h
+++ b/include/kcenon/pacs/monitoring/collectors/dicom_storage_collector.h
@@ -66,7 +66,7 @@ struct storage_metric {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * dicom_storage_collector collector;
  * collector.initialize({});

--- a/include/kcenon/pacs/monitoring/health_checker.h
+++ b/include/kcenon/pacs/monitoring/health_checker.h
@@ -80,7 +80,7 @@ struct health_checker_config {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Create and configure the health checker
  * health_checker_config config;

--- a/include/kcenon/pacs/monitoring/health_json.h
+++ b/include/kcenon/pacs/monitoring/health_json.h
@@ -216,7 +216,7 @@ namespace kcenon::pacs::monitoring {
  * @param status The health status to convert
  * @return JSON representation
  *
- * @example
+ * @par Example:
  * @code
  * health_status status;
  * status.level = health_level::healthy;

--- a/include/kcenon/pacs/monitoring/health_status.h
+++ b/include/kcenon/pacs/monitoring/health_status.h
@@ -199,7 +199,7 @@ struct version_info {
  * Thread Safety: Read operations are thread-safe. Write operations require
  * external synchronization.
  *
- * @example
+ * @par Example:
  * @code
  * health_status status;
  * status.level = health_level::healthy;

--- a/include/kcenon/pacs/monitoring/pacs_metrics.h
+++ b/include/kcenon/pacs/monitoring/pacs_metrics.h
@@ -334,7 +334,7 @@ struct pool_counters {
  *
  * Thread Safety: All public methods are thread-safe using atomic operations.
  *
- * @example
+ * @par Example:
  * @code
  * // Get global metrics instance
  * auto& metrics = pacs_metrics::global_metrics();

--- a/include/kcenon/pacs/monitoring/pacs_monitor.h
+++ b/include/kcenon/pacs/monitoring/pacs_monitor.h
@@ -197,7 +197,7 @@ struct pacs_monitor_config {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Initialize the monitor
  * pacs_monitor_config config;

--- a/include/kcenon/pacs/network/association.h
+++ b/include/kcenon/pacs/network/association.h
@@ -508,7 +508,10 @@ public:
 
     /**
      * @brief Process received A-RELEASE-RQ.
-     * @return A-RELEASE-RP PDU to send
+     *
+     * Transitions the association into Sta13 and enqueues an A-RELEASE-RP
+     * PDU for the sender. No return value; errors are surfaced via the
+     * association state machine.
      */
     void process_release_rq();
 

--- a/include/kcenon/pacs/network/association.h
+++ b/include/kcenon/pacs/network/association.h
@@ -257,7 +257,7 @@ private:
  * Manages the DICOM association state machine, presentation context
  * negotiation, and DIMSE message exchange per PS3.8.
  *
- * @example SCU Usage
+ * @par Example: SCU Usage
  * @code
  * association_config config;
  * config.calling_ae_title = "MY_SCU";

--- a/include/kcenon/pacs/network/detail/accept_worker.h
+++ b/include/kcenon/pacs/network/detail/accept_worker.h
@@ -62,7 +62,7 @@ namespace common = kcenon::common;
  *       network_system TCP integration. The actual socket accept logic will
  *       be implemented when network_system provides TCP server support.
  *
- * @example Usage in dicom_server
+ * @par Example: Usage in dicom_server
  * @code
  * accept_worker_ = std::make_unique<detail::accept_worker>(
  *     config_.port,

--- a/include/kcenon/pacs/network/dicom_server.h
+++ b/include/kcenon/pacs/network/dicom_server.h
@@ -65,7 +65,7 @@ class association_pool;
  * The server integrates with the ecosystem's thread_system for efficient
  * task scheduling and network_system for TCP operations.
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * server_config config;
  * config.ae_title = "MY_PACS";

--- a/include/kcenon/pacs/network/dimse/dimse_message.h
+++ b/include/kcenon/pacs/network/dimse/dimse_message.h
@@ -184,7 +184,7 @@ using dimse_result = kcenon::pacs::Result<T>;
  * The command set is always encoded using Implicit VR Little Endian.
  * The data set uses the negotiated transfer syntax.
  *
- * @example
+ * @par Example:
  * @code
  * // Create a C-STORE request
  * dimse_message msg{command_field::c_store_rq, 1};

--- a/include/kcenon/pacs/network/pdu_buffer_pool.h
+++ b/include/kcenon/pacs/network/pdu_buffer_pool.h
@@ -234,7 +234,7 @@ private:
  * Provides thread-safe access to object pools for PDU-related types.
  * Uses a singleton pattern for global access.
  *
- * @example
+ * @par Example:
  * @code
  * // Acquire a pooled buffer
  * auto buffer = pdu_buffer_pool::get().acquire_buffer();

--- a/include/kcenon/pacs/network/pipeline/jobs/dimse_process_job.h
+++ b/include/kcenon/pacs/network/pipeline/jobs/dimse_process_job.h
@@ -99,7 +99,7 @@ struct dimse_request {
  * Stage 3 of the pipeline. Processes DIMSE messages and routes
  * them to the storage/query execution stage.
  *
- * @example
+ * @par Example:
  * @code
  * auto job = std::make_unique<dimse_process_job>(decoded_pdu, on_request);
  * coordinator.submit_to_stage(pipeline_stage::dimse_process, std::move(job));

--- a/include/kcenon/pacs/network/pipeline/jobs/pdu_decode_job.h
+++ b/include/kcenon/pacs/network/pipeline/jobs/pdu_decode_job.h
@@ -57,7 +57,7 @@ struct decoded_pdu {
  * Stage 2 of the pipeline. Decodes PDU bytes and submits
  * the decoded result to the DIMSE processing stage.
  *
- * @example
+ * @par Example:
  * @code
  * auto job = std::make_unique<pdu_decode_job>(session_id, pdu_bytes);
  * coordinator.submit_to_stage(pipeline_stage::pdu_decode, std::move(job));

--- a/include/kcenon/pacs/network/pipeline/jobs/receive_network_io_job.h
+++ b/include/kcenon/pacs/network/pipeline/jobs/receive_network_io_job.h
@@ -35,7 +35,7 @@ namespace kcenon::pacs::network::pipeline {
  * Stage 1 of the pipeline. Receives raw bytes from the network
  * and forwards them to the PDU decode stage.
  *
- * @example
+ * @par Example:
  * @code
  * auto job = std::make_unique<receive_network_io_job>(session_id, on_data_received);
  * coordinator.submit_to_stage(pipeline_stage::network_receive, std::move(job));

--- a/include/kcenon/pacs/network/pipeline/jobs/response_encode_job.h
+++ b/include/kcenon/pacs/network/pipeline/jobs/response_encode_job.h
@@ -53,7 +53,7 @@ struct encoded_response {
  * Stage 5 of the pipeline. Encodes service results into PDU format
  * and submits to the network send stage.
  *
- * @example
+ * @par Example:
  * @code
  * auto job = std::make_unique<response_encode_job>(result, max_pdu_size);
  * coordinator.submit_to_stage(pipeline_stage::response_encode, std::move(job));

--- a/include/kcenon/pacs/network/pipeline/jobs/send_network_io_job.h
+++ b/include/kcenon/pacs/network/pipeline/jobs/send_network_io_job.h
@@ -33,7 +33,7 @@ namespace kcenon::pacs::network::pipeline {
  *
  * Stage 6 of the pipeline. Sends encoded PDU bytes to the network.
  *
- * @example
+ * @par Example:
  * @code
  * auto job = std::make_unique<send_network_io_job>(session_id, pdu_data, on_complete);
  * coordinator.submit_to_stage(pipeline_stage::network_send, std::move(job));

--- a/include/kcenon/pacs/network/pipeline/jobs/storage_query_exec_job.h
+++ b/include/kcenon/pacs/network/pipeline/jobs/storage_query_exec_job.h
@@ -100,7 +100,7 @@ struct service_result {
  * Stage 4 of the pipeline. Executes the actual DICOM operations
  * with blocking I/O allowed for database and file system access.
  *
- * @example
+ * @par Example:
  * @code
  * auto job = std::make_unique<storage_query_exec_job>(request, store_handler);
  * coordinator.submit_to_stage(pipeline_stage::storage_query_exec, std::move(job));

--- a/include/kcenon/pacs/network/pipeline/metrics/pipeline_metrics.h
+++ b/include/kcenon/pacs/network/pipeline/metrics/pipeline_metrics.h
@@ -187,7 +187,7 @@ struct category_metrics {
  * Provides thread-safe metrics collection with minimal overhead using
  * atomic operations and relaxed memory ordering where safe.
  *
- * @example
+ * @par Example:
  * @code
  * pipeline_metrics metrics;
  *

--- a/include/kcenon/pacs/network/pipeline/pipeline_adapter.h
+++ b/include/kcenon/pacs/network/pipeline/pipeline_adapter.h
@@ -70,7 +70,7 @@ struct session_context {
  * - Network send/receive callbacks
  * - Graceful shutdown coordination
  *
- * @example
+ * @par Example:
  * @code
  * // Create and configure adapter
  * pipeline_config config;

--- a/include/kcenon/pacs/network/pipeline/pipeline_coordinator.h
+++ b/include/kcenon/pacs/network/pipeline/pipeline_coordinator.h
@@ -113,7 +113,7 @@ class pipeline_job_base;
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Create coordinator with custom configuration
  * pipeline_config config;

--- a/include/kcenon/pacs/network/server_config.h
+++ b/include/kcenon/pacs/network/server_config.h
@@ -31,7 +31,7 @@ namespace kcenon::pacs::network {
  *
  * Defines all configurable parameters for a DICOM server instance.
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * server_config config;
  * config.ae_title = "MY_PACS";

--- a/include/kcenon/pacs/network/v2/dicom_association_handler.h
+++ b/include/kcenon/pacs/network/v2/dicom_association_handler.h
@@ -133,7 +133,7 @@ using handler_error_callback =
  * 4. DIMSE messages are dispatched to registered services
  * 5. Call `stop()` or let graceful release complete
  *
- * @example
+ * @par Example:
  * @code
  * auto handler = std::make_shared<dicom_association_handler>(
  *     session, config, services);

--- a/include/kcenon/pacs/network/v2/dicom_server_v2.h
+++ b/include/kcenon/pacs/network/v2/dicom_server_v2.h
@@ -82,7 +82,7 @@ namespace kcenon::pacs::network::v2 {
  * 2. No changes needed to service registration or callbacks
  * 3. Feature flag: `PACS_USE_NETWORK_SYSTEM_SERVER` (when available)
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * server_config config;
  * config.ae_title = "MY_PACS";

--- a/include/kcenon/pacs/security/anonymizer.h
+++ b/include/kcenon/pacs/security/anonymizer.h
@@ -62,7 +62,7 @@ enum class private_tag_action : std::uint8_t {
  * Thread Safety: This class is NOT thread-safe. Create separate instances
  * for concurrent operations, or use external synchronization.
  *
- * @example
+ * @par Example:
  * @code
  * // Basic anonymization
  * anonymizer anon(anonymization_profile::hipaa_safe_harbor);

--- a/include/kcenon/pacs/security/audit_log_cipher.h
+++ b/include/kcenon/pacs/security/audit_log_cipher.h
@@ -12,7 +12,9 @@
  * after rotation.
  *
  * Record format (ASCII, single line, terminated by '\n'):
+ * @verbatim
  *   PACSAUDIT|v1|<key_id>|<iv_b64>|<ciphertext_b64>|<tag_b64>|<hmac_b64>
+ * @endverbatim
  *
  * Where:
  *   - v1 is the format version tag
@@ -163,7 +165,8 @@ public:
      *   - base64 (standard alphabet, padding required) of N bytes
      *
      * @param encoded the encoded string
-     * @param out destination buffer; must be exactly `N` bytes
+     * @param out destination buffer; must be exactly @p out_size bytes
+     * @param out_size size of the destination buffer; must equal the key length N
      * @return VoidResult success or decode error
      */
     [[nodiscard]] static VoidResult decode_key(

--- a/include/kcenon/pacs/security/certificate.h
+++ b/include/kcenon/pacs/security/certificate.h
@@ -42,7 +42,7 @@ class private_key_impl;
  *
  * Thread Safety: This class is thread-safe for read operations.
  *
- * @example
+ * @par Example:
  * @code
  * auto cert_result = certificate::load_from_pem("/path/to/cert.pem");
  * if (cert_result.is_ok()) {
@@ -226,7 +226,7 @@ private:
  *
  * Thread Safety: This class is thread-safe for read operations.
  *
- * @example
+ * @par Example:
  * @code
  * auto key_result = private_key::load_from_pem("/path/to/key.pem", "password");
  * if (key_result.is_ok()) {

--- a/include/kcenon/pacs/security/digital_signature.h
+++ b/include/kcenon/pacs/security/digital_signature.h
@@ -44,7 +44,7 @@ namespace kcenon::pacs::security {
  *
  * Thread Safety: Static methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Sign a dataset
  * auto cert = certificate::load_from_pem("signer.pem").value();

--- a/include/kcenon/pacs/security/uid_mapping.h
+++ b/include/kcenon/pacs/security/uid_mapping.h
@@ -39,7 +39,7 @@ namespace kcenon::pacs::security {
  *
  * Thread Safety: This class is thread-safe for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * uid_mapping mapping;
  *

--- a/include/kcenon/pacs/services/cache/database_cursor.h
+++ b/include/kcenon/pacs/services/cache/database_cursor.h
@@ -68,7 +68,7 @@ using query_record = std::variant<storage::patient_record, storage::study_record
  * used from a single thread, and the underlying database connection
  * must remain valid for the cursor's lifetime.
  *
- * @example
+ * @par Example:
  * @code
  * // Create cursor from a query
  * auto cursor_result = database_cursor::create_study_cursor(db, query);

--- a/include/kcenon/pacs/services/cache/parallel_query_executor.h
+++ b/include/kcenon/pacs/services/cache/parallel_query_executor.h
@@ -128,7 +128,7 @@ struct parallel_executor_config {
  * Thread Safety: This class is thread-safe. All public methods can be
  * called concurrently from multiple threads.
  *
- * @example
+ * @par Example:
  * @code
  * // Create executor
  * parallel_executor_config config;

--- a/include/kcenon/pacs/services/cache/query_cache.h
+++ b/include/kcenon/pacs/services/cache/query_cache.h
@@ -102,7 +102,7 @@ struct cached_query_result {
  *
  * Thread Safety: All public methods are thread-safe.
  *
- * @example
+ * @par Example:
  * @code
  * // Create the cache
  * query_cache_config config;
@@ -203,7 +203,7 @@ public:
      * @param prefix The key prefix to match
      * @return Number of entries removed
      *
-     * @example
+     * @par Example:
      * @code
      * // Invalidate all PATIENT level queries
      * cache.invalidate_by_prefix("PATIENT:");
@@ -229,7 +229,7 @@ public:
      * @param pred Predicate function; entries where pred returns true are removed
      * @return Number of entries removed
      *
-     * @example
+     * @par Example:
      * @code
      * // Invalidate entries with too many results
      * cache.invalidate_if([](const auto&, const cached_query_result& r) {

--- a/include/kcenon/pacs/services/cache/query_result_stream.h
+++ b/include/kcenon/pacs/services/cache/query_result_stream.h
@@ -80,7 +80,7 @@ struct stream_config {
  * Thread Safety: This class is NOT thread-safe. The stream should
  * be used from a single thread.
  *
- * @example
+ * @par Example:
  * @code
  * // Create stream from query
  * stream_config config;

--- a/include/kcenon/pacs/services/cache/simple_lru_cache.h
+++ b/include/kcenon/pacs/services/cache/simple_lru_cache.h
@@ -145,7 +145,7 @@ struct cache_stats {
  * @tparam Hash Hash function for keys (defaults to std::hash<Key>)
  * @tparam KeyEqual Equality comparison for keys (defaults to std::equal_to<Key>)
  *
- * @example
+ * @par Example:
  * @code
  * // Create a cache for query results
  * cache_config config;
@@ -389,7 +389,7 @@ public:
      * @param pred The predicate function; entries where pred(key, value) returns true are removed
      * @return Number of entries removed
      *
-     * @example
+     * @par Example:
      * @code
      * // Invalidate all entries with keys starting with "PATIENT:"
      * cache.invalidate_if([](const std::string& key, const auto&) {

--- a/include/kcenon/pacs/services/cache/streaming_query_handler.h
+++ b/include/kcenon/pacs/services/cache/streaming_query_handler.h
@@ -45,7 +45,7 @@ namespace kcenon::pacs::services {
  * with query_scp. Instead of returning all results in a vector, it
  * allows fetching results in batches.
  *
- * @example
+ * @par Example:
  * @code
  * // Create streaming handler
  * streaming_query_handler handler(db);

--- a/include/kcenon/pacs/services/monitoring/database_metrics_service.h
+++ b/include/kcenon/pacs/services/monitoring/database_metrics_service.h
@@ -105,7 +105,7 @@ struct slow_query {
  * **Thread Safety:** This class is thread-safe for read operations.
  * Callbacks are invoked synchronously and should complete quickly.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("/path/to/db.sqlite");
  * db->connect();

--- a/include/kcenon/pacs/services/mpps_scp.h
+++ b/include/kcenon/pacs/services/mpps_scp.h
@@ -210,7 +210,7 @@ using mpps_set_handler = std::function<network::Result<std::monostate>(
  *  Note: COMPLETED and DISCONTINUED are final states
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * mpps_scp scp;
  *

--- a/include/kcenon/pacs/services/mpps_scu.h
+++ b/include/kcenon/pacs/services/mpps_scu.h
@@ -209,7 +209,7 @@ struct mpps_scu_config {
  *  |<------------------------------------|
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * // Establish association
  * association_config config;

--- a/include/kcenon/pacs/services/n_get_scp.h
+++ b/include/kcenon/pacs/services/n_get_scp.h
@@ -83,7 +83,7 @@ using n_get_handler = std::function<network::Result<core::dicom_dataset>(
  *  |<-----------------------------------|
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * n_get_scp scp;
  *

--- a/include/kcenon/pacs/services/n_get_scu.h
+++ b/include/kcenon/pacs/services/n_get_scu.h
@@ -106,7 +106,7 @@ struct n_get_scu_config {
  *  |<-----------------------------------|
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * n_get_scu scu;
  *

--- a/include/kcenon/pacs/services/pir/patient_reconciliation_service.h
+++ b/include/kcenon/pacs/services/pir/patient_reconciliation_service.h
@@ -175,7 +175,7 @@ struct reconciliation_audit_record {
  * - **Patient Merge** (ADT^A40): Reassign all instances from source patient
  *   to target patient
  *
- * @example
+ * @par Example:
  * @code
  * patient_reconciliation_service service;
  *

--- a/include/kcenon/pacs/services/print_scu.h
+++ b/include/kcenon/pacs/services/print_scu.h
@@ -183,7 +183,7 @@ struct print_scu_config {
  *  |<------------------------------------------|
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * // Establish association with Print SCP
  * association_config config;

--- a/include/kcenon/pacs/services/query_scp.h
+++ b/include/kcenon/pacs/services/query_scp.h
@@ -170,7 +170,7 @@ using cancel_check = std::function<bool()>;
  *  │◄─────────────────────────────────────│
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * query_scp scp;
  *

--- a/include/kcenon/pacs/services/query_scu.h
+++ b/include/kcenon/pacs/services/query_scu.h
@@ -239,7 +239,7 @@ using query_streaming_callback = std::function<bool(const core::dicom_dataset&)>
  *  |<-----------------------------------|
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * // Establish association with presentation contexts for query
  * association_config config;
@@ -275,7 +275,7 @@ using query_streaming_callback = std::function<bool(const core::dicom_dataset&)>
  * assoc.release();
  * @endcode
  *
- * @example Streaming Query for Large Results
+ * @par Example: Streaming Query for Large Results
  * @code
  * query_scu scu;
  * core::dicom_dataset query;

--- a/include/kcenon/pacs/services/retrieve_scp.h
+++ b/include/kcenon/pacs/services/retrieve_scp.h
@@ -208,7 +208,7 @@ using retrieve_cancel_check = std::function<bool()>;
  *     │◄───────────────────────────────│
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * retrieve_scp scp;
  *

--- a/include/kcenon/pacs/services/retrieve_scu.h
+++ b/include/kcenon/pacs/services/retrieve_scu.h
@@ -284,7 +284,7 @@ struct retrieve_scu_config {
  *  |<-----------------------------------|
  * ```
  *
- * @example Basic C-MOVE Usage
+ * @par Example: Basic C-MOVE Usage
  * @code
  * // Establish association
  * association_config config;
@@ -311,7 +311,7 @@ struct retrieve_scu_config {
  * assoc.release();
  * @endcode
  *
- * @example C-MOVE with Progress Tracking
+ * @par Example: C-MOVE with Progress Tracking
  * @code
  * retrieve_scu scu;
  * scu.set_move_destination("WORKSTATION");
@@ -327,7 +327,7 @@ struct retrieve_scu_config {
  *     });
  * @endcode
  *
- * @example C-GET with Instance Callback
+ * @par Example: C-GET with Instance Callback
  * @code
  * retrieve_scu_config cfg;
  * cfg.mode = retrieve_mode::c_get;

--- a/include/kcenon/pacs/services/scp_service.h
+++ b/include/kcenon/pacs/services/scp_service.h
@@ -36,7 +36,7 @@ namespace kcenon::pacs::services {
  * Each derived class handles specific SOP Classes and their corresponding
  * DIMSE operations.
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * class verification_scp : public scp_service {
  * public:

--- a/include/kcenon/pacs/services/sop_class_registry.h
+++ b/include/kcenon/pacs/services/sop_class_registry.h
@@ -98,7 +98,7 @@ struct sop_class_info {
  * across all service types. Supports filtering by category, modality,
  * and other criteria.
  *
- * @example
+ * @par Example:
  * @code
  * sop_class_registry registry;
  *

--- a/include/kcenon/pacs/services/storage_scp.h
+++ b/include/kcenon/pacs/services/storage_scp.h
@@ -136,7 +136,7 @@ using post_store_handler = std::function<void(
  *  │                                      │
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * storage_scp_config config;
  * config.accepted_sop_classes = {"1.2.840.10008.5.1.4.1.1.2"};  // CT
@@ -214,7 +214,7 @@ public:
      *
      * @param handler The post-store callback function
      *
-     * @example Cache invalidation on storage
+     * @par Example: Cache invalidation on storage
      * @code
      * storage_scp scp{config};
      * scp.set_post_store_handler([](const auto& dataset,

--- a/include/kcenon/pacs/services/storage_scu.h
+++ b/include/kcenon/pacs/services/storage_scu.h
@@ -123,7 +123,7 @@ struct storage_scu_config {
  *  |                                    |
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * // Establish association with presentation contexts for storage
  * association_config config;
@@ -152,7 +152,7 @@ struct storage_scu_config {
  * assoc.release();
  * @endcode
  *
- * @example Batch Store with Progress
+ * @par Example: Batch Store with Progress
  * @code
  * storage_scu scu;
  * auto results = scu.store_batch(assoc, datasets,

--- a/include/kcenon/pacs/services/ups/ups_push_scp.h
+++ b/include/kcenon/pacs/services/ups/ups_push_scp.h
@@ -152,7 +152,7 @@ using ups_request_cancel_handler = std::function<network::Result<std::monostate>
  *  │◄──────────────────────────────────────│
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * ups_push_scp scp;
  *

--- a/include/kcenon/pacs/services/ups/ups_push_scu.h
+++ b/include/kcenon/pacs/services/ups/ups_push_scu.h
@@ -204,7 +204,7 @@ struct ups_push_scu_config {
  *  |<---------------------------------------|
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * ups_push_scu scu;
  *

--- a/include/kcenon/pacs/services/validation/ct_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/ct_iod_validator.h
@@ -143,7 +143,7 @@ struct ct_validation_options {
  * - CT Image Module (M)
  * - SOP Common Module (M)
  *
- * @example
+ * @par Example:
  * @code
  * ct_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/ct_processing_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/ct_processing_iod_validator.h
@@ -118,7 +118,7 @@ struct ct_processing_validation_options {
  * - CT Image Module (M)
  * - SOP Common Module (M)
  *
- * @example
+ * @par Example:
  * @code
  * ct_processing_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/dx_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/dx_iod_validator.h
@@ -101,7 +101,7 @@ struct dx_validation_options {
  * - DX Positioning Module (required if view position is specified)
  * - VOI LUT Module (For Presentation images)
  *
- * @example
+ * @par Example:
  * @code
  * dx_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/heightmap_seg_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/heightmap_seg_iod_validator.h
@@ -157,7 +157,7 @@ struct heightmap_seg_validation_options {
  * - Common Instance Reference Module (M)
  * - SOP Common Module (M)
  *
- * @example
+ * @par Example:
  * @code
  * heightmap_seg_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/label_map_seg_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/label_map_seg_iod_validator.h
@@ -159,7 +159,7 @@ struct label_map_seg_validation_options {
  * - Common Instance Reference Module (M)
  * - SOP Common Module (M)
  *
- * @example
+ * @par Example:
  * @code
  * label_map_seg_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/mg_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/mg_iod_validator.h
@@ -144,7 +144,7 @@ struct mg_validation_options {
  *    - Validated against typical range (50-200 N)
  *    - Warning if outside normal range
  *
- * @example
+ * @par Example:
  * @code
  * mg_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/mr_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/mr_iod_validator.h
@@ -158,7 +158,7 @@ struct mr_validation_options {
  * - MR Image Module (M)
  * - SOP Common Module (M)
  *
- * @example
+ * @par Example:
  * @code
  * mr_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/nm_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/nm_iod_validator.h
@@ -98,7 +98,7 @@ struct nm_validation_options {
  * - Detector Information Sequence
  * - Rotation Information
  *
- * @example
+ * @par Example:
  * @code
  * nm_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/ophthalmic_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/ophthalmic_iod_validator.h
@@ -123,7 +123,7 @@ struct ophthalmic_validation_options {
  * ### Conditional Modules
  * - Multi-frame Module (C) — for OCT images
  *
- * @example
+ * @par Example:
  * @code
  * ophthalmic_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/parametric_map_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/parametric_map_iod_validator.h
@@ -156,7 +156,7 @@ struct pmap_validation_options {
  * - Common Instance Reference Module (M)
  * - SOP Common Module (M)
  *
- * @example
+ * @par Example:
  * @code
  * parametric_map_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/pet_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/pet_iod_validator.h
@@ -97,7 +97,7 @@ struct pet_validation_options {
  * - Attenuation correction method
  * - Scatter correction method
  *
- * @example
+ * @par Example:
  * @code
  * pet_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/seg_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/seg_iod_validator.h
@@ -97,7 +97,7 @@ struct seg_validation_options {
  * - Common Instance Reference Module (M)
  * - SOP Common Module (M)
  *
- * @example
+ * @par Example:
  * @code
  * seg_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/sr_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/sr_iod_validator.h
@@ -102,7 +102,7 @@ struct sr_validation_options {
  * ### Comprehensive SR Additional Modules
  * - SCOORD/SCOORD3D support
  *
- * @example
+ * @par Example:
  * @code
  * sr_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/us_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/us_iod_validator.h
@@ -142,7 +142,7 @@ struct us_validation_options {
  * - US Multi-frame Module (C) - for multi-frame images
  * - Cine Module (C) - for multi-frame images
  *
- * @example
+ * @par Example:
  * @code
  * us_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/wsi_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/wsi_iod_validator.h
@@ -131,7 +131,7 @@ struct wsi_validation_options {
  * ### User Optional Modules
  * - Specimen Module (U) — checked at info level
  *
- * @example
+ * @par Example:
  * @code
  * wsi_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/validation/xa_iod_validator.h
+++ b/include/kcenon/pacs/services/validation/xa_iod_validator.h
@@ -166,7 +166,7 @@ struct xa_validation_options {
  * - Cine Module (C) - for multi-frame XA
  * - XA Calibration Module (C) - for quantitative analysis
  *
- * @example
+ * @par Example:
  * @code
  * xa_iod_validator validator;
  * auto result = validator.validate(dataset);

--- a/include/kcenon/pacs/services/verification_scp.h
+++ b/include/kcenon/pacs/services/verification_scp.h
@@ -57,7 +57,7 @@ inline constexpr std::string_view verification_sop_class_uid = "1.2.840.10008.1.
  *  │                                      │
  * ```
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * verification_scp scp;
  *

--- a/include/kcenon/pacs/services/worklist_scp.h
+++ b/include/kcenon/pacs/services/worklist_scp.h
@@ -59,7 +59,7 @@ inline constexpr std::string_view worklist_find_sop_class_uid =
  * @param calling_ae The calling AE title of the requesting modality
  * @return Vector of matching worklist item datasets (empty if no matches)
  *
- * @example Handler Implementation
+ * @par Example: Handler Implementation
  * @code
  * worklist_handler handler = [&database](
  *     const dicom_dataset& query,
@@ -173,7 +173,7 @@ using worklist_cancel_check = std::function<bool()>;
  * | >(0040,0007) | ScheduledProcedureStepDescription | Step description |
  * | >(0040,0009) | ScheduledProcedureStepID | Step ID |
  *
- * @example Usage
+ * @par Example: Usage
  * @code
  * worklist_scp scp;
  *

--- a/include/kcenon/pacs/services/worklist_scu.h
+++ b/include/kcenon/pacs/services/worklist_scu.h
@@ -304,7 +304,7 @@ using worklist_streaming_callback = std::function<bool(const worklist_item&)>;
  *  |<---------------------------------------|
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * // Establish association with MWL presentation context
  * association_config config;
@@ -338,7 +338,7 @@ using worklist_streaming_callback = std::function<bool(const worklist_item&)>;
  * assoc.release();
  * @endcode
  *
- * @example Streaming Query for Large Worklists
+ * @par Example: Streaming Query for Large Worklists
  * @code
  * worklist_scu scu;
  * worklist_query_keys keys;

--- a/include/kcenon/pacs/services/xds/imaging_document_consumer.h
+++ b/include/kcenon/pacs/services/xds/imaging_document_consumer.h
@@ -181,7 +181,7 @@ struct imaging_document_consumer_config {
  * 3. Extract image references from the KOS document
  * 4. Retrieve images via WADO-RS using build_wado_rs_url()
  *
- * @example
+ * @par Example:
  * @code
  * imaging_document_consumer_config config;
  * config.registry_url = "https://xds-registry.example.com/services/iti18";

--- a/include/kcenon/pacs/services/xds/imaging_document_source.h
+++ b/include/kcenon/pacs/services/xds/imaging_document_source.h
@@ -236,7 +236,7 @@ struct imaging_document_source_config {
  * 2. Optionally customize the document metadata
  * 3. Call publish_document() to submit to the XDS registry
  *
- * @example
+ * @par Example:
  * @code
  * imaging_document_source_config config;
  * config.registry_url = "https://xds-registry.example.com/services/iti41";

--- a/include/kcenon/pacs/storage/annotation_record.h
+++ b/include/kcenon/pacs/storage/annotation_record.h
@@ -147,7 +147,7 @@ struct annotation_record {
  * Supports filtering by study, series, instance, user, and type.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * annotation_query query;
  * query.study_uid = "1.2.3.4.5";

--- a/include/kcenon/pacs/storage/annotation_repository.h
+++ b/include/kcenon/pacs/storage/annotation_repository.h
@@ -45,7 +45,7 @@ namespace kcenon::pacs::storage {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/azure_blob_storage.h
+++ b/include/kcenon/pacs/storage/azure_blob_storage.h
@@ -144,7 +144,7 @@ using azure_progress_callback =
  * - Writes require exclusive lock for index updates
  * - Azure SDK operations themselves are thread-safe
  *
- * @example
+ * @par Example:
  * @code
  * azure_storage_config config;
  * config.container_name = "dicom-container";

--- a/include/kcenon/pacs/storage/base_repository.h
+++ b/include/kcenon/pacs/storage/base_repository.h
@@ -61,7 +61,7 @@ using database_value = database::core::database_value;
  * @tparam Entity The domain entity type to be persisted
  * @tparam PrimaryKey The primary key type (default: int64_t)
  *
- * @example
+ * @par Example:
  * @code
  * // Define a domain entity
  * struct Patient {
@@ -192,7 +192,7 @@ public:
      * @param value Value to compare against
      * @return Result containing matching entities or error
      *
-     * @example
+     * @par Example:
      * @code
      * // Find patients with specific patient_id
      * auto result = repo.find_where("patient_id", "=", "P001");
@@ -303,7 +303,7 @@ public:
      * @param func Function to execute within transaction
      * @return Result from the function or transaction error
      *
-     * @example
+     * @par Example:
      * @code
      * auto result = repo.in_transaction([&]() -> VoidResult {
      *     auto r1 = repo.insert(entity1);

--- a/include/kcenon/pacs/storage/base_repository_impl.h
+++ b/include/kcenon/pacs/storage/base_repository_impl.h
@@ -26,6 +26,11 @@
 
 namespace kcenon::pacs::storage {
 
+/// @cond DOXYGEN_IGNORE_IMPL
+// Template method implementations below are internal to base_repository.hpp
+// and not part of the public API. Doxygen skips this block to avoid
+// ambiguous cross-references with derived repository classes.
+
 // =============================================================================
 // Constructor
 // =============================================================================
@@ -564,5 +569,7 @@ auto base_repository<Entity, PrimaryKey>::pk_column() const
     -> const std::string& {
     return pk_column_;
 }
+
+/// @endcond
 
 }  // namespace kcenon::pacs::storage

--- a/include/kcenon/pacs/storage/file_storage.h
+++ b/include/kcenon/pacs/storage/file_storage.h
@@ -99,7 +99,7 @@ struct file_storage_config {
  * - Writes require exclusive lock
  * - File operations use atomic write pattern (write to temp, then rename)
  *
- * @example
+ * @par Example:
  * @code
  * file_storage_config config;
  * config.root_path = "/data/dicom";

--- a/include/kcenon/pacs/storage/hsm_migration_service.h
+++ b/include/kcenon/pacs/storage/hsm_migration_service.h
@@ -77,7 +77,7 @@ struct migration_service_config {
  * - Uses condition variables for efficient scheduling
  * - Graceful shutdown support
  *
- * @example
+ * @par Example:
  * @code
  * // Create HSM storage
  * hsm_storage storage{hot, warm, cold};

--- a/include/kcenon/pacs/storage/hsm_storage.h
+++ b/include/kcenon/pacs/storage/hsm_storage.h
@@ -60,7 +60,7 @@ struct hsm_storage_config {
  * - Concurrent reads are allowed (shared lock)
  * - Writes and migrations require exclusive lock
  *
- * @example
+ * @par Example:
  * @code
  * // Create tier backends
  * auto hot = std::make_unique<file_storage>(hot_config);

--- a/include/kcenon/pacs/storage/hsm_types.h
+++ b/include/kcenon/pacs/storage/hsm_types.h
@@ -88,7 +88,7 @@ enum class storage_tier {
  * Defines the rules for automatic migration between storage tiers.
  * Instances are migrated based on their age (time since last access or storage).
  *
- * @example
+ * @par Example:
  * @code
  * tier_policy policy;
  * policy.hot_to_warm = std::chrono::days{30};   // Move to warm after 30 days

--- a/include/kcenon/pacs/storage/index_database.h
+++ b/include/kcenon/pacs/storage/index_database.h
@@ -96,7 +96,7 @@ using VoidResult = kcenon::common::VoidResult;
  * is required for concurrent access. Consider using a connection pool
  * for multi-threaded applications.
  *
- * @example
+ * @par Example:
  * @code
  * // Open or create database
  * auto db_result = index_database::open(":memory:");
@@ -791,7 +791,7 @@ public:
      * @param before Time point; items scheduled before this are eligible for deletion
      * @return Result containing the number of deleted items or error
      *
-     * @example
+     * @par Example:
      * @code
      * // Delete items scheduled before 2024-01-01 00:00:00 UTC
      * std::tm tm = {};

--- a/include/kcenon/pacs/storage/instance_record.h
+++ b/include/kcenon/pacs/storage/instance_record.h
@@ -94,7 +94,7 @@ struct instance_record {
  * Supports wildcard matching using '*' for prefix/suffix matching.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * instance_query query;
  * query.series_uid = "1.2.840.123456.1";  // Exact series match

--- a/include/kcenon/pacs/storage/job_repository.h
+++ b/include/kcenon/pacs/storage/job_repository.h
@@ -59,7 +59,7 @@ struct job_query_options {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/key_image_record.h
+++ b/include/kcenon/pacs/storage/key_image_record.h
@@ -80,7 +80,7 @@ struct key_image_record {
  * Supports filtering by study, instance, and user.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * key_image_query query;
  * query.study_uid = "1.2.3.4.5";

--- a/include/kcenon/pacs/storage/key_image_repository.h
+++ b/include/kcenon/pacs/storage/key_image_repository.h
@@ -43,7 +43,7 @@ namespace kcenon::pacs::storage {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/measurement_record.h
+++ b/include/kcenon/pacs/storage/measurement_record.h
@@ -123,7 +123,7 @@ struct measurement_record {
  * Supports filtering by instance, study (via instance), user, and type.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * measurement_query query;
  * query.sop_instance_uid = "1.2.3.4.5.6";

--- a/include/kcenon/pacs/storage/measurement_repository.h
+++ b/include/kcenon/pacs/storage/measurement_repository.h
@@ -43,7 +43,7 @@ namespace kcenon::pacs::storage {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/migration_runner.h
+++ b/include/kcenon/pacs/storage/migration_runner.h
@@ -83,7 +83,7 @@ using adapter_migration_function =
  * Thread Safety: This class is NOT thread-safe. External synchronization
  * is required for concurrent access to the same database.
  *
- * @example
+ * @par Example:
  * @code
  * sqlite3* db = ...;
  * migration_runner runner;

--- a/include/kcenon/pacs/storage/mpps_record.h
+++ b/include/kcenon/pacs/storage/mpps_record.h
@@ -191,7 +191,7 @@ struct mpps_record {
  *
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * mpps_query query;
  * query.station_ae = "CT_SCANNER_1";

--- a/include/kcenon/pacs/storage/node_repository.h
+++ b/include/kcenon/pacs/storage/node_repository.h
@@ -45,7 +45,7 @@ namespace kcenon::pacs::storage {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/pacs_database_adapter.h
+++ b/include/kcenon/pacs/storage/pacs_database_adapter.h
@@ -177,7 +177,7 @@ private:
  * is required for concurrent access. Consider using a connection pool or
  * mutex for multi-threaded applications.
  *
- * @example
+ * @par Example:
  * @code
  * // Create adapter for SQLite database
  * pacs_database_adapter db("/path/to/pacs.db");
@@ -295,7 +295,7 @@ public:
      *
      * @return Query builder instance
      *
-     * @example
+     * @par Example:
      * @code
      * auto builder = db.create_query_builder();
      * builder.select({"patient_id", "patient_name"})
@@ -405,7 +405,7 @@ public:
      * @return Success if function succeeds and transaction commits, error
      * otherwise
      *
-     * @example
+     * @par Example:
      * @code
      * auto result = db.transaction([&]() -> VoidResult {
      *     auto r1 = db.insert("INSERT INTO patients ...");
@@ -489,7 +489,7 @@ private:
  * If commit() is not called before destruction, the transaction is
  * automatically rolled back.
  *
- * @example
+ * @par Example:
  * @code
  * {
  *     scoped_transaction tx(db);

--- a/include/kcenon/pacs/storage/patient_record.h
+++ b/include/kcenon/pacs/storage/patient_record.h
@@ -75,7 +75,7 @@ struct patient_record {
  * Supports wildcard matching using '*' for prefix/suffix matching.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * patient_query query;
  * query.patient_name = "Doe*";  // Match names starting with "Doe"

--- a/include/kcenon/pacs/storage/prefetch_repository.h
+++ b/include/kcenon/pacs/storage/prefetch_repository.h
@@ -76,7 +76,7 @@ struct prefetch_history_query_options {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/recent_study_repository.h
+++ b/include/kcenon/pacs/storage/recent_study_repository.h
@@ -35,7 +35,7 @@ namespace kcenon::pacs::storage {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/repository_factory.h
+++ b/include/kcenon/pacs/storage/repository_factory.h
@@ -138,7 +138,7 @@ struct compatibility_repository_set {
  * - Use external synchronization (mutex)
  * - Pre-initialize all repositories before sharing
  *
- * @example
+ * @par Example:
  * @code
  * // Create database adapter
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");

--- a/include/kcenon/pacs/storage/routing_repository.h
+++ b/include/kcenon/pacs/storage/routing_repository.h
@@ -56,7 +56,7 @@ struct routing_rule_query_options {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/s3_storage.h
+++ b/include/kcenon/pacs/storage/s3_storage.h
@@ -135,7 +135,7 @@ using progress_callback =
  * - Writes require exclusive lock for index updates
  * - S3 operations themselves are thread-safe
  *
- * @example
+ * @par Example:
  * @code
  * cloud_storage_config config;
  * config.bucket_name = "my-dicom-bucket";

--- a/include/kcenon/pacs/storage/series_record.h
+++ b/include/kcenon/pacs/storage/series_record.h
@@ -79,7 +79,7 @@ struct series_record {
  * Supports wildcard matching using '*' for prefix/suffix matching.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * series_query query;
  * query.study_uid = "1.2.840.123456";  // Exact study match

--- a/include/kcenon/pacs/storage/storage_interface.h
+++ b/include/kcenon/pacs/storage/storage_interface.h
@@ -70,7 +70,7 @@ struct storage_statistics {
  * - Concurrent reads are allowed
  * - Writes must be atomic
  *
- * @example
+ * @par Example:
  * @code
  * // Using a concrete implementation (e.g., file_storage)
  * std::unique_ptr<storage_interface> storage =

--- a/include/kcenon/pacs/storage/study_record.h
+++ b/include/kcenon/pacs/storage/study_record.h
@@ -88,7 +88,7 @@ struct study_record {
  * Supports wildcard matching using '*' for prefix/suffix matching.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * study_query query;
  * query.patient_id = "12345";     // Exact patient match

--- a/include/kcenon/pacs/storage/sync_repository.h
+++ b/include/kcenon/pacs/storage/sync_repository.h
@@ -54,7 +54,7 @@ using VoidResult = kcenon::common::VoidResult;
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/ups_workitem.h
+++ b/include/kcenon/pacs/storage/ups_workitem.h
@@ -328,7 +328,7 @@ struct ups_subscription {
  * Empty fields are not included in the query filter.
  * Used for UPS C-FIND operations.
  *
- * @example
+ * @par Example:
  * @code
  * ups_workitem_query query;
  * query.state = "SCHEDULED";

--- a/include/kcenon/pacs/storage/viewer_state_record.h
+++ b/include/kcenon/pacs/storage/viewer_state_record.h
@@ -69,7 +69,7 @@ struct viewer_state_record {
  * Supports filtering by study and user.
  * Empty fields are not included in the query filter.
  *
- * @example
+ * @par Example:
  * @code
  * viewer_state_query query;
  * query.study_uid = "1.2.3.4.5";

--- a/include/kcenon/pacs/storage/viewer_state_record_repository.h
+++ b/include/kcenon/pacs/storage/viewer_state_record_repository.h
@@ -35,7 +35,7 @@ namespace kcenon::pacs::storage {
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/viewer_state_repository.h
+++ b/include/kcenon/pacs/storage/viewer_state_repository.h
@@ -52,7 +52,7 @@ using VoidResult = kcenon::common::VoidResult;
  * - This class is NOT thread-safe. External synchronization is required
  *   for concurrent access.
  *
- * @example
+ * @par Example:
  * @code
  * auto db = std::make_shared<pacs_database_adapter>("pacs.db");
  * db->connect();

--- a/include/kcenon/pacs/storage/worklist_record.h
+++ b/include/kcenon/pacs/storage/worklist_record.h
@@ -201,7 +201,7 @@ struct worklist_item {
  * Used for MWL C-FIND operations. Empty fields are not included in the filter.
  * Only items with status 'SCHEDULED' are returned by default.
  *
- * @example
+ * @par Example:
  * @code
  * worklist_query query;
  * query.station_ae = "CT_SCANNER_1";

--- a/include/kcenon/pacs/web/auth/jwks_provider.h
+++ b/include/kcenon/pacs/web/auth/jwks_provider.h
@@ -54,7 +54,7 @@ using jwks_fetch_callback =
  * Manages JSON Web Key Sets for JWT signature verification. Keys can be
  * loaded statically from JSON or fetched dynamically via a callback.
  *
- * @example
+ * @par Example:
  * @code
  * jwks_provider provider;
  * provider.load_from_json(R"({"keys":[...]})");

--- a/include/kcenon/pacs/web/auth/jwt_validator.h
+++ b/include/kcenon/pacs/web/auth/jwt_validator.h
@@ -104,7 +104,7 @@ enum class jwt_error {
  * Provides JWT decoding, claim validation, and signature verification.
  * Signature verification requires OpenSSL (PACS_WITH_DIGITAL_SIGNATURES).
  *
- * @example
+ * @par Example:
  * @code
  * oauth2_config config;
  * config.issuer = "https://auth.example.com";

--- a/include/kcenon/pacs/web/auth/oauth2_middleware.h
+++ b/include/kcenon/pacs/web/auth/oauth2_middleware.h
@@ -90,7 +90,7 @@ struct auth_result {
  * When OAuth 2.0 is disabled, the middleware is a no-op and the system
  * falls back to the existing X-User-ID header-based authentication.
  *
- * @example
+ * @par Example:
  * @code
  * oauth2_config config;
  * config.enabled = true;

--- a/include/kcenon/pacs/web/endpoints/wado_uri_endpoints.h
+++ b/include/kcenon/pacs/web/endpoints/wado_uri_endpoints.h
@@ -90,7 +90,6 @@ struct validation_result {
 
 /**
  * @brief Parse WADO-URI query parameters from an HTTP request
- * @param request_type The requestType parameter value
  * @param study_uid The studyUID parameter value
  * @param series_uid The seriesUID parameter value
  * @param object_uid The objectUID parameter value

--- a/include/kcenon/pacs/web/metadata_service.h
+++ b/include/kcenon/pacs/web/metadata_service.h
@@ -442,6 +442,8 @@ private:
     /**
      * @brief Read DICOM dataset from file
      * @param file_path Path to DICOM file
+     * @param requested_tags Set of tag keys (e.g. "00100010") to extract
+     * @param include_private If true, include private tags (odd group numbers)
      * @return Map of tag values
      */
     [[nodiscard]] std::unordered_map<std::string, std::string> read_dicom_tags(

--- a/include/kcenon/pacs/web/rest_server.h
+++ b/include/kcenon/pacs/web/rest_server.h
@@ -138,10 +138,6 @@ public:
    * @brief Set metrics provider for /api/v1/system/metrics endpoint
    * @param metrics Metrics instance
    */
-  /**
-   * @brief Set metrics provider for /api/v1/system/metrics endpoint
-   * @param metrics Metrics instance
-   */
   void set_metrics_provider(std::shared_ptr<monitoring::pacs_metrics> metrics);
 
   /**

--- a/include/kcenon/pacs/workflow/auto_prefetch_service.h
+++ b/include/kcenon/pacs/workflow/auto_prefetch_service.h
@@ -166,7 +166,7 @@ struct prefetch_request {
  * └─────────────────────────┘
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * // Configure prefetch service
  * prefetch_service_config config;

--- a/include/kcenon/pacs/workflow/study_lock_manager.h
+++ b/include/kcenon/pacs/workflow/study_lock_manager.h
@@ -309,7 +309,7 @@ namespace lock_error {
  * 2. Exclusive locks block new shared locks
  * 3. Shared locks can coexist with other shared locks
  *
- * @example
+ * @par Example:
  * @code
  * study_lock_manager_config config;
  * config.default_timeout = std::chrono::minutes{30};

--- a/include/kcenon/pacs/workflow/task_scheduler.h
+++ b/include/kcenon/pacs/workflow/task_scheduler.h
@@ -121,7 +121,7 @@ class Result;
  * └─────────────────────────┘
  * ```
  *
- * @example Basic Usage
+ * @par Example: Basic Usage
  * @code
  * // Configure scheduler
  * task_scheduler_config config;


### PR DESCRIPTION
## What

Implements #1103.

Doxygen warning count for `include/kcenon/pacs/**` reduced from **159 to 1** (99.4% reduction):

| Stage | Total warnings | `include/` warnings |
|-------|---------------:|--------------------:|
| Baseline (develop) | 350 | 159 |
| After @par Example: / @license alias | 258 | 91 |
| After @cond, @verbatim, targeted @param fixes | 133 | 1 |

The single remaining `include/` warning (`end of comment block while expecting command </em>` in `index_database.h:227`) appears to be a Doxygen false positive — the reported lines contain no HTML tags, and no `<em>` exists in the file.

## Why

Closes #1103. Before this PR the generated API reference carried ~159 warnings on
public headers, many from malformed `@example`, unknown `@license`, duplicate doc
blocks, and stale `@param` names pointing at removed arguments. These collectively
made the Doxygen output unreliable as the primary API entry point for integrators.

## How

Four commits, each a focused class of fix:

1. **`@par Example:` and `@license` alias** — `@example` is a built-in Doxygen
   command expecting a filename; the codebase used it inline with `@code`, which
   produced ~25 duplicate-example warnings. Replaced with `@par Example:` across
   144 headers. Added `license=@par License:^^` to `ALIASES` so the 26 occurrences
   of `@license MIT` stop generating "unknown command" warnings.

2. **Targeted @param / @return / HTML fixes** — 11 files:
   - `base_repository_impl.h`: wrapped template method implementations in
     `@cond/@endcond` so Doxygen stops ambiguously matching them to derived
     repositories (19 warnings eliminated).
   - `audit_log_cipher.h`: wrapped record format spec in `@verbatim/@endverbatim`
     (literal `<key_id>` etc. no longer parsed as HTML); added missing `out_size`
     param doc.
   - `compat/format.h` + `compat/time.h`: wrapped usage snippets in `@code/@endcode`
     so `#include <...>` stops being treated as `\ref include`.
   - `ai_service_connector.h`, `dicom_element.h`, `simd_photometric.h`,
     `metadata_service.h`: fixed/added missing @param entries.
   - `association.h`: dropped stray `@return` from void `process_release_rq`.
   - `rest_server.h`: removed duplicated doc block on `set_metrics_provider`.
   - `wado_uri_endpoints.h`: removed stale `@param request_type`.

3. **@defgroup pages** — new `docs/groups.dox` defines module-level landing
   pages for Core, Network, Security, Storage, Web. Each group carries a
   description and `@ref` cross-references to the main entry points. Added
   `docs/groups.dox` to `Doxyfile` `INPUT`.

4. **README link** — added a direct link to the hosted Doxygen output at
   <https://kcenon.github.io/pacs_system/>. Distinguished from the existing
   narrative API walkthrough (`docs/API_REFERENCE.md`) by renaming that bullet.

## Where

- `Doxyfile`: `ALIASES`, `INPUT` updates
- `include/kcenon/pacs/**`: 147 files touched (144 mechanical + 3 targeted)
- `docs/groups.dox`: new
- `README.md`: one-line addition in Documentation section

## Test Plan

Local verification:

```bash
doxygen Doxyfile
# Expected:
#   Total warnings: 133
#   include/kcenon/pacs/ warnings: 1  (Doxygen false positive in index_database.h:227)
```

The existing `build-Doxygen.yaml` workflow runs on pushes to `main` only; the
hosted Pages site (`kcenon.github.io/pacs_system`) will pick up these changes on
the next `develop` → `main` release cut, which is consistent with the repo's
branching strategy.

## Acceptance Criteria

- [x] Doxygen warn count < 5 for public headers (1, down from 159)
- [x] Generated docs deployed to GitHub Pages (already live at kcenon.github.io/pacs_system; next refresh on develop→main merge)
- [x] README links to the hosted API reference (new bullet at the top of Documentation section)

Closes #1103