### PR TITLE
docs: add Doxygen warning-count gate for API reference quality

### DIFF
--- a/.github/workflows/doxygen-warn-count.yml
+++ b/.github/workflows/doxygen-warn-count.yml
@@ -1,0 +1,82 @@
+name: Doxygen Warning Count
+
+# Counts Doxygen warnings on every PR so the API-reference quality is
+# visible in review. Fails the job if the count regresses significantly
+# (> 500) so we never suddenly lose hundreds of annotated symbols. The
+# strict <5 target from #1103 will be enforced in a follow-up PR once
+# the current baseline is measured and gaps are filled.
+
+on:
+  push:
+    branches: [ main, develop, phase-* ]
+  pull_request:
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+jobs:
+  count-doxygen-warnings:
+    name: Doxygen warning count
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y doxygen graphviz
+
+      - name: Run Doxygen and capture warnings
+        id: run
+        run: |
+          set -o pipefail
+          # Separate stdout and stderr so we count only actual warnings,
+          # not progress output. Doxygen emits warnings on stderr.
+          doxygen Doxyfile 2> doxygen.warn > doxygen.log || true
+
+          # Match "warning:" lines (the WARN_FORMAT in Doxyfile prefixes
+          # file:line but always includes "warning:" per Doxygen convention).
+          COUNT=$(grep -cE "warning:" doxygen.warn || true)
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Doxygen warnings: $COUNT"
+
+      - name: Write job summary
+        run: |
+          COUNT=${{ steps.run.outputs.count }}
+          {
+            echo "## Doxygen API Reference Quality"
+            echo ""
+            echo "**Warning count: ${COUNT}**"
+            echo ""
+            echo "### Top 30 warnings"
+            echo '```'
+            head -30 doxygen.warn || echo "(no warnings)"
+            echo '```'
+            echo ""
+            echo "### Targets"
+            echo "- Current regression floor (this workflow): **500**"
+            echo "- Issue #1103 eventual target: **< 5** — tracked for a follow-up PR"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload warning log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doxygen-warnings
+          path: |
+            doxygen.warn
+            doxygen.log
+          retention-days: 14
+
+      - name: Enforce regression floor
+        run: |
+          COUNT=${{ steps.run.outputs.count }}
+          FLOOR=500
+          if [ "$COUNT" -gt "$FLOOR" ]; then
+            echo "::error::Doxygen warning count ($COUNT) exceeds regression floor ($FLOOR)."
+            echo "Inspect the uploaded doxygen-warnings artifact and address the new warnings"
+            echo "before merging. The long-term target per #1103 is < 5."
+            exit 1
+          fi
+          echo "Doxygen warning count $COUNT within regression floor ($FLOOR)."


### PR DESCRIPTION
## What

### Summary
Adds `.github/workflows/doxygen-warn-count.yml` — a lightweight CI job that installs Doxygen, runs it against the existing `Doxyfile`, and exposes the warning count to reviewers via the PR job summary. Fails the job if the count regresses past 500 so the baseline cannot silently worsen. The strict "< 5" target from #1103 is left for a follow-up PR once we know the current count.

### Change Type
- [x] CI / documentation infrastructure (no source or docs content change)

### Affected Components
- `.github/workflows/doxygen-warn-count.yml` (new, 82 lines)

## Why

### Investigation finding
Audit confirms #1103's AC items are already mostly met:
| AC item | Status | Evidence |
|---|---|---|
| Doxygen warn count < 5 for public headers | **Unknown** — no gate exists | Addressed by this PR (measure first, enforce later) |
| Generated docs deployed to GitHub Pages | **Done** | [kcenon.github.io/pacs_system](https://kcenon.github.io/pacs_system/) via `build-Doxygen.yaml` |
| README links to the hosted API reference | **Done** | `README.md` line 470 |

The concrete remaining gap is the absence of a warn-count gate. Doxygen is not installed locally on this machine, so we cannot measure the baseline before pushing. This PR therefore adds a permissive gate (regression floor at 500) so the first CI run publishes the actual baseline in the job summary; a follow-up PR will lower the threshold to 5 once we know how far we have to go.

### Related Issues
- Relates to #1103 (this PR does not close it — reserves the final lowering to 5 for a follow-up, similar pattern to logger_system #619 / #620)

## How

### Implementation Details
- Installs Doxygen + Graphviz on Ubuntu runner (single-purpose job, \<5 min expected).
- Separates stdout/stderr so the count only reflects real warnings.
- Publishes `**Warning count: N**` and the top 30 warnings to the GitHub Actions job summary visible on every PR.
- Uploads `doxygen.warn` and `doxygen.log` as an artifact (14-day retention) so reviewers can inspect the full output.
- Regression floor set to 500. Any PR that reintroduces hundreds of undocumented symbols fails immediately; everything under 500 is informational until the follow-up PR lowers the floor toward 5.

### Testing Done
- [x] YAML syntax validated locally
- [ ] Actual warn count verified — **this is the first measurement**; CI on this PR will publish it

### Test Plan for Reviewers
1. Observe the job summary on the `Doxygen warning count` check — `**Warning count: N**` at the top.
2. If N is already < 5, we can immediately file a trivial follow-up lowering the floor.
3. If N is between 5 and 500, this PR establishes the measurement; the follow-up will be a concrete annotation-adding effort sized against N.
4. If N is > 500 on this PR alone, something is wrong with the workflow itself — investigate before merging.

### Breaking Changes
None — workflow addition only.