### PR TITLE
ci(docs): tighten Doxygen warn-count floor to 160

### DIFF
--- a/.github/workflows/doxygen-warn-count.yml
+++ b/.github/workflows/doxygen-warn-count.yml
@@ -1,10 +1,10 @@
 name: Doxygen Warning Count
 
 # Counts Doxygen warnings on every PR so the API-reference quality is
-# visible in review. Fails the job if the count regresses significantly
-# (> 500) so we never suddenly lose hundreds of annotated symbols. The
+# visible in review. Fails the job if the count regresses above the
+# current baseline (> 160) so we ratchet down as gaps are filled. The
 # strict <5 target from #1103 will be enforced in a follow-up PR once
-# the current baseline is measured and gaps are filled.
+# the annotation gaps in include/kcenon/pacs/** are closed.
 
 on:
   push:
@@ -72,7 +72,7 @@ jobs:
       - name: Enforce regression floor
         run: |
           COUNT=${{ steps.run.outputs.count }}
-          FLOOR=500
+          FLOOR=160
           if [ "$COUNT" -gt "$FLOOR" ]; then
             echo "::error::Doxygen warning count ($COUNT) exceeds regression floor ($FLOOR)."
             echo "Inspect the uploaded doxygen-warnings artifact and address the new warnings"


### PR DESCRIPTION
## What

Lowers the Doxygen warning-count regression floor from 500 to 160 in `.github/workflows/doxygen-warn-count.yml`.

## Why

PR #1117 landed the Doxygen warn-count CI job with a deliberately generous floor of 500 so the first measurement would not fail the gate. The first measurement reported **152 warnings** on develop. That leaves the current 500 floor functionally inactive — 348 warnings of regression could land silently.

This PR tightens the floor to **160** (baseline 152 + 8 warnings buffer) so new regressions are caught immediately while still allowing routine drift between commits. The strict `< 5` target from #1103 remains the long-term goal and is not addressed here.

## Where

- `.github/workflows/doxygen-warn-count.yml` (1 line change + header comment update)

## How

- Changed `FLOOR=500` to `FLOOR=160`
- Updated the top-of-file comment to describe the ratchet approach and reference `include/kcenon/pacs/**`
- No code under `include/` or `src/` changed

## Test Plan

- The `Doxygen Warning Count` CI job runs on this PR and reports the current count against the new floor
- Expected: count ≤ 160, gate passes
- If count > 160 on this PR, inspect the `doxygen-warnings` artifact — it means this branch introduced new warnings and those must be addressed before merge

## Related

- Relates to #1118 (parent — this PR does not close it; the issue stays open until the full <5 target lands)
- Relates to #1103 (long-term <5 target; deferred)
- Follows-up on #1117 (introduced the 500-floor measurement scaffolding)