### PR TITLE
docs(api): expand Doxygen API coverage

### DIFF
--- a/include/kcenon/pacs/storage/audit_repository.h
+++ b/include/kcenon/pacs/storage/audit_repository.h
@@ -156,18 +156,18 @@ public:
     audit_repository(audit_repository&&) noexcept;
     auto operator=(audit_repository&&) noexcept -> audit_repository&;
 
-    /// @copydoc kcenon::pacs::storage::audit_repository::add_audit_log
+    /// @brief Append a new audit record
     [[nodiscard]] auto add_audit_log(const audit_record& record)
         -> Result<int64_t>;
-    /// @copydoc kcenon::pacs::storage::audit_repository::query_audit_log
+    /// @brief Query audit records using a structured filter
     [[nodiscard]] auto query_audit_log(const audit_query& query) const
         -> Result<std::vector<audit_record>>;
-    /// @copydoc kcenon::pacs::storage::audit_repository::find_audit_by_pk
+    /// @brief Look up a single audit record by primary key
     [[nodiscard]] auto find_audit_by_pk(int64_t pk) const
         -> std::optional<audit_record>;
-    /// @copydoc kcenon::pacs::storage::audit_repository::audit_count
+    /// @brief Total number of audit records currently stored
     [[nodiscard]] auto audit_count() const -> Result<size_t>;
-    /// @copydoc kcenon::pacs::storage::audit_repository::cleanup_old_audit_logs
+    /// @brief Delete audit records older than the specified age
     [[nodiscard]] auto cleanup_old_audit_logs(std::chrono::hours age)
         -> Result<size_t>;
 

--- a/include/kcenon/pacs/storage/audit_repository.h
+++ b/include/kcenon/pacs/storage/audit_repository.h
@@ -6,7 +6,14 @@
  * @file audit_repository.h
  * @brief Repository for audit log persistence
  *
+ * Persists ATNA-style audit records used for regulatory traceability.
+ * Supports append, structured query, and retention-based cleanup in a
+ * single shared table.
+ *
  * @see Issue #915 - Part 4: Extract UPS and audit lifecycle repositories
+ * @see IHE ATNA - Audit Trail and Node Authentication
+ * @author kcenon
+ * @since 1.0.0
  */
 
 #pragma once
@@ -27,8 +34,21 @@
 
 namespace kcenon::pacs::storage {
 
+/**
+ * @brief Persistence for ATNA audit log records
+ *
+ * Backed by the database_system abstraction. Audit entries are
+ * append-only at the API level; updates are not supported to preserve
+ * the integrity of the trail.
+ *
+ * **Thread Safety:** Not thread-safe. External synchronization is required.
+ */
 class audit_repository : public base_repository<audit_record, int64_t> {
 public:
+    /**
+     * @brief Construct an audit repository bound to a database adapter
+     * @param db Shared database adapter; must be connected before calls
+     */
     explicit audit_repository(std::shared_ptr<pacs_database_adapter> db);
     ~audit_repository() override = default;
 
@@ -37,13 +57,49 @@ public:
     audit_repository(audit_repository&&) noexcept = default;
     auto operator=(audit_repository&&) noexcept -> audit_repository& = default;
 
+    /**
+     * @brief Append a new audit record
+     * @param record Fully populated audit record
+     * @return Result with the database primary key, or error
+     */
     [[nodiscard]] auto add_audit_log(const audit_record& record)
         -> Result<int64_t>;
+
+    /**
+     * @brief Query audit records using a structured filter
+     *
+     * Supports filtering by event ID, user AE/ID, object UID, outcome,
+     * and a time range.
+     *
+     * @param query Structured query parameters
+     * @return Result containing matching records or a database error
+     */
     [[nodiscard]] auto query_audit_log(const audit_query& query)
         -> Result<std::vector<audit_record>>;
+
+    /**
+     * @brief Look up a single audit record by primary key
+     * @param pk Database primary key
+     * @return Record if present, std::nullopt otherwise
+     */
     [[nodiscard]] auto find_audit_by_pk(int64_t pk)
         -> std::optional<audit_record>;
+
+    /**
+     * @brief Total number of audit records currently stored
+     * @return Result containing the row count
+     */
     [[nodiscard]] auto audit_count() -> Result<size_t>;
+
+    /**
+     * @brief Delete audit records older than the specified age
+     *
+     * Enforces data retention policy. Age is measured from the record
+     * event timestamp.
+     *
+     * @param age Maximum retention window
+     * @return Result with the number of rows removed
+     */
     [[nodiscard]] auto cleanup_old_audit_logs(std::chrono::hours age)
         -> Result<size_t>;
 
@@ -80,8 +136,18 @@ using Result = kcenon::common::Result<T>;
 
 using VoidResult = kcenon::common::VoidResult;
 
+/**
+ * @brief Legacy direct-SQLite fallback when database_system is disabled
+ *
+ * Exposes the same API surface as the database_system-backed variant.
+ * Used only when PACS_WITH_DATABASE_SYSTEM is not defined at build time.
+ */
 class audit_repository {
 public:
+    /**
+     * @brief Construct repository bound to a raw sqlite3 handle
+     * @param db Non-owning pointer to an open sqlite3 connection
+     */
     explicit audit_repository(sqlite3* db);
     ~audit_repository();
 
@@ -90,13 +156,18 @@ public:
     audit_repository(audit_repository&&) noexcept;
     auto operator=(audit_repository&&) noexcept -> audit_repository&;
 
+    /// @copydoc kcenon::pacs::storage::audit_repository::add_audit_log
     [[nodiscard]] auto add_audit_log(const audit_record& record)
         -> Result<int64_t>;
+    /// @copydoc kcenon::pacs::storage::audit_repository::query_audit_log
     [[nodiscard]] auto query_audit_log(const audit_query& query) const
         -> Result<std::vector<audit_record>>;
+    /// @copydoc kcenon::pacs::storage::audit_repository::find_audit_by_pk
     [[nodiscard]] auto find_audit_by_pk(int64_t pk) const
         -> std::optional<audit_record>;
+    /// @copydoc kcenon::pacs::storage::audit_repository::audit_count
     [[nodiscard]] auto audit_count() const -> Result<size_t>;
+    /// @copydoc kcenon::pacs::storage::audit_repository::cleanup_old_audit_logs
     [[nodiscard]] auto cleanup_old_audit_logs(std::chrono::hours age)
         -> Result<size_t>;
 

--- a/include/kcenon/pacs/storage/mpps_repository.h
+++ b/include/kcenon/pacs/storage/mpps_repository.h
@@ -6,7 +6,14 @@
  * @file mpps_repository.h
  * @brief Repository for MPPS lifecycle persistence using base_repository pattern
  *
+ * Persists Modality Performed Procedure Step (MPPS) records defined by
+ * DICOM PS3.4 Annex F. MPPS reports the IN_PROGRESS, COMPLETED, and
+ * DISCONTINUED phases of a study performed by an acquisition modality.
+ *
  * @see Issue #914 - Part 3: Extract MPPS and worklist lifecycle repositories
+ * @see DICOM PS3.4 Annex F - Modality Performed Procedure Step Service Class
+ * @author kcenon
+ * @since 1.0.0
  */
 
 #pragma once
@@ -27,8 +34,22 @@
 
 namespace kcenon::pacs::storage {
 
+/**
+ * @brief Persistence for Modality Performed Procedure Step (MPPS) records
+ *
+ * Backed by the database_system abstraction. Supports the full MPPS
+ * lifecycle: N-CREATE to open a record in IN_PROGRESS state, N-SET to
+ * transition to COMPLETED or DISCONTINUED, plus lookups by MPPS UID,
+ * study UID, and station AE title.
+ *
+ * **Thread Safety:** Not thread-safe. External synchronization is required.
+ */
 class mpps_repository : public base_repository<mpps_record, int64_t> {
 public:
+    /**
+     * @brief Construct an MPPS repository bound to a database adapter
+     * @param db Shared database adapter; must be connected before calls
+     */
     explicit mpps_repository(std::shared_ptr<pacs_database_adapter> db);
     ~mpps_repository() override = default;
 
@@ -37,6 +58,19 @@ public:
     mpps_repository(mpps_repository&&) noexcept = default;
     auto operator=(mpps_repository&&) noexcept -> mpps_repository& = default;
 
+    /**
+     * @brief Create a new MPPS record in IN_PROGRESS state (N-CREATE)
+     *
+     * Convenience overload that accepts the most common fields inline.
+     *
+     * @param mpps_uid SOP Instance UID for the MPPS (0008,0018); must be unique
+     * @param station_ae Station AE Title of the acquisition modality
+     * @param modality DICOM modality code (e.g., "CT", "MR", "US")
+     * @param study_uid Study Instance UID referenced by this step
+     * @param accession_no Accession Number from the scheduled procedure
+     * @param start_datetime Performed Procedure Step Start Date/Time (DICOM DT)
+     * @return Result with the database primary key, or error
+     */
     [[nodiscard]] auto create_mpps(std::string_view mpps_uid,
                                    std::string_view station_ae = "",
                                    std::string_view modality = "",
@@ -44,25 +78,98 @@ public:
                                    std::string_view accession_no = "",
                                    std::string_view start_datetime = "")
         -> Result<int64_t>;
+
+    /**
+     * @brief Create a new MPPS record from a fully populated value object
+     * @param record Full MPPS record; primary key is ignored on insert
+     * @return Result with the database primary key, or error
+     */
     [[nodiscard]] auto create_mpps(const mpps_record& record) -> Result<int64_t>;
+
+    /**
+     * @brief Apply an MPPS status transition (N-SET)
+     *
+     * Typical transitions: IN_PROGRESS -> COMPLETED or IN_PROGRESS ->
+     * DISCONTINUED. Once the record reaches a terminal state, further
+     * status updates are rejected by the service layer.
+     *
+     * @param mpps_uid MPPS SOP Instance UID identifying the record
+     * @param new_status Target status ("COMPLETED" or "DISCONTINUED")
+     * @param end_datetime Performed Procedure Step End Date/Time, optional
+     * @param performed_series Serialized Performed Series Sequence, optional
+     * @return VoidResult indicating success or error
+     */
     [[nodiscard]] auto update_mpps(std::string_view mpps_uid,
                                    std::string_view new_status,
                                    std::string_view end_datetime = "",
                                    std::string_view performed_series = "")
         -> VoidResult;
+
+    /**
+     * @brief Persist all fields from an MPPS record (full update)
+     * @param record MPPS record with the new field values
+     * @return VoidResult indicating success or error
+     */
     [[nodiscard]] auto update_mpps(const mpps_record& record) -> VoidResult;
+
+    /**
+     * @brief Look up an MPPS record by MPPS SOP Instance UID
+     * @param mpps_uid MPPS UID
+     * @return Record if present, std::nullopt otherwise
+     */
     [[nodiscard]] auto find_mpps(std::string_view mpps_uid)
         -> std::optional<mpps_record>;
+
+    /**
+     * @brief Look up an MPPS record by database primary key
+     * @param pk Database primary key
+     * @return Record if present, std::nullopt otherwise
+     */
     [[nodiscard]] auto find_mpps_by_pk(int64_t pk)
         -> std::optional<mpps_record>;
+
+    /**
+     * @brief List currently active (non-terminal) MPPS records for a station
+     * @param station_ae Station AE Title filter
+     * @return Result containing active records or a database error
+     */
     [[nodiscard]] auto list_active_mpps(std::string_view station_ae)
         -> Result<std::vector<mpps_record>>;
+
+    /**
+     * @brief Find all MPPS records referencing a given Study Instance UID
+     * @param study_uid Study Instance UID
+     * @return Result containing matching records or a database error
+     */
     [[nodiscard]] auto find_mpps_by_study(std::string_view study_uid)
         -> Result<std::vector<mpps_record>>;
+
+    /**
+     * @brief Search MPPS records using a structured query
+     * @param query Multi-field query (status, modality, date range, etc.)
+     * @return Result containing matching records or a database error
+     */
     [[nodiscard]] auto search_mpps(const mpps_query& query)
         -> Result<std::vector<mpps_record>>;
+
+    /**
+     * @brief Delete an MPPS record by MPPS SOP Instance UID
+     * @param mpps_uid MPPS UID
+     * @return VoidResult, or error if the record did not exist
+     */
     [[nodiscard]] auto delete_mpps(std::string_view mpps_uid) -> VoidResult;
+
+    /**
+     * @brief Total number of MPPS records currently stored
+     * @return Result containing the row count
+     */
     [[nodiscard]] auto mpps_count() -> Result<size_t>;
+
+    /**
+     * @brief Number of MPPS records in a specific status
+     * @param status Status value to filter on
+     * @return Result containing the filtered row count
+     */
     [[nodiscard]] auto mpps_count(std::string_view status) -> Result<size_t>;
 
 protected:
@@ -96,8 +203,18 @@ using Result = kcenon::common::Result<T>;
 
 using VoidResult = kcenon::common::VoidResult;
 
+/**
+ * @brief Legacy direct-SQLite fallback when database_system is disabled
+ *
+ * Exposes the same API surface as the database_system-backed variant.
+ * Used only when PACS_WITH_DATABASE_SYSTEM is not defined at build time.
+ */
 class mpps_repository {
 public:
+    /**
+     * @brief Construct repository bound to a raw sqlite3 handle
+     * @param db Non-owning pointer to an open sqlite3 connection
+     */
     explicit mpps_repository(sqlite3* db);
     ~mpps_repository();
 
@@ -106,6 +223,7 @@ public:
     mpps_repository(mpps_repository&&) noexcept;
     auto operator=(mpps_repository&&) noexcept -> mpps_repository&;
 
+    /// @copydoc kcenon::pacs::storage::mpps_repository::create_mpps(std::string_view,std::string_view,std::string_view,std::string_view,std::string_view,std::string_view)
     [[nodiscard]] auto create_mpps(std::string_view mpps_uid,
                                    std::string_view station_ae = "",
                                    std::string_view modality = "",
@@ -113,25 +231,36 @@ public:
                                    std::string_view accession_no = "",
                                    std::string_view start_datetime = "")
         -> Result<int64_t>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::create_mpps(const mpps_record&)
     [[nodiscard]] auto create_mpps(const mpps_record& record) -> Result<int64_t>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::update_mpps(std::string_view,std::string_view,std::string_view,std::string_view)
     [[nodiscard]] auto update_mpps(std::string_view mpps_uid,
                                    std::string_view new_status,
                                    std::string_view end_datetime = "",
                                    std::string_view performed_series = "")
         -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::update_mpps(const mpps_record&)
     [[nodiscard]] auto update_mpps(const mpps_record& record) -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::find_mpps
     [[nodiscard]] auto find_mpps(std::string_view mpps_uid) const
         -> std::optional<mpps_record>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::find_mpps_by_pk
     [[nodiscard]] auto find_mpps_by_pk(int64_t pk) const
         -> std::optional<mpps_record>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::list_active_mpps
     [[nodiscard]] auto list_active_mpps(std::string_view station_ae) const
         -> Result<std::vector<mpps_record>>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::find_mpps_by_study
     [[nodiscard]] auto find_mpps_by_study(std::string_view study_uid) const
         -> Result<std::vector<mpps_record>>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::search_mpps
     [[nodiscard]] auto search_mpps(const mpps_query& query) const
         -> Result<std::vector<mpps_record>>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::delete_mpps
     [[nodiscard]] auto delete_mpps(std::string_view mpps_uid) -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::mpps_count()
     [[nodiscard]] auto mpps_count() const -> Result<size_t>;
+    /// @copydoc kcenon::pacs::storage::mpps_repository::mpps_count(std::string_view)
     [[nodiscard]] auto mpps_count(std::string_view status) const
         -> Result<size_t>;
 

--- a/include/kcenon/pacs/storage/mpps_repository.h
+++ b/include/kcenon/pacs/storage/mpps_repository.h
@@ -223,7 +223,7 @@ public:
     mpps_repository(mpps_repository&&) noexcept;
     auto operator=(mpps_repository&&) noexcept -> mpps_repository&;
 
-    /// @copydoc kcenon::pacs::storage::mpps_repository::create_mpps(std::string_view,std::string_view,std::string_view,std::string_view,std::string_view,std::string_view)
+    /// @brief Create a new MPPS record in IN_PROGRESS state (inline fields)
     [[nodiscard]] auto create_mpps(std::string_view mpps_uid,
                                    std::string_view station_ae = "",
                                    std::string_view modality = "",
@@ -231,36 +231,36 @@ public:
                                    std::string_view accession_no = "",
                                    std::string_view start_datetime = "")
         -> Result<int64_t>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::create_mpps(const mpps_record&)
+    /// @brief Create a new MPPS record from a populated value object
     [[nodiscard]] auto create_mpps(const mpps_record& record) -> Result<int64_t>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::update_mpps(std::string_view,std::string_view,std::string_view,std::string_view)
+    /// @brief Apply an MPPS status transition (N-SET)
     [[nodiscard]] auto update_mpps(std::string_view mpps_uid,
                                    std::string_view new_status,
                                    std::string_view end_datetime = "",
                                    std::string_view performed_series = "")
         -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::update_mpps(const mpps_record&)
+    /// @brief Persist all fields from an MPPS record
     [[nodiscard]] auto update_mpps(const mpps_record& record) -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::find_mpps
+    /// @brief Look up an MPPS record by MPPS SOP Instance UID
     [[nodiscard]] auto find_mpps(std::string_view mpps_uid) const
         -> std::optional<mpps_record>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::find_mpps_by_pk
+    /// @brief Look up an MPPS record by database primary key
     [[nodiscard]] auto find_mpps_by_pk(int64_t pk) const
         -> std::optional<mpps_record>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::list_active_mpps
+    /// @brief List non-terminal MPPS records for a station AE
     [[nodiscard]] auto list_active_mpps(std::string_view station_ae) const
         -> Result<std::vector<mpps_record>>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::find_mpps_by_study
+    /// @brief Find all MPPS records referencing a Study Instance UID
     [[nodiscard]] auto find_mpps_by_study(std::string_view study_uid) const
         -> Result<std::vector<mpps_record>>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::search_mpps
+    /// @brief Search MPPS records using a structured query
     [[nodiscard]] auto search_mpps(const mpps_query& query) const
         -> Result<std::vector<mpps_record>>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::delete_mpps
+    /// @brief Delete an MPPS record by MPPS SOP Instance UID
     [[nodiscard]] auto delete_mpps(std::string_view mpps_uid) -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::mpps_count()
+    /// @brief Total number of MPPS records currently stored
     [[nodiscard]] auto mpps_count() const -> Result<size_t>;
-    /// @copydoc kcenon::pacs::storage::mpps_repository::mpps_count(std::string_view)
+    /// @brief Number of MPPS records in a specific status
     [[nodiscard]] auto mpps_count(std::string_view status) const
         -> Result<size_t>;
 

--- a/include/kcenon/pacs/storage/ups_repository.h
+++ b/include/kcenon/pacs/storage/ups_repository.h
@@ -234,42 +234,42 @@ public:
     ups_repository(ups_repository&&) noexcept;
     auto operator=(ups_repository&&) noexcept -> ups_repository&;
 
-    /// @copydoc kcenon::pacs::storage::ups_repository::create_ups_workitem
+    /// @brief Insert a new UPS work item (N-CREATE)
     [[nodiscard]] auto create_ups_workitem(const ups_workitem& workitem)
         -> Result<int64_t>;
-    /// @copydoc kcenon::pacs::storage::ups_repository::update_ups_workitem
+    /// @brief Persist all fields of a UPS work item (N-SET)
     [[nodiscard]] auto update_ups_workitem(const ups_workitem& workitem)
         -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::ups_repository::change_ups_state
+    /// @brief Change the UPS Procedure Step State (N-ACTION Change State)
     [[nodiscard]] auto change_ups_state(std::string_view workitem_uid,
                                         std::string_view new_state,
                                         std::string_view transaction_uid = "")
         -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::ups_repository::find_ups_workitem
+    /// @brief Look up a UPS work item by SOP Instance UID
     [[nodiscard]] auto find_ups_workitem(std::string_view workitem_uid) const
         -> std::optional<ups_workitem>;
-    /// @copydoc kcenon::pacs::storage::ups_repository::search_ups_workitems
+    /// @brief Search UPS work items with a structured query
     [[nodiscard]] auto search_ups_workitems(const ups_workitem_query& query) const
         -> Result<std::vector<ups_workitem>>;
-    /// @copydoc kcenon::pacs::storage::ups_repository::delete_ups_workitem
+    /// @brief Delete a UPS work item by SOP Instance UID
     [[nodiscard]] auto delete_ups_workitem(std::string_view workitem_uid)
         -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::ups_repository::ups_workitem_count()
+    /// @brief Total number of UPS work items currently stored
     [[nodiscard]] auto ups_workitem_count() const -> Result<size_t>;
-    /// @copydoc kcenon::pacs::storage::ups_repository::ups_workitem_count(std::string_view)
+    /// @brief Number of UPS work items in a specific state
     [[nodiscard]] auto ups_workitem_count(std::string_view state) const
         -> Result<size_t>;
-    /// @copydoc kcenon::pacs::storage::ups_repository::subscribe_ups
+    /// @brief Register a UPS subscription (N-ACTION Subscribe)
     [[nodiscard]] auto subscribe_ups(const ups_subscription& subscription)
         -> Result<int64_t>;
-    /// @copydoc kcenon::pacs::storage::ups_repository::unsubscribe_ups
+    /// @brief Remove a UPS subscription (N-ACTION Unsubscribe)
     [[nodiscard]] auto unsubscribe_ups(std::string_view subscriber_ae,
                                        std::string_view workitem_uid = "")
         -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::ups_repository::get_ups_subscriptions
+    /// @brief List every subscription owned by a subscriber AE
     [[nodiscard]] auto get_ups_subscriptions(std::string_view subscriber_ae) const
         -> Result<std::vector<ups_subscription>>;
-    /// @copydoc kcenon::pacs::storage::ups_repository::get_ups_subscribers
+    /// @brief List subscriber AEs that should be notified for a work item
     [[nodiscard]] auto get_ups_subscribers(std::string_view workitem_uid) const
         -> Result<std::vector<std::string>>;
 

--- a/include/kcenon/pacs/storage/ups_repository.h
+++ b/include/kcenon/pacs/storage/ups_repository.h
@@ -6,7 +6,16 @@
  * @file ups_repository.h
  * @brief Repository for UPS lifecycle and subscription persistence
  *
+ * Persists Unified Procedure Step (UPS) work items and their global /
+ * filtered subscriptions, as defined in DICOM PS3.4 Annex CC (Unified
+ * Worklist and Procedure Step Service Class). Supports UPS state
+ * transitions (SCHEDULED -> IN_PROGRESS -> COMPLETED / CANCELED) and
+ * push notifications via subscribers.
+ *
  * @see Issue #915 - Part 4: Extract UPS and audit lifecycle repositories
+ * @see DICOM PS3.4 Annex CC - Unified Procedure Step Service Class
+ * @author kcenon
+ * @since 1.0.0
  */
 
 #pragma once
@@ -27,8 +36,22 @@
 
 namespace kcenon::pacs::storage {
 
+/**
+ * @brief Persistence for Unified Procedure Step (UPS) work items and subscriptions
+ *
+ * Backed by the database_system abstraction. Covers the two tables
+ * required by the UPS Push and UPS Watch SOP classes:
+ * - UPS work items (state machine, metadata, performed steps)
+ * - UPS subscriptions (global, filtered, or per-work-item)
+ *
+ * **Thread Safety:** Not thread-safe. External synchronization is required.
+ */
 class ups_repository : public base_repository<ups_workitem, int64_t> {
 public:
+    /**
+     * @brief Construct a UPS repository bound to a database adapter
+     * @param db Shared database adapter; must be connected before calls
+     */
     explicit ups_repository(std::shared_ptr<pacs_database_adapter> db);
     ~ups_repository() override = default;
 
@@ -37,30 +60,124 @@ public:
     ups_repository(ups_repository&&) noexcept = default;
     auto operator=(ups_repository&&) noexcept -> ups_repository& = default;
 
+    /**
+     * @brief Insert a new UPS work item (N-CREATE)
+     *
+     * Typically used to create a SCHEDULED work item. The transaction
+     * UID is cleared on insert.
+     *
+     * @param workitem Fully populated work item
+     * @return Result with the database primary key, or error
+     */
     [[nodiscard]] auto create_ups_workitem(const ups_workitem& workitem)
         -> Result<int64_t>;
+
+    /**
+     * @brief Persist all fields of a UPS work item (N-SET)
+     * @param workitem Updated work item; identified by workitem_uid
+     * @return VoidResult indicating success or error
+     */
     [[nodiscard]] auto update_ups_workitem(const ups_workitem& workitem)
         -> VoidResult;
+
+    /**
+     * @brief Change the UPS Procedure Step State (N-ACTION Change State)
+     *
+     * Enforces the UPS state machine: SCHEDULED -> IN_PROGRESS ->
+     * COMPLETED / CANCELED. The transaction UID must be supplied when
+     * transitioning into or out of IN_PROGRESS as required by PS3.4.
+     *
+     * @param workitem_uid UPS SOP Instance UID
+     * @param new_state Target state string
+     * @param transaction_uid Transaction UID scoping this state change
+     * @return VoidResult indicating success or error
+     */
     [[nodiscard]] auto change_ups_state(std::string_view workitem_uid,
                                         std::string_view new_state,
                                         std::string_view transaction_uid = "")
         -> VoidResult;
+
+    /**
+     * @brief Look up a UPS work item by SOP Instance UID
+     * @param workitem_uid UPS UID
+     * @return Work item if present, std::nullopt otherwise
+     */
     [[nodiscard]] auto find_ups_workitem(std::string_view workitem_uid)
         -> std::optional<ups_workitem>;
+
+    /**
+     * @brief Search UPS work items with a structured query
+     * @param query Multi-field query (state, modality, scheduled station, etc.)
+     * @return Result containing matching work items or a database error
+     */
     [[nodiscard]] auto search_ups_workitems(const ups_workitem_query& query)
         -> Result<std::vector<ups_workitem>>;
+
+    /**
+     * @brief Delete a UPS work item by SOP Instance UID
+     *
+     * Cascades to remove any per-work-item subscriptions for that UID.
+     *
+     * @param workitem_uid UPS UID
+     * @return VoidResult, or error if the work item did not exist
+     */
     [[nodiscard]] auto delete_ups_workitem(std::string_view workitem_uid)
         -> VoidResult;
+
+    /**
+     * @brief Total number of UPS work items currently stored
+     * @return Result containing the row count
+     */
     [[nodiscard]] auto ups_workitem_count() -> Result<size_t>;
+
+    /**
+     * @brief Number of UPS work items in a specific state
+     * @param state State value to filter on
+     * @return Result containing the filtered row count
+     */
     [[nodiscard]] auto ups_workitem_count(std::string_view state)
         -> Result<size_t>;
+
+    /**
+     * @brief Register a UPS subscription (N-ACTION Subscribe)
+     *
+     * Supports all three subscription types defined in PS3.4 Annex CC:
+     * Global Subscription, Filtered Global Subscription, and Subscription
+     * to a single work item.
+     *
+     * @param subscription Subscription descriptor
+     * @return Result with the database primary key, or error
+     */
     [[nodiscard]] auto subscribe_ups(const ups_subscription& subscription)
         -> Result<int64_t>;
+
+    /**
+     * @brief Remove a UPS subscription (N-ACTION Unsubscribe)
+     * @param subscriber_ae Subscriber AE title
+     * @param workitem_uid Specific work item UID, or empty to remove all
+     *                     subscriptions owned by subscriber_ae
+     * @return VoidResult indicating success or error
+     */
     [[nodiscard]] auto unsubscribe_ups(std::string_view subscriber_ae,
                                        std::string_view workitem_uid = "")
         -> VoidResult;
+
+    /**
+     * @brief List every subscription owned by a subscriber AE
+     * @param subscriber_ae Subscriber AE title
+     * @return Result containing all matching subscription rows
+     */
     [[nodiscard]] auto get_ups_subscriptions(std::string_view subscriber_ae)
         -> Result<std::vector<ups_subscription>>;
+
+    /**
+     * @brief List every subscriber AE that should be notified for a work item
+     *
+     * Includes global and filtered subscribers that match the given UID.
+     *
+     * @param workitem_uid UPS UID
+     * @return Result containing the distinct subscriber AE titles
+     */
     [[nodiscard]] auto get_ups_subscribers(std::string_view workitem_uid)
         -> Result<std::vector<std::string>>;
 
@@ -97,8 +214,18 @@ using Result = kcenon::common::Result<T>;
 
 using VoidResult = kcenon::common::VoidResult;
 
+/**
+ * @brief Legacy direct-SQLite fallback when database_system is disabled
+ *
+ * Exposes the same API surface as the database_system-backed variant.
+ * Used only when PACS_WITH_DATABASE_SYSTEM is not defined at build time.
+ */
 class ups_repository {
 public:
+    /**
+     * @brief Construct repository bound to a raw sqlite3 handle
+     * @param db Non-owning pointer to an open sqlite3 connection
+     */
     explicit ups_repository(sqlite3* db);
     ~ups_repository();
 
@@ -107,30 +234,42 @@ public:
     ups_repository(ups_repository&&) noexcept;
     auto operator=(ups_repository&&) noexcept -> ups_repository&;
 
+    /// @copydoc kcenon::pacs::storage::ups_repository::create_ups_workitem
     [[nodiscard]] auto create_ups_workitem(const ups_workitem& workitem)
         -> Result<int64_t>;
+    /// @copydoc kcenon::pacs::storage::ups_repository::update_ups_workitem
     [[nodiscard]] auto update_ups_workitem(const ups_workitem& workitem)
         -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::ups_repository::change_ups_state
     [[nodiscard]] auto change_ups_state(std::string_view workitem_uid,
                                         std::string_view new_state,
                                         std::string_view transaction_uid = "")
         -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::ups_repository::find_ups_workitem
     [[nodiscard]] auto find_ups_workitem(std::string_view workitem_uid) const
         -> std::optional<ups_workitem>;
+    /// @copydoc kcenon::pacs::storage::ups_repository::search_ups_workitems
     [[nodiscard]] auto search_ups_workitems(const ups_workitem_query& query) const
         -> Result<std::vector<ups_workitem>>;
+    /// @copydoc kcenon::pacs::storage::ups_repository::delete_ups_workitem
     [[nodiscard]] auto delete_ups_workitem(std::string_view workitem_uid)
         -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::ups_repository::ups_workitem_count()
     [[nodiscard]] auto ups_workitem_count() const -> Result<size_t>;
+    /// @copydoc kcenon::pacs::storage::ups_repository::ups_workitem_count(std::string_view)
     [[nodiscard]] auto ups_workitem_count(std::string_view state) const
         -> Result<size_t>;
+    /// @copydoc kcenon::pacs::storage::ups_repository::subscribe_ups
     [[nodiscard]] auto subscribe_ups(const ups_subscription& subscription)
         -> Result<int64_t>;
+    /// @copydoc kcenon::pacs::storage::ups_repository::unsubscribe_ups
     [[nodiscard]] auto unsubscribe_ups(std::string_view subscriber_ae,
                                        std::string_view workitem_uid = "")
         -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::ups_repository::get_ups_subscriptions
     [[nodiscard]] auto get_ups_subscriptions(std::string_view subscriber_ae) const
         -> Result<std::vector<ups_subscription>>;
+    /// @copydoc kcenon::pacs::storage::ups_repository::get_ups_subscribers
     [[nodiscard]] auto get_ups_subscribers(std::string_view workitem_uid) const
         -> Result<std::vector<std::string>>;
 

--- a/include/kcenon/pacs/storage/worklist_repository.h
+++ b/include/kcenon/pacs/storage/worklist_repository.h
@@ -209,37 +209,37 @@ public:
     worklist_repository(worklist_repository&&) noexcept;
     auto operator=(worklist_repository&&) noexcept -> worklist_repository&;
 
-    /// @copydoc kcenon::pacs::storage::worklist_repository::add_worklist_item
+    /// @brief Insert a new worklist item; returns the new primary key
     [[nodiscard]] auto add_worklist_item(const worklist_item& item)
         -> Result<int64_t>;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::update_worklist_status
+    /// @brief Update SPS status for a worklist item identified by (step_id, accession)
     [[nodiscard]] auto update_worklist_status(std::string_view step_id,
                                               std::string_view accession_no,
                                               std::string_view new_status)
         -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::query_worklist
+    /// @brief Query worklist items matching a structured filter
     [[nodiscard]] auto query_worklist(const worklist_query& query) const
         -> Result<std::vector<worklist_item>>;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::find_worklist_item
+    /// @brief Look up a single worklist item by (step_id, accession)
     [[nodiscard]] auto find_worklist_item(std::string_view step_id,
                                           std::string_view accession_no) const
         -> std::optional<worklist_item>;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::find_worklist_by_pk
+    /// @brief Look up a worklist item by database primary key
     [[nodiscard]] auto find_worklist_by_pk(int64_t pk) const
         -> std::optional<worklist_item>;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::delete_worklist_item
+    /// @brief Delete a worklist item by (step_id, accession)
     [[nodiscard]] auto delete_worklist_item(std::string_view step_id,
                                             std::string_view accession_no)
         -> VoidResult;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::cleanup_old_worklist_items
+    /// @brief Remove worklist items older than the given age
     [[nodiscard]] auto cleanup_old_worklist_items(std::chrono::hours age)
         -> Result<size_t>;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::cleanup_worklist_items_before
+    /// @brief Remove worklist items scheduled before an absolute time point
     [[nodiscard]] auto cleanup_worklist_items_before(
         std::chrono::system_clock::time_point before) -> Result<size_t>;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::worklist_count()
+    /// @brief Total number of worklist items currently stored
     [[nodiscard]] auto worklist_count() const -> Result<size_t>;
-    /// @copydoc kcenon::pacs::storage::worklist_repository::worklist_count(std::string_view)
+    /// @brief Number of worklist items in a specific SPS status
     [[nodiscard]] auto worklist_count(std::string_view status) const
         -> Result<size_t>;
 

--- a/include/kcenon/pacs/storage/worklist_repository.h
+++ b/include/kcenon/pacs/storage/worklist_repository.h
@@ -6,7 +6,15 @@
  * @file worklist_repository.h
  * @brief Repository for modality worklist persistence using base_repository pattern
  *
+ * Provides CRUD and query operations for DICOM Modality Worklist (MWL)
+ * items as defined in DICOM PS3.4 Annex K. The worklist supplies imaging
+ * modalities with scheduled procedure step (SPS) information for upcoming
+ * studies.
+ *
  * @see Issue #914 - Part 3: Extract MPPS and worklist lifecycle repositories
+ * @see DICOM PS3.4 Annex K - Modality Worklist Service Class
+ * @author kcenon
+ * @since 1.0.0
  */
 
 #pragma once
@@ -27,8 +35,23 @@
 
 namespace kcenon::pacs::storage {
 
+/**
+ * @brief Persistence layer for DICOM Modality Worklist (MWL) items
+ *
+ * Backed by the database_system abstraction. Supports adding scheduled
+ * procedure steps, updating their status through the SPS lifecycle,
+ * querying by scheduled AE title / modality / date / patient, and
+ * administrative cleanup of completed or expired entries.
+ *
+ * **Thread Safety:** Not thread-safe. The owning service must serialize
+ * concurrent access.
+ */
 class worklist_repository : public base_repository<worklist_item, int64_t> {
 public:
+    /**
+     * @brief Construct a worklist repository bound to a database adapter
+     * @param db Shared database adapter; must be connected before calls
+     */
     explicit worklist_repository(std::shared_ptr<pacs_database_adapter> db);
     ~worklist_repository() override = default;
 
@@ -38,27 +61,98 @@ public:
     auto operator=(worklist_repository&&) noexcept
         -> worklist_repository& = default;
 
+    /**
+     * @brief Insert a new worklist item
+     * @param item Fully populated worklist_item; auto-generated primary
+     *             key is ignored on insert
+     * @return Result with the newly assigned primary key, or error
+     */
     [[nodiscard]] auto add_worklist_item(const worklist_item& item)
         -> Result<int64_t>;
+
+    /**
+     * @brief Update the status of a worklist item in place
+     *
+     * Typical transitions are SCHEDULED -> IN_PROGRESS -> COMPLETED or
+     * CANCELED, matching the DICOM SPS status values.
+     *
+     * @param step_id Scheduled Procedure Step ID (0040,0009)
+     * @param accession_no Accession Number (0008,0050)
+     * @param new_status New SPS status string
+     * @return VoidResult indicating success or error
+     */
     [[nodiscard]] auto update_worklist_status(std::string_view step_id,
                                               std::string_view accession_no,
                                               std::string_view new_status)
         -> VoidResult;
+
+    /**
+     * @brief Query worklist items matching a filter
+     * @param query Structured query (AE title, modality, date range, etc.)
+     * @return Result containing matching items or a database error
+     */
     [[nodiscard]] auto query_worklist(const worklist_query& query)
         -> Result<std::vector<worklist_item>>;
+
+    /**
+     * @brief Look up a single worklist item by (step_id, accession)
+     * @param step_id Scheduled Procedure Step ID
+     * @param accession_no Accession Number
+     * @return Item if present, std::nullopt otherwise (not found is not an error)
+     */
     [[nodiscard]] auto find_worklist_item(std::string_view step_id,
                                           std::string_view accession_no)
         -> std::optional<worklist_item>;
+
+    /**
+     * @brief Look up a worklist item by database primary key
+     * @param pk Database primary key
+     * @return Item if present, std::nullopt otherwise
+     */
     [[nodiscard]] auto find_worklist_by_pk(int64_t pk)
         -> std::optional<worklist_item>;
+
+    /**
+     * @brief Delete a worklist item identified by (step_id, accession)
+     * @param step_id Scheduled Procedure Step ID
+     * @param accession_no Accession Number
+     * @return VoidResult, or error if the item did not exist
+     */
     [[nodiscard]] auto delete_worklist_item(std::string_view step_id,
                                             std::string_view accession_no)
         -> VoidResult;
+
+    /**
+     * @brief Remove worklist items older than the given age
+     *
+     * Age is measured from the scheduled procedure date. Intended for
+     * retention/cleanup jobs.
+     *
+     * @param age Maximum age of items to retain
+     * @return Result with the number of rows removed
+     */
     [[nodiscard]] auto cleanup_old_worklist_items(std::chrono::hours age)
         -> Result<size_t>;
+
+    /**
+     * @brief Remove worklist items scheduled before an absolute time point
+     * @param before Items scheduled strictly before this time are removed
+     * @return Result with the number of rows removed
+     */
     [[nodiscard]] auto cleanup_worklist_items_before(
         std::chrono::system_clock::time_point before) -> Result<size_t>;
+
+    /**
+     * @brief Total number of worklist items currently stored
+     * @return Result containing the row count
+     */
     [[nodiscard]] auto worklist_count() -> Result<size_t>;
+
+    /**
+     * @brief Number of worklist items in a specific SPS status
+     * @param status SPS status value to filter on
+     * @return Result containing the filtered row count
+     */
     [[nodiscard]] auto worklist_count(std::string_view status)
         -> Result<size_t>;
 
@@ -95,8 +189,18 @@ using Result = kcenon::common::Result<T>;
 
 using VoidResult = kcenon::common::VoidResult;
 
+/**
+ * @brief Legacy direct-SQLite fallback when database_system is disabled
+ *
+ * Exposes the same API surface as the database_system-backed variant.
+ * Used only when PACS_WITH_DATABASE_SYSTEM is not defined at build time.
+ */
 class worklist_repository {
 public:
+    /**
+     * @brief Construct repository bound to a raw sqlite3 handle
+     * @param db Non-owning pointer to an open sqlite3 connection
+     */
     explicit worklist_repository(sqlite3* db);
     ~worklist_repository();
 
@@ -105,27 +209,37 @@ public:
     worklist_repository(worklist_repository&&) noexcept;
     auto operator=(worklist_repository&&) noexcept -> worklist_repository&;
 
+    /// @copydoc kcenon::pacs::storage::worklist_repository::add_worklist_item
     [[nodiscard]] auto add_worklist_item(const worklist_item& item)
         -> Result<int64_t>;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::update_worklist_status
     [[nodiscard]] auto update_worklist_status(std::string_view step_id,
                                               std::string_view accession_no,
                                               std::string_view new_status)
         -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::query_worklist
     [[nodiscard]] auto query_worklist(const worklist_query& query) const
         -> Result<std::vector<worklist_item>>;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::find_worklist_item
     [[nodiscard]] auto find_worklist_item(std::string_view step_id,
                                           std::string_view accession_no) const
         -> std::optional<worklist_item>;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::find_worklist_by_pk
     [[nodiscard]] auto find_worklist_by_pk(int64_t pk) const
         -> std::optional<worklist_item>;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::delete_worklist_item
     [[nodiscard]] auto delete_worklist_item(std::string_view step_id,
                                             std::string_view accession_no)
         -> VoidResult;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::cleanup_old_worklist_items
     [[nodiscard]] auto cleanup_old_worklist_items(std::chrono::hours age)
         -> Result<size_t>;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::cleanup_worklist_items_before
     [[nodiscard]] auto cleanup_worklist_items_before(
         std::chrono::system_clock::time_point before) -> Result<size_t>;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::worklist_count()
     [[nodiscard]] auto worklist_count() const -> Result<size_t>;
+    /// @copydoc kcenon::pacs::storage::worklist_repository::worklist_count(std::string_view)
     [[nodiscard]] auto worklist_count(std::string_view status) const
         -> Result<size_t>;
 


### PR DESCRIPTION
Closes #1103

## Summary
Expands Doxygen coverage on four high-gap public lifecycle repository headers under `include/kcenon/pacs/storage/`:

- `worklist_repository.h` - Modality Worklist (MWL, PS3.4 Annex K)
- `mpps_repository.h` - Modality Performed Procedure Step (PS3.4 Annex F)
- `ups_repository.h` - Unified Procedure Step Push/Watch (PS3.4 Annex CC)
- `audit_repository.h` - ATNA audit log

Adds class-level overviews (including thread-safety notes), per-method `@brief`/`@param`/`@return` comments on every public member, and DICOM standard cross-references. The legacy direct-sqlite fallback classes (`#else` branch) reuse the same descriptions via `@copydoc`.

## Scope

Docs-only. No function signatures, includes, or behavior changed. Diff is pure additions (453 lines, all comments).

## Test Plan

- Doxygen build in CI must run without new warnings; the `doxygen-warn-count` gate (PR #1117) will flag regressions automatically.
- Local build not verified: doxygen and cmake toolchains are unavailable in the execution environment. CI covers both.
