### PR TITLE
fix(ci): remove invalid JS escape in doc-audit workflow

### DIFF
--- a/.github/workflows/doc-audit.yml
+++ b/.github/workflows/doc-audit.yml
@@ -54,9 +54,9 @@ jobs:
           script: |
             const fs = require('fs');
             const reportPath = 'audit-report.md';
-            if (\!fs.existsSync(reportPath)) return;
+            if (!fs.existsSync(reportPath)) return;
             const report = fs.readFileSync(reportPath, 'utf8');
-            if (\!report.trim()) return;
+            if (!report.trim()) return;
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,


### PR DESCRIPTION
Closes #1121

## Summary
Replace `\!` with `!` on lines 57 and 59 of .github/workflows/doc-audit.yml.
The backslash-escaped form is a JavaScript SyntaxError which was breaking
the doc-audit check on every PR.

## Test Plan
- This PR's own doc-audit run must succeed (was failing before)
- No other changes