### PR TITLE
feat(xds): emit ATNA audit records for XDS-I.b transactions

### DIFF
--- a/include/kcenon/pacs/security/atna_service_auditor.h
+++ b/include/kcenon/pacs/security/atna_service_auditor.h
@@ -19,8 +19,10 @@
 #include "atna_syslog_transport.h"
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace kcenon::pacs::security {
 
@@ -64,7 +66,7 @@ public:
     atna_service_auditor(const syslog_transport_config& config,
                          std::string audit_source_id);
 
-    ~atna_service_auditor() = default;
+    virtual ~atna_service_auditor() = default;
 
     // Non-copyable, movable
     atna_service_auditor(const atna_service_auditor&) = delete;
@@ -123,6 +125,82 @@ public:
      */
     void audit_security_alert(const std::string& user_id,
                               const std::string& alert_description);
+
+    // =========================================================================
+    // IHE XDS-I.b Transaction Audit Methods
+    // =========================================================================
+
+    /**
+     * @brief XDS-I.b source-side transaction identifier
+     *
+     * Used by audit_xds_provide_and_register() to distinguish between
+     * ITI-41 (general document set) and RAD-68 (imaging document set)
+     * transactions.
+     */
+    enum class xds_source_transaction : uint8_t {
+        iti_41,   ///< ITI-41 Provide and Register Document Set-b
+        rad_68    ///< RAD-68 Provide and Register Imaging Document Set
+    };
+
+    /**
+     * @brief XDS-I.b consumer-side transaction identifier
+     *
+     * Used by audit_xds_retrieve() to distinguish between ITI-43
+     * (general document retrieval) and RAD-69 (imaging document
+     * retrieval) transactions.
+     */
+    enum class xds_consumer_transaction : uint8_t {
+        iti_43,   ///< ITI-43 Retrieve Document Set
+        rad_69    ///< RAD-69 Retrieve Imaging Document Set
+    };
+
+    /**
+     * @brief Audit an XDS-I.b Provide and Register Document Set transaction
+     *
+     * Emits an Export (DCM 110106) audit event for source-side XDS
+     * transactions (ITI-41 / RAD-68). The transaction identifier is
+     * recorded as an event type code to distinguish ITI-41 from RAD-68.
+     *
+     * @param transaction Transaction identifier (ITI-41 or RAD-68)
+     * @param source_ae Local source participant (AE / device identifier)
+     * @param dest_ae Remote destination participant (XDS registry/repository)
+     * @param study_uid Study Instance UID (the study being provided)
+     * @param patient_id Patient ID (optional, empty if unavailable)
+     * @param sop_instance_uids Referenced SOP Instance UIDs (may be empty for ITI-41)
+     * @param success Whether the transaction succeeded
+     */
+    virtual void audit_xds_provide_and_register(
+        xds_source_transaction transaction,
+        const std::string& source_ae,
+        const std::string& dest_ae,
+        const std::string& study_uid,
+        const std::string& patient_id,
+        const std::vector<std::string>& sop_instance_uids,
+        bool success);
+
+    /**
+     * @brief Audit an XDS-I.b Retrieve Document Set transaction
+     *
+     * Emits an Import (DCM 110107, via DICOM Instances Transferred) audit
+     * event for consumer-side XDS transactions (ITI-43 / RAD-69). The
+     * transaction identifier is recorded as an event type code.
+     *
+     * @param transaction Transaction identifier (ITI-43 or RAD-69)
+     * @param source_ae Remote source participant (XDS repository)
+     * @param dest_ae Local destination participant (this consumer)
+     * @param study_uid Study Instance UID (the study being retrieved)
+     * @param patient_id Patient ID (optional, empty if unavailable)
+     * @param sop_instance_uids Referenced SOP Instance UIDs (may be empty)
+     * @param success Whether the transaction succeeded
+     */
+    virtual void audit_xds_retrieve(
+        xds_consumer_transaction transaction,
+        const std::string& source_ae,
+        const std::string& dest_ae,
+        const std::string& study_uid,
+        const std::string& patient_id,
+        const std::vector<std::string>& sop_instance_uids,
+        bool success);
 
     // =========================================================================
     // Enable / Disable

--- a/include/kcenon/pacs/services/xds/imaging_document_consumer.h
+++ b/include/kcenon/pacs/services/xds/imaging_document_consumer.h
@@ -23,9 +23,12 @@
 #include "kcenon/pacs/core/dicom_dataset.h"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
+
+namespace kcenon::pacs::security { class atna_service_auditor; }
 
 namespace kcenon::pacs::services::xds {
 
@@ -222,14 +225,33 @@ public:
     /**
      * @brief Retrieve a specific document from the XDS repository.
      *
-     * Performs an ITI-43 (Retrieve Document Set) to fetch a
-     * KOS document identified by the document reference.
+     * Performs an ITI-43 (Retrieve Document Set) or RAD-69 (Retrieve
+     * Imaging Document Set) transaction to fetch a KOS document
+     * identified by the document reference. When an ATNA audit handler
+     * is installed, an Import audit event is emitted for both success
+     * and failure paths.
      *
      * @param doc_ref The document reference from a registry query
+     * @param is_imaging true for RAD-69 (Retrieve Imaging Document Set),
+     *   false for ITI-43 (Retrieve Document Set). Controls the
+     *   transaction code recorded in the ATNA audit.
      * @return Retrieval result with the KOS dataset
      */
     [[nodiscard]] document_retrieval_result retrieve_document(
-        const document_reference& doc_ref) const;
+        const document_reference& doc_ref,
+        bool is_imaging = true) const;
+
+    /**
+     * @brief Install an ATNA audit handler for XDS-I.b transactions
+     *
+     * When set, an audit event is emitted for each retrieve_document()
+     * call (ITI-43 or RAD-69) on both success and failure paths. Passing
+     * nullptr disables auditing for this consumer.
+     *
+     * @param auditor Shared pointer to an ATNA service auditor
+     */
+    void set_audit_handler(
+        std::shared_ptr<kcenon::pacs::security::atna_service_auditor> auditor);
 
     /**
      * @brief Extract image references from a KOS dataset.
@@ -273,6 +295,7 @@ public:
 
 private:
     imaging_document_consumer_config config_;
+    std::shared_ptr<kcenon::pacs::security::atna_service_auditor> auditor_;
 };
 
 }  // namespace kcenon::pacs::services::xds

--- a/include/kcenon/pacs/services/xds/imaging_document_source.h
+++ b/include/kcenon/pacs/services/xds/imaging_document_source.h
@@ -24,9 +24,12 @@
 #include "kcenon/pacs/core/dicom_dataset.h"
 
 #include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
 #include <vector>
+
+namespace kcenon::pacs::security { class atna_service_auditor; }
 
 namespace kcenon::pacs::services::xds {
 
@@ -309,15 +312,32 @@ public:
      *
      * Performs the ITI-41 (Provide and Register Document Set-b) transaction
      * to publish the KOS document and its metadata to the configured
-     * XDS registry/repository.
+     * XDS registry/repository. When an ATNA audit handler is installed,
+     * an Export audit event is emitted for both success and failure paths.
      *
      * @param kos_dataset The KOS dataset to publish
      * @param entry The document entry metadata
+     * @param is_imaging true for RAD-68 (Provide and Register Imaging
+     *   Document Set), false for ITI-41 (Provide and Register Document
+     *   Set-b). Controls the transaction code recorded in the ATNA audit.
      * @return Publication result
      */
     [[nodiscard]] publication_result publish_document(
         const core::dicom_dataset& kos_dataset,
-        const xds_document_entry& entry) const;
+        const xds_document_entry& entry,
+        bool is_imaging = true) const;
+
+    /**
+     * @brief Install an ATNA audit handler for XDS-I.b transactions
+     *
+     * When set, an audit event is emitted for each publish_document()
+     * call (ITI-41 or RAD-68) on both success and failure paths. Passing
+     * nullptr disables auditing for this source.
+     *
+     * @param auditor Shared pointer to an ATNA service auditor
+     */
+    void set_audit_handler(
+        std::shared_ptr<kcenon::pacs::security::atna_service_auditor> auditor);
 
     /**
      * @brief Get current configuration.
@@ -333,6 +353,7 @@ public:
 
 private:
     imaging_document_source_config config_;
+    std::shared_ptr<kcenon::pacs::security::atna_service_auditor> auditor_;
 
     /// Generate a new UID for KOS instances
     [[nodiscard]] std::string generate_uid() const;

--- a/src/security/atna_service_auditor.cpp
+++ b/src/security/atna_service_auditor.cpp
@@ -138,6 +138,128 @@ void atna_service_auditor::audit_security_alert(
 }
 
 // =============================================================================
+// IHE XDS-I.b Transaction Audit Methods
+// =============================================================================
+
+namespace {
+
+/// Event type codes that identify the specific XDS-I.b transaction
+/// within a generic Export / DICOM Instances Transferred event.
+const atna_coded_value xds_event_type_iti_41{
+    "ITI-41", "IHE Transactions", "Provide and Register Document Set-b"};
+const atna_coded_value xds_event_type_rad_68{
+    "RAD-68", "IHE Transactions", "Provide and Register Imaging Document Set"};
+const atna_coded_value xds_event_type_iti_43{
+    "ITI-43", "IHE Transactions", "Retrieve Document Set"};
+const atna_coded_value xds_event_type_rad_69{
+    "RAD-69", "IHE Transactions", "Retrieve Imaging Document Set"};
+
+/// Object ID type code for SOP Instance UID participant objects
+const atna_coded_value sop_instance_uid_type{
+    "110181", "DCM", "SOP Instance UID"};
+
+/// Append SOP Instance UID references as participant objects
+void append_sop_instance_objects(
+    atna_audit_message& msg,
+    const std::vector<std::string>& sop_instance_uids) {
+    for (const auto& uid : sop_instance_uids) {
+        if (uid.empty()) continue;
+        atna_participant_object obj;
+        obj.object_type = atna_object_type::system_object;
+        obj.object_role = atna_object_role::report;
+        obj.object_id_type_code = sop_instance_uid_type;
+        obj.object_id = uid;
+        msg.participant_objects.push_back(std::move(obj));
+    }
+}
+
+}  // namespace
+
+void atna_service_auditor::audit_xds_provide_and_register(
+    xds_source_transaction transaction,
+    const std::string& source_ae,
+    const std::string& dest_ae,
+    const std::string& study_uid,
+    const std::string& patient_id,
+    const std::vector<std::string>& sop_instance_uids,
+    bool success) {
+
+    if (!enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    auto outcome = success ? atna_event_outcome::success
+                           : atna_event_outcome::serious_failure;
+
+    // XDS-I.b Provide and Register is an Export event (DCM 110106) —
+    // the local actor is sending a document set to a remote registry.
+    auto msg = atna_audit_logger::build_export(
+        audit_source_id_,
+        source_ae,   // user (the local source actor)
+        "",          // user IP (not available at service level)
+        dest_ae,     // destination identifier (remote registry)
+        study_uid,
+        patient_id,
+        outcome);
+
+    // Tag the event with the specific IHE transaction code so consumers
+    // of the audit log can differentiate ITI-41 from RAD-68.
+    msg.event_type_codes.push_back(
+        transaction == xds_source_transaction::iti_41
+            ? xds_event_type_iti_41
+            : xds_event_type_rad_68);
+
+    // Add SOP Instance UID references if provided (required for RAD-68,
+    // optional but recommended for ITI-41).
+    append_sop_instance_objects(msg, sop_instance_uids);
+
+    send_audit(msg);
+}
+
+void atna_service_auditor::audit_xds_retrieve(
+    xds_consumer_transaction transaction,
+    const std::string& source_ae,
+    const std::string& dest_ae,
+    const std::string& study_uid,
+    const std::string& patient_id,
+    const std::vector<std::string>& sop_instance_uids,
+    bool success) {
+
+    if (!enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+
+    auto outcome = success ? atna_event_outcome::success
+                           : atna_event_outcome::serious_failure;
+
+    // XDS-I.b Retrieve Document Set is an Import event
+    // (DICOM Instances Transferred with is_import=true) — the local
+    // actor is receiving a document set from a remote repository.
+    auto msg = atna_audit_logger::build_dicom_instances_transferred(
+        audit_source_id_,
+        source_ae,
+        "",          // source IP (not available at service level)
+        dest_ae,
+        "",          // destination IP (not available at service level)
+        study_uid,
+        patient_id,
+        true,        // is_import (consumer is receiving)
+        outcome);
+
+    // Tag the event with the specific IHE transaction code so consumers
+    // of the audit log can differentiate ITI-43 from RAD-69.
+    msg.event_type_codes.push_back(
+        transaction == xds_consumer_transaction::iti_43
+            ? xds_event_type_iti_43
+            : xds_event_type_rad_69);
+
+    // Add SOP Instance UID references if provided.
+    append_sop_instance_objects(msg, sop_instance_uids);
+
+    send_audit(msg);
+}
+
+// =============================================================================
 // Enable / Disable
 // =============================================================================
 

--- a/src/services/xds/imaging_document_consumer.cpp
+++ b/src/services/xds/imaging_document_consumer.cpp
@@ -9,6 +9,7 @@
 
 #include "kcenon/pacs/services/xds/imaging_document_consumer.h"
 #include "kcenon/pacs/core/dicom_tag_constants.h"
+#include "kcenon/pacs/security/atna_service_auditor.h"
 
 #include <algorithm>
 #include <sstream>
@@ -58,21 +59,53 @@ registry_query_result imaging_document_consumer::query_registry(
 }
 
 document_retrieval_result imaging_document_consumer::retrieve_document(
-    [[maybe_unused]] const document_reference& doc_ref) const {
+    const document_reference& doc_ref,
+    bool is_imaging) const {
 
     document_retrieval_result result;
 
+    const auto transaction =
+        is_imaging
+            ? security::atna_service_auditor::xds_consumer_transaction::rad_69
+            : security::atna_service_auditor::xds_consumer_transaction::iti_43;
+
     if (config_.repository_url.empty()) {
         result.error_message = "XDS repository URL not configured";
+        if (auditor_) {
+            auditor_->audit_xds_retrieve(
+                transaction,
+                doc_ref.repository_unique_id,  // remote source
+                config_.repository_url,        // local destination (empty)
+                doc_ref.unique_id,             // document/study identifier
+                doc_ref.patient_id,
+                {doc_ref.unique_id},           // SOP-level reference
+                false);
+        }
         return result;
     }
 
-    // NOTE: Actual SOAP/MTOM request to the XDS repository (ITI-43)
+    // NOTE: Actual SOAP/MTOM request to the XDS repository (ITI-43 / RAD-69)
     // would be implemented here. The response contains the KOS
     // document as an MTOM attachment.
     result.success = true;
 
+    if (auditor_) {
+        auditor_->audit_xds_retrieve(
+            transaction,
+            doc_ref.repository_unique_id,
+            config_.repository_url,
+            doc_ref.unique_id,
+            doc_ref.patient_id,
+            {doc_ref.unique_id},
+            true);
+    }
+
     return result;
+}
+
+void imaging_document_consumer::set_audit_handler(
+    std::shared_ptr<kcenon::pacs::security::atna_service_auditor> auditor) {
+    auditor_ = std::move(auditor);
 }
 
 document_retrieval_result imaging_document_consumer::extract_references(

--- a/src/services/xds/imaging_document_source.cpp
+++ b/src/services/xds/imaging_document_source.cpp
@@ -10,6 +10,7 @@
 #include "kcenon/pacs/services/xds/imaging_document_source.h"
 #include "kcenon/pacs/core/dicom_tag_constants.h"
 #include "kcenon/pacs/encoding/vr_type.h"
+#include "kcenon/pacs/security/atna_service_auditor.h"
 #include "kcenon/pacs/services/sop_classes/sr_storage.h"
 
 #include <algorithm>
@@ -239,25 +240,91 @@ xds_submission_set imaging_document_source::build_submission_set(
     return set;
 }
 
+namespace {
+
+/// Extract all Referenced SOP Instance UIDs from the KOS evidence sequence
+std::vector<std::string> collect_sop_instance_uids(
+    const core::dicom_dataset& kos_dataset) {
+    std::vector<std::string> uids;
+    const auto* evidence_elem =
+        kos_dataset.get(kos_tags::current_requested_procedure_evidence_sequence);
+    if (!evidence_elem || !evidence_elem->is_sequence()) {
+        return uids;
+    }
+    for (const auto& study_item : evidence_elem->sequence_items()) {
+        const auto* series_elem =
+            study_item.get(kos_tags::referenced_series_sequence);
+        if (!series_elem || !series_elem->is_sequence()) continue;
+        for (const auto& series_item : series_elem->sequence_items()) {
+            const auto* sop_elem =
+                series_item.get(kos_tags::referenced_sop_sequence);
+            if (!sop_elem || !sop_elem->is_sequence()) continue;
+            for (const auto& sop_item : sop_elem->sequence_items()) {
+                auto uid = sop_item.get_string(kos_tags::referenced_sop_instance_uid);
+                if (!uid.empty()) uids.push_back(std::move(uid));
+            }
+        }
+    }
+    return uids;
+}
+
+}  // namespace
+
 publication_result imaging_document_source::publish_document(
-    [[maybe_unused]] const core::dicom_dataset& kos_dataset,
-    [[maybe_unused]] const xds_document_entry& entry) const {
+    const core::dicom_dataset& kos_dataset,
+    const xds_document_entry& entry,
+    bool is_imaging) const {
 
     publication_result result;
 
+    // Build audit fields once; used for both success and failure paths.
+    auto study_uid = kos_dataset.get_string(core::tags::study_instance_uid);
+    auto patient_id = kos_dataset.get_string(core::tags::patient_id);
+    auto sop_instance_uids = collect_sop_instance_uids(kos_dataset);
+    const auto transaction =
+        is_imaging
+            ? security::atna_service_auditor::xds_source_transaction::rad_68
+            : security::atna_service_auditor::xds_source_transaction::iti_41;
+
     if (config_.registry_url.empty()) {
         result.error_message = "XDS registry URL not configured";
+        if (auditor_) {
+            auditor_->audit_xds_provide_and_register(
+                transaction,
+                config_.source_oid,
+                config_.registry_url,   // empty when unconfigured
+                study_uid,
+                patient_id,
+                sop_instance_uids,
+                false);
+        }
         return result;
     }
 
-    // NOTE: Actual HTTP POST to the XDS registry/repository (ITI-41)
+    // NOTE: Actual HTTP POST to the XDS registry/repository (ITI-41 / RAD-68)
     // would be implemented here using the network layer.
-    // The ITI-41 transaction uses SOAP/MTOM encoding.
+    // The ITI-41 / RAD-68 transactions use SOAP/MTOM encoding.
     // For now, return success to indicate the interface is operational.
     result.success = true;
     result.document_entry_uuid = entry.entry_uuid;
 
+    if (auditor_) {
+        auditor_->audit_xds_provide_and_register(
+            transaction,
+            config_.source_oid,
+            config_.registry_url,
+            study_uid,
+            patient_id,
+            sop_instance_uids,
+            true);
+    }
+
     return result;
+}
+
+void imaging_document_source::set_audit_handler(
+    std::shared_ptr<kcenon::pacs::security::atna_service_auditor> auditor) {
+    auditor_ = std::move(auditor);
 }
 
 const imaging_document_source_config&

--- a/tests/services/xds/xds_imaging_test.cpp
+++ b/tests/services/xds/xds_imaging_test.cpp
@@ -9,8 +9,13 @@
 #include <kcenon/pacs/core/dicom_dataset.h>
 #include <kcenon/pacs/core/dicom_tag_constants.h>
 #include <kcenon/pacs/encoding/vr_type.h>
+#include <kcenon/pacs/security/atna_service_auditor.h>
+#include <kcenon/pacs/security/atna_syslog_transport.h>
 
 #include <catch2/catch_test_macros.hpp>
+
+#include <algorithm>
+#include <memory>
 
 using namespace kcenon::pacs::services::xds;
 using namespace kcenon::pacs::services::sop_classes;
@@ -347,4 +352,232 @@ TEST_CASE("KOS round-trip: create and extract references", "[services][xds][roun
             ref.sop_instance_uid);
         CHECK(it != extract_result.referenced_instance_uids.end());
     }
+}
+
+// ============================================================================
+// ATNA Audit Emission Tests (Issue #1114)
+// ============================================================================
+
+namespace {
+
+/// Captured shape of an XDS audit event emitted by the spy auditor.
+struct captured_xds_audit {
+    enum class kind { provide_and_register, retrieve };
+    kind event_kind{kind::provide_and_register};
+    std::string event_id;           // transaction code (ITI-41/RAD-68/ITI-43/RAD-69)
+    std::string source_participant;
+    std::string destination_participant;
+    std::string study_uid;
+    std::string patient_id;
+    std::vector<std::string> sop_instance_uids;
+    bool success{false};
+};
+
+/// Test spy that captures XDS-I.b audit calls without sending to syslog.
+///
+/// Uses the standard atna_service_auditor constructor with a harmless
+/// transport config, then overrides the virtual audit methods so no
+/// network traffic is produced.
+class xds_audit_spy final : public kcenon::pacs::security::atna_service_auditor {
+public:
+    xds_audit_spy()
+        : atna_service_auditor(
+              kcenon::pacs::security::syslog_transport_config{},
+              "TEST_PACS") {}
+
+    void audit_xds_provide_and_register(
+        xds_source_transaction transaction,
+        const std::string& source_ae,
+        const std::string& dest_ae,
+        const std::string& study_uid,
+        const std::string& patient_id,
+        const std::vector<std::string>& sop_instance_uids,
+        bool success) override {
+        captured_xds_audit c;
+        c.event_kind = captured_xds_audit::kind::provide_and_register;
+        c.event_id = transaction == xds_source_transaction::iti_41
+                         ? "ITI-41"
+                         : "RAD-68";
+        c.source_participant = source_ae;
+        c.destination_participant = dest_ae;
+        c.study_uid = study_uid;
+        c.patient_id = patient_id;
+        c.sop_instance_uids = sop_instance_uids;
+        c.success = success;
+        events.push_back(std::move(c));
+    }
+
+    void audit_xds_retrieve(
+        xds_consumer_transaction transaction,
+        const std::string& source_ae,
+        const std::string& dest_ae,
+        const std::string& study_uid,
+        const std::string& patient_id,
+        const std::vector<std::string>& sop_instance_uids,
+        bool success) override {
+        captured_xds_audit c;
+        c.event_kind = captured_xds_audit::kind::retrieve;
+        c.event_id = transaction == xds_consumer_transaction::iti_43
+                         ? "ITI-43"
+                         : "RAD-69";
+        c.source_participant = source_ae;
+        c.destination_participant = dest_ae;
+        c.study_uid = study_uid;
+        c.patient_id = patient_id;
+        c.sop_instance_uids = sop_instance_uids;
+        c.success = success;
+        events.push_back(std::move(c));
+    }
+
+    std::vector<captured_xds_audit> events;
+};
+
+imaging_document_source make_source_with_registry() {
+    imaging_document_source_config config;
+    config.registry_url = "https://xds.example.com/iti41";
+    config.source_oid = "1.2.3.4.5.6.7.8.9";
+    return imaging_document_source{config};
+}
+
+imaging_document_source make_source_without_registry() {
+    imaging_document_source_config config;
+    config.source_oid = "1.2.3.4.5.6.7.8.9";  // registry_url intentionally empty
+    return imaging_document_source{config};
+}
+
+document_reference make_doc_ref() {
+    document_reference ref;
+    ref.unique_id = "1.2.3.4.5.6.7.200";          // also serves as SOP Instance UID
+    ref.repository_unique_id = "1.2.3.4.5.6.7.99";
+    ref.entry_uuid = "urn:uuid:00000000-0000-0000-0000-000000000001";
+    ref.patient_id = "12345";
+    ref.class_code = "IMG";
+    ref.type_code = "KOS";
+    return ref;
+}
+
+}  // namespace
+
+TEST_CASE("ATNA audit emitted for ITI-41 provide-and-register (success)",
+          "[services][xds][atna]") {
+    auto spy = std::make_shared<xds_audit_spy>();
+    auto source = make_source_with_registry();
+    source.set_audit_handler(spy);
+
+    auto references = create_sample_references();
+    auto patient = create_patient_demographics();
+    auto kos_result = source.create_kos_document(
+        "1.2.3.4.5.6.7.200", references, patient);
+    REQUIRE(kos_result.success);
+
+    auto entry = source.build_document_entry(kos_result.kos_dataset.value());
+    auto pub_result = source.publish_document(
+        kos_result.kos_dataset.value(), entry, /*is_imaging=*/false);
+
+    REQUIRE(pub_result.success);
+    REQUIRE(spy->events.size() == 1);
+
+    const auto& ev = spy->events.front();
+    CHECK(ev.event_kind == captured_xds_audit::kind::provide_and_register);
+    CHECK(ev.event_id == "ITI-41");
+    CHECK_FALSE(ev.source_participant.empty());
+    CHECK_FALSE(ev.destination_participant.empty());
+    CHECK(ev.study_uid == "1.2.3.4.5.6.7.200");
+    CHECK(ev.patient_id == "12345");
+    CHECK_FALSE(ev.sop_instance_uids.empty());
+    CHECK(ev.success);
+}
+
+TEST_CASE("ATNA audit emitted for RAD-68 provide-and-register (failure path)",
+          "[services][xds][atna]") {
+    auto spy = std::make_shared<xds_audit_spy>();
+    auto source = make_source_without_registry();  // forces failure
+    source.set_audit_handler(spy);
+
+    auto references = create_sample_references();
+    auto patient = create_patient_demographics();
+    auto kos_result = source.create_kos_document(
+        "1.2.3.4.5.6.7.200", references, patient);
+    REQUIRE(kos_result.success);
+
+    auto entry = source.build_document_entry(kos_result.kos_dataset.value());
+    auto pub_result = source.publish_document(
+        kos_result.kos_dataset.value(), entry, /*is_imaging=*/true);
+
+    CHECK_FALSE(pub_result.success);
+    REQUIRE(spy->events.size() == 1);
+
+    const auto& ev = spy->events.front();
+    CHECK(ev.event_kind == captured_xds_audit::kind::provide_and_register);
+    CHECK(ev.event_id == "RAD-68");
+    CHECK_FALSE(ev.source_participant.empty());
+    CHECK(ev.study_uid == "1.2.3.4.5.6.7.200");
+    CHECK(ev.patient_id == "12345");
+    // RAD-68 must carry SOP Instance UIDs from the KOS evidence sequence
+    CHECK(ev.sop_instance_uids.size() == 3);
+    CHECK_FALSE(ev.success);
+}
+
+TEST_CASE("ATNA audit emitted for ITI-43 retrieve document set (success)",
+          "[services][xds][atna]") {
+    auto spy = std::make_shared<xds_audit_spy>();
+    imaging_document_consumer_config config;
+    config.repository_url = "https://xds.example.com/iti43";
+    imaging_document_consumer consumer{config};
+    consumer.set_audit_handler(spy);
+
+    auto result = consumer.retrieve_document(make_doc_ref(), /*is_imaging=*/false);
+
+    CHECK(result.success);
+    REQUIRE(spy->events.size() == 1);
+
+    const auto& ev = spy->events.front();
+    CHECK(ev.event_kind == captured_xds_audit::kind::retrieve);
+    CHECK(ev.event_id == "ITI-43");
+    CHECK_FALSE(ev.source_participant.empty());
+    CHECK_FALSE(ev.destination_participant.empty());
+    CHECK(ev.study_uid == "1.2.3.4.5.6.7.200");
+    CHECK(ev.patient_id == "12345");
+    CHECK_FALSE(ev.sop_instance_uids.empty());
+    CHECK(ev.success);
+}
+
+TEST_CASE("ATNA audit emitted for RAD-69 retrieve imaging document set (failure)",
+          "[services][xds][atna]") {
+    auto spy = std::make_shared<xds_audit_spy>();
+    imaging_document_consumer consumer;  // no repository_url configured
+    consumer.set_audit_handler(spy);
+
+    auto result = consumer.retrieve_document(make_doc_ref(), /*is_imaging=*/true);
+
+    CHECK_FALSE(result.success);
+    REQUIRE(spy->events.size() == 1);
+
+    const auto& ev = spy->events.front();
+    CHECK(ev.event_kind == captured_xds_audit::kind::retrieve);
+    CHECK(ev.event_id == "RAD-69");
+    CHECK_FALSE(ev.source_participant.empty());
+    CHECK(ev.study_uid == "1.2.3.4.5.6.7.200");
+    CHECK(ev.patient_id == "12345");
+    CHECK_FALSE(ev.sop_instance_uids.empty());
+    CHECK_FALSE(ev.success);
+}
+
+TEST_CASE("no audit emitted when audit handler is not installed",
+          "[services][xds][atna]") {
+    // Source without auditor: should not crash, no events captured.
+    auto source = make_source_with_registry();
+    auto references = create_sample_references();
+    auto patient = create_patient_demographics();
+    auto kos_result = source.create_kos_document(
+        "1.2.3.4.5.6.7.200", references, patient);
+    REQUIRE(kos_result.success);
+    auto entry = source.build_document_entry(kos_result.kos_dataset.value());
+    CHECK(source.publish_document(kos_result.kos_dataset.value(), entry).success);
+
+    // Consumer without auditor: should not crash either.
+    imaging_document_consumer_config cc;
+    cc.repository_url = "https://xds.example.com/iti43";
+    imaging_document_consumer consumer{cc};
+    CHECK(consumer.retrieve_document(make_doc_ref()).success);
 }


### PR DESCRIPTION
Closes #1114

Part of #1101 (IHE XDS.b v1.0 readiness).

## Summary
- ITI-41 / RAD-68 (Source): emit ATNA on success + failure
- ITI-43 / RAD-69 (Consumer): emit ATNA on success + failure
- Uses existing `atna_service_auditor` from `src/security/`
- Added fixture in `tests/services/xds/xds_imaging_test.cpp` that captures 4 message shapes

## Changes
- `atna_service_auditor`: add `audit_xds_provide_and_register` and `audit_xds_retrieve` helpers. Audit methods are virtual to enable test spies; destructor is virtual.
- `imaging_document_source`: `set_audit_handler` + audit emission on success and failure of `publish_document()`. `is_imaging` flag distinguishes ITI-41 from RAD-68.
- `imaging_document_consumer`: `set_audit_handler` + audit emission on success and failure of `retrieve_document()`. `is_imaging` flag distinguishes ITI-43 from RAD-69.
- Event ID carries the transaction code (ITI-41/RAD-68/ITI-43/RAD-69) as an ATNA event type code; Source/Destination participants, Study UID, and SOP Instance UIDs are included per transaction.

## Test Plan
- Catch2 cases verify Event ID, Source/Destination participant, and SOP Instance / Study UID presence for each transaction
- Both success and failure paths covered (RAD-68 and RAD-69 cases exercise failure)
- Additional test verifies no-handler path is safe
- Local build: skipped (toolchain unavailable in environment)