### PR TITLE
docs(api): tighten Doxygen warn-count FLOOR to 40

### DIFF
--- a/.github/workflows/doxygen-warn-count.yml
+++ b/.github/workflows/doxygen-warn-count.yml
@@ -2,9 +2,10 @@ name: Doxygen Warning Count
 
 # Counts Doxygen warnings on every PR so the API-reference quality is
 # visible in review. Fails the job if the count regresses above the
-# current baseline (> 160) so we ratchet down as gaps are filled. The
+# current regression floor so we ratchet down as gaps are filled. The
 # strict <5 target from #1103 will be enforced in a follow-up PR once
-# the annotation gaps in include/kcenon/pacs/** are closed.
+# the remaining structural issues (ai_service_connector.cpp pimpl docs
+# and annotation_repository overload disambiguation) are cleaned up.
 
 on:
   push:
@@ -55,7 +56,7 @@ jobs:
             echo '```'
             echo ""
             echo "### Targets"
-            echo "- Current regression floor (this workflow): **500**"
+            echo "- Current regression floor (this workflow): **40**"
             echo "- Issue #1103 eventual target: **< 5** — tracked for a follow-up PR"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -72,7 +73,7 @@ jobs:
       - name: Enforce regression floor
         run: |
           COUNT=${{ steps.run.outputs.count }}
-          FLOOR=160
+          FLOOR=40
           if [ "$COUNT" -gt "$FLOOR" ]; then
             echo "::error::Doxygen warning count ($COUNT) exceeds regression floor ($FLOOR)."
             echo "Inspect the uploaded doxygen-warnings artifact and address the new warnings"

--- a/Doxyfile
+++ b/Doxyfile
@@ -114,7 +114,6 @@ WARN_LOGFILE           =
 #---------------------------------------------------------------------------
 INPUT                  = ./include \
                          ./src \
-                         ./README.md \
                          ./docs/mainpage.dox \
                          ./docs/groups.dox \
                          ./docs/tutorial_dicom_basics.dox \
@@ -149,7 +148,8 @@ EXCLUDE_PATTERNS       = */CMakeFiles/* \
                          */_deps/* \
                          */node_modules/* \
                          */build/* \
-                         */build_simple/*
+                         */build_simple/* \
+                         */integration_tests/README.md
 EXCLUDE_SYMBOLS        =
 EXAMPLE_PATH           = ./examples
 EXAMPLE_PATTERNS       = *.cpp \
@@ -194,7 +194,8 @@ HTML_EXTRA_FILES       = docs/doxygen-awesome-css/doxygen-awesome-darkmode-toggl
                          docs/doxygen-awesome-css/doxygen-awesome-fragment-copy-button.js \
                          docs/doxygen-awesome-css/doxygen-awesome-paragraph-link.js \
                          docs/doxygen-awesome-css/doxygen-awesome-interactive-toc.js
-HTML_COPY_CLIPBOARD    = NO
+# HTML_COPY_CLIPBOARD is not supported by all Doxygen versions; copy-to-clipboard
+# is provided instead via doxygen-awesome-fragment-copy-button.js in header.html.
 HTML_COLORSTYLE        = LIGHT
 HTML_COLORSTYLE_HUE    = 220
 HTML_COLORSTYLE_SAT    = 100
@@ -311,7 +312,7 @@ GRAPHICAL_HIERARCHY    = YES
 DIRECTORY_GRAPH        = YES
 DOT_IMAGE_FORMAT       = png
 INTERACTIVE_SVG        = NO
-DOT_GRAPH_MAX_NODES    = 50
+DOT_GRAPH_MAX_NODES    = 300
 MAX_DOT_GRAPH_DEPTH    = 0
 DOT_MULTI_TARGETS      = NO
 GENERATE_LEGEND        = YES

--- a/docs/header.html
+++ b/docs/header.html
@@ -8,18 +8,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
 <!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
-<!--BEGIN PROJECT_ICON-->
-<link rel="icon" href="$relpath^$projecticon" type="image/x-icon" />
-<!--END PROJECT_ICON-->
 <link href="$relpath^tabs.css" rel="stylesheet" type="text/css"/>
 <!--BEGIN FULL_SIDEBAR-->
 <script type="text/javascript">var page_layout=1;</script>
 <!--END FULL_SIDEBAR-->
 <script type="text/javascript" src="$relpath^jquery.js"></script>
 <script type="text/javascript" src="$relpath^dynsections.js"></script>
-<!--BEGIN COPY_CLIPBOARD-->
-<script type="text/javascript" src="$relpath^clipboard.js"></script>
-<!--END COPY_CLIPBOARD-->
 $treeview
 $search
 $mathjax

--- a/docs/mainpage.dox
+++ b/docs/mainpage.dox
@@ -193,16 +193,16 @@ target_link_libraries(your_target PRIVATE kcenon::pacs_core)
 
 | Example | Source | Description |
 |---------|--------|-------------|
-| dcm_extract | @ref dcm_extract | Extract pixel data from DICOM files to JPEG, PNG, or raw binary |
-| dcm_conv | @ref dcm_conv | Convert DICOM files between transfer syntaxes |
-| img_to_dcm | @ref img_to_dcm | Encapsulate standard images (JPEG, PNG) into DICOM Part 10 files |
-| query_scu | @ref query_scu | Query a PACS server using C-FIND at Patient/Study/Series level |
-| dcm_dump | @ref dcm_dump | Dump DICOM file metadata as human-readable text |
-| dcm_info | @ref dcm_info | Display summary information for a DICOM file |
-| echo_scu | @ref echo_scu | Verify DICOM association with C-ECHO |
-| store_scu | @ref store_scu | Send DICOM files to a PACS server via C-STORE |
-| find_scu | @ref find_scu | Query remote PACS with C-FIND |
-| pacs_server | @ref pacs_server | Full PACS server with SCP services |
+| dcm_extract | `examples/dcm_extract/main.cpp` | Extract pixel data from DICOM files to JPEG, PNG, or raw binary |
+| dcm_conv | `examples/dcm_conv/main.cpp` | Convert DICOM files between transfer syntaxes |
+| img_to_dcm | `examples/img_to_dcm/main.cpp` | Encapsulate standard images (JPEG, PNG) into DICOM Part 10 files |
+| query_scu | `examples/query_scu/main.cpp` | Query a PACS server using C-FIND at Patient/Study/Series level |
+| dcm_dump | `examples/dcm_dump/main.cpp` | Dump DICOM file metadata as human-readable text |
+| dcm_info | `examples/dcm_info/main.cpp` | Display summary information for a DICOM file |
+| echo_scu | `examples/echo_scu/main.cpp` | Verify DICOM association with C-ECHO |
+| store_scu | `examples/store_scu/main.cpp` | Send DICOM files to a PACS server via C-STORE |
+| find_scu | `examples/find_scu/main.cpp` | Query remote PACS with C-FIND |
+| pacs_server | `examples/pacs_server/main.cpp` | Full PACS server with SCP services |
 
 @section learning_resources Learning Resources
 

--- a/examples/db_browser/main.cpp
+++ b/examples/db_browser/main.cpp
@@ -8,6 +8,7 @@
  *
  * @see Issue #109 - Database Browser Sample
  *
+ * @code{.unparsed}
  * Usage:
  *   db_browser <database> <command> [options]
  *
@@ -16,6 +17,7 @@
  *   db_browser pacs.db studies --patient-id "12345"
  *   db_browser pacs.db stats
  *   db_browser pacs.db vacuum
+ * @endcode
  */
 
 #include "kcenon/pacs/storage/index_database.h"

--- a/examples/dcm_anonymize/main.cpp
+++ b/examples/dcm_anonymize/main.cpp
@@ -10,6 +10,7 @@
  * @see Issue #284 - dcm_anonymize: Implement DICOM anonymization utility
  * @see DICOM PS3.15 Annex E - Attribute Confidentiality Profiles
  *
+ * @code{.unparsed}
  * Usage:
  *   dcm_anonymize [options] <input> [output]
  *
@@ -17,6 +18,7 @@
  *   dcm_anonymize patient.dcm anonymous.dcm
  *   dcm_anonymize --profile hipaa_safe_harbor patient.dcm anonymized.dcm
  *   dcm_anonymize --recursive -o anonymized/ ./originals/
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dictionary.h"

--- a/examples/dcm_conv/main.cpp
+++ b/examples/dcm_conv/main.cpp
@@ -9,6 +9,7 @@
  * @see Issue #280 - dcm_conv: Transfer Syntax conversion utility
  * @see DICOM PS3.5 Section 10 - Transfer Syntax
  *
+ * @code{.unparsed}
  * Usage:
  *   dcm_conv <input> <output> [options]
  *
@@ -16,6 +17,7 @@
  *   dcm_conv image.dcm converted.dcm --explicit
  *   dcm_conv image.dcm compressed.dcm --jpeg-baseline -q 90
  *   dcm_conv ./input_dir/ ./output_dir/ --recursive --implicit
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_file.h"

--- a/examples/dcm_dir/main.cpp
+++ b/examples/dcm_dir/main.cpp
@@ -10,6 +10,7 @@
  * @see DICOM PS3.3 - Basic Directory Information Object Definition
  * @see DICOM PS3.10 - Media Storage and File Format
  *
+ * @code{.unparsed}
  * Usage:
  *   dcm_dir <command> [options] <arguments>
  *
@@ -18,6 +19,7 @@
  *   list      Display DICOMDIR contents
  *   verify    Validate DICOMDIR
  *   update    Update existing DICOMDIR (add/remove files)
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dictionary.h"

--- a/examples/dcm_dump/main.cpp
+++ b/examples/dcm_dump/main.cpp
@@ -9,6 +9,7 @@
  * @see Issue #107 - DICOM Dump Sample
  * @see DICOM PS3.10 - Media Storage and File Format
  *
+ * @code{.unparsed}
  * Usage:
  *   dcm_dump <path> [options]
  *
@@ -18,6 +19,7 @@
  *   dcm_dump image.dcm --pixel-info
  *   dcm_dump image.dcm --format json
  *   dcm_dump ./dicom_folder/ --recursive --summary
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dictionary.h"

--- a/examples/dcm_extract/main.cpp
+++ b/examples/dcm_extract/main.cpp
@@ -9,6 +9,7 @@
  * @see Issue #387 - dcm_extract: DICOM pixel data extractor
  * @see DICOM PS3.5 Section 8 - Pixel Data Encoding
  *
+ * @code{.unparsed}
  * Usage:
  *   dcm_extract <input> [output] [options]
  *
@@ -17,6 +18,7 @@
  *   dcm_extract image.dcm output.jpg --jpeg   # Extract to JPEG
  *   dcm_extract image.dcm --info              # Show pixel data info only
  *   dcm_extract ./dicom/ ./images/ --recursive --jpeg
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/dcm_info/main.cpp
+++ b/examples/dcm_info/main.cpp
@@ -10,6 +10,7 @@
  * @see Parent Issue #278 - DICOM File Utilities Implementation
  * @see DICOM PS3.10 - Media Storage and File Format
  *
+ * @code{.unparsed}
  * Usage:
  *   dcm_info <path> [options]
  *
@@ -17,6 +18,7 @@
  *   dcm_info image.dcm
  *   dcm_info image.dcm --format json
  *   dcm_info ./dicom_folder/ --recursive
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_file.h"

--- a/examples/echo_scp/main.cpp
+++ b/examples/echo_scp/main.cpp
@@ -9,11 +9,13 @@
  * @see Issue #99 - Echo SCU/SCP Sample
  * @see DICOM PS3.7 Section 9.1 - C-ECHO Service
  *
+ * @code{.unparsed}
  * Usage:
  *   echo_scp <port> <ae_title>
  *
  * Example:
  *   echo_scp 11112 MY_PACS
+ * @endcode
  */
 
 #include "kcenon/pacs/network/dicom_server.h"

--- a/examples/echo_scu/main.cpp
+++ b/examples/echo_scu/main.cpp
@@ -12,6 +12,7 @@
  * @see DICOM PS3.7 Section 9.1 - C-ECHO Service
  * @see https://support.dcmtk.org/docs/echoscu.html
  *
+ * @code{.unparsed}
  * Usage:
  *   echo_scu [options] <peer> <port>
  *
@@ -19,6 +20,7 @@
  *   echo_scu localhost 11112
  *   echo_scu -aet MYSCU -aec PACS localhost 11112
  *   echo_scu --repeat 10 --repeat-delay 1000 localhost 11112
+ * @endcode
  */
 
 #include "kcenon/pacs/network/association.h"

--- a/examples/find_scu/main.cpp
+++ b/examples/find_scu/main.cpp
@@ -13,12 +13,14 @@
  * @see DICOM PS3.7 Section 9.1.2 - C-FIND Service
  * @see https://support.dcmtk.org/docs/findscu.html
  *
+ * @code{.unparsed}
  * Usage:
  *   find_scu [options] <peer> <port>
  *
  * Example:
  *   find_scu -P -L STUDY -k "0010,0010=Smith*" localhost 11112
  *   find_scu -S -k "0008,0060=CT" -k "0008,0020=20240101-20241231" pacs.example.com 104
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/get_scu/main.cpp
+++ b/examples/get_scu/main.cpp
@@ -13,11 +13,13 @@
  * @see DICOM PS3.7 Section 9.1.4 - C-GET Service
  * @see https://support.dcmtk.org/docs/getscu.html
  *
+ * @code{.unparsed}
  * Usage:
  *   get_scu [options] <peer> <port>
  *
  * Example:
  *   get_scu -L STUDY -k "0020,000D=1.2.840..." -od ./downloads localhost 11112
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/img_to_dcm/main.cpp
+++ b/examples/img_to_dcm/main.cpp
@@ -9,6 +9,7 @@
  * @see Issue #386 - img_to_dcm: Image to DICOM converter
  * @see DICOM PS3.3 Section A.8 - Secondary Capture Image IOD
  *
+ * @code{.unparsed}
  * Usage:
  *   img_to_dcm <input> <output> [options]
  *
@@ -16,6 +17,7 @@
  *   img_to_dcm photo.jpg output.dcm
  *   img_to_dcm photo.jpg output.dcm --patient-name "DOE^JOHN"
  *   img_to_dcm ./images/ ./dicom/ --recursive
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/integration_tests/test_fixtures.h
+++ b/examples/integration_tests/test_fixtures.h
@@ -143,7 +143,8 @@ inline std::chrono::milliseconds dcmtk_server_ready_timeout() {
  *       this function returns false.
  *
  * @see accept_worker.cpp - "association doesn't support real network I/O yet"
- * @see Issue #XXX - Real TCP DICOM connection support (TODO: create issue)
+ * @note Real TCP DICOM connection support is tracked as a separate issue
+ *       (TODO: create issue for real TCP DICOM connection).
  */
 inline bool supports_real_tcp_dicom() {
     // Currently, pacs_system does not support real TCP connections

--- a/examples/move_scu/main.cpp
+++ b/examples/move_scu/main.cpp
@@ -13,11 +13,13 @@
  * @see DICOM PS3.7 Section 9.1.3 - C-MOVE Service
  * @see https://support.dcmtk.org/docs/movescu.html
  *
+ * @code{.unparsed}
  * Usage:
  *   move_scu [options] <peer> <port>
  *
  * Example:
  *   move_scu -aem WORKSTATION -L STUDY -k "0020,000D=1.2.840..." localhost 11112
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/mpps_scp/main.cpp
+++ b/examples/mpps_scp/main.cpp
@@ -10,12 +10,14 @@
  * @see DICOM PS3.4 Section F - MPPS SOP Class
  * @see DICOM PS3.7 Section 10 - DIMSE-N Services
  *
+ * @code{.unparsed}
  * Usage:
  *   mpps_scp <port> <ae_title> [options]
  *
  * Examples:
  *   mpps_scp 11112 MY_MPPS --output-dir ./mpps_records
  *   mpps_scp 11112 MY_MPPS --output-file ./mpps.json
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/mpps_scu/main.cpp
+++ b/examples/mpps_scu/main.cpp
@@ -10,6 +10,7 @@
  * @see DICOM PS3.4 Section F - MPPS SOP Class
  * @see DICOM PS3.7 Section 10 - DIMSE-N Services
  *
+ * @code{.unparsed}
  * Usage:
  *   mpps_scu <host> <port> <called_ae> <command> [options]
  *
@@ -20,6 +21,7 @@
  * Examples:
  *   mpps_scu localhost 11112 RIS_SCP create --patient-id P001 --modality CT
  *   mpps_scu localhost 11112 RIS_SCP set --mpps-uid 1.2.3... --status COMPLETED
+ * @endcode
  */
 
 #include "kcenon/pacs/services/mpps_scu.h"

--- a/examples/pacs_server/config.h
+++ b/examples/pacs_server/config.h
@@ -107,6 +107,7 @@ struct pacs_server_config {
      * @brief Parse configuration from command line arguments
      *
      * Supported options:
+     * @code{.unparsed}
      *   --port <port>           Port to listen on (default: 11112)
      *   --ae-title <title>      AE title (default: MY_PACS)
      *   --storage-dir <path>    Storage directory (default: ./archive)
@@ -114,6 +115,7 @@ struct pacs_server_config {
      *   --log-level <level>     Log level (default: info)
      *   --max-associations <n>  Max concurrent associations (default: 50)
      *   --help                  Show help message
+     * @endcode
      *
      * @param argc Argument count
      * @param argv Argument vector

--- a/examples/pacs_server/main.cpp
+++ b/examples/pacs_server/main.cpp
@@ -8,6 +8,7 @@
  *
  * @see Issue #106 - Full PACS Server Sample
  *
+ * @code{.unparsed}
  * Usage:
  *   pacs_server [OPTIONS]
  *
@@ -19,6 +20,7 @@
  *   --log-level <level>     Log level (default: info)
  *   --max-associations <n>  Max concurrent associations (default: 50)
  *   --help                  Show help message
+ * @endcode
  */
 
 #include "config.h"

--- a/examples/print_scu/main.cpp
+++ b/examples/print_scu/main.cpp
@@ -10,6 +10,7 @@
  * @see DICOM PS3.4 Annex H - Print Management Service Class
  * @see DICOM PS3.7 Section 10 - DIMSE-N Services
  *
+ * @code{.unparsed}
  * Usage:
  *   print_scu <host> <port> <called_ae> <command> [options]
  *
@@ -20,6 +21,7 @@
  * Examples:
  *   print_scu localhost 10400 PRINTER print --copies 1 --priority HIGH
  *   print_scu localhost 10400 PRINTER status
+ * @endcode
  */
 
 #include "kcenon/pacs/services/print_scu.h"

--- a/examples/qr_scp/main.cpp
+++ b/examples/qr_scp/main.cpp
@@ -9,12 +9,14 @@
  * @see Issue #380 - qr_scp: Implement Query/Retrieve SCP utility
  * @see DICOM PS3.4 Section C - Query/Retrieve Service Class
  *
+ * @code{.unparsed}
  * Usage:
  *   qr_scp <port> <ae_title> --storage-dir <path> [options]
  *
  * Examples:
  *   qr_scp 11112 MY_PACS --storage-dir ./dicom --index-db ./pacs.db
  *   qr_scp 11112 MY_PACS --storage-dir ./dicom --peer VIEWER:192.168.1.10:11113
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/query_scu/main.cpp
+++ b/examples/query_scu/main.cpp
@@ -11,11 +11,13 @@
  * @see DICOM PS3.4 Section C - Query/Retrieve Service Class
  * @see DICOM PS3.7 Section 9.1.2 - C-FIND Service
  *
+ * @code{.unparsed}
  * Usage:
  *   query_scu <host> <port> <called_ae> [options]
  *
  * Example:
  *   query_scu localhost 11112 PACS_SCP --level STUDY --patient-name "DOE^*"
+ * @endcode
  */
 
 #include "query_builder.h"

--- a/examples/retrieve_scu/main.cpp
+++ b/examples/retrieve_scu/main.cpp
@@ -11,11 +11,13 @@
  * @see DICOM PS3.7 Section 9.1.3 - C-MOVE Service
  * @see DICOM PS3.7 Section 9.1.4 - C-GET Service
  *
+ * @code{.unparsed}
  * Usage:
  *   retrieve_scu <host> <port> <called_ae> [options]
  *
  * Example:
  *   retrieve_scu localhost 11112 PACS_SCP --mode get --study-uid "1.2.3.4.5"
+ * @endcode
  */
 
 #include "kcenon/pacs/network/association.h"

--- a/examples/secure_dicom/secure_echo_scp.cpp
+++ b/examples/secure_dicom/secure_echo_scp.cpp
@@ -11,11 +11,13 @@
  * @see DICOM PS3.15 - Security and System Management Profiles
  * @see DICOM PS3.7 Section 9.1 - C-ECHO Service
  *
+ * @code{.unparsed}
  * Usage:
  *   secure_echo_scp <port> <ae_title> --cert <cert> --key <key> [options]
  *
  * Example:
  *   secure_echo_scp 2762 MY_PACS --cert server.crt --key server.key --ca ca.crt
+ * @endcode
  */
 
 #include "kcenon/pacs/network/dicom_server.h"

--- a/examples/secure_dicom/secure_echo_scu.cpp
+++ b/examples/secure_dicom/secure_echo_scu.cpp
@@ -11,11 +11,13 @@
  * @see DICOM PS3.15 - Security and System Management Profiles
  * @see DICOM PS3.7 Section 9.1 - C-ECHO Service
  *
+ * @code{.unparsed}
  * Usage:
  *   secure_echo_scu <host> <port> <called_ae> --cert <cert> --key <key> [options]
  *
  * Example:
  *   secure_echo_scu localhost 2762 PACS_SCP --cert client.crt --key client.key --ca ca.crt
+ * @endcode
  */
 
 #include "kcenon/pacs/network/association.h"

--- a/examples/store_scp/main.cpp
+++ b/examples/store_scp/main.cpp
@@ -9,6 +9,7 @@
  * @see Issue #101 - Storage SCP Sample
  * @see DICOM PS3.4 Section B - Storage Service Class
  *
+ * @code{.unparsed}
  * Usage:
  *   store_scp <port> <ae_title> [options]
  *
@@ -16,6 +17,7 @@
  *   store_scp 11112 MY_PACS --storage-dir ./received
  *   store_scp 11112 MY_PACS --storage-dir ./received --index-db ./pacs.db
  *   store_scp 11112 MY_PACS --storage-dir ./received --accept "CT,MR,US"
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/store_scu/main.cpp
+++ b/examples/store_scu/main.cpp
@@ -13,6 +13,7 @@
  * @see DICOM PS3.7 Section 9.1.1 - C-STORE Service
  * @see https://support.dcmtk.org/docs/storescu.html
  *
+ * @code{.unparsed}
  * Usage:
  *   store_scu [options] <peer> <port> <dcmfile-in> [dcmfile-in...]
  *
@@ -20,6 +21,7 @@
  *   store_scu localhost 11112 image.dcm
  *   store_scu -aet MYSCU -aec PACS localhost 11112 ./dicom_folder/ -r
  *   store_scu --progress --report-file transfer.log localhost 11112 *.dcm
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_file.h"

--- a/examples/worklist_scp/main.cpp
+++ b/examples/worklist_scp/main.cpp
@@ -9,12 +9,14 @@
  * @see Issue #381 - worklist_scp: Implement Modality Worklist SCP utility
  * @see DICOM PS3.4 Section K - Basic Worklist Management Service Class
  *
+ * @code{.unparsed}
  * Usage:
  *   worklist_scp <port> <ae_title> --worklist-file <path> [options]
  *
  * Examples:
  *   worklist_scp 11112 MY_WORKLIST --worklist-file ./worklist.json
  *   worklist_scp 11112 MY_WORKLIST --worklist-dir ./worklist_data
+ * @endcode
  */
 
 #include "kcenon/pacs/core/dicom_dataset.h"

--- a/examples/worklist_scu/main.cpp
+++ b/examples/worklist_scu/main.cpp
@@ -16,11 +16,13 @@
  * @see DICOM PS3.4 Section K - Basic Worklist Management Service Class
  * @see DICOM PS3.7 Section 9.1.2 - C-FIND Service
  *
+ * @code{.unparsed}
  * Usage:
  *   worklist_scu [options] <host> <port>
  *
  * Example:
  *   worklist_scu --modality CT --date 20241215 localhost 11112
+ * @endcode
  */
 
 #include "worklist_result_formatter.h"


### PR DESCRIPTION
Closes #1118

## Summary
- Wrapped CLI `Usage:` / `Options:` comment blocks in 28 example files under `examples/` with `@code{.unparsed}` ... `@endcode` to stop Doxygen parsing `<port>`, `<host>`, `<path>`, `<title>`, `<input>`, `<output>`, `<command>`, `<arguments>`, `<called_ae>`, `<ae_title>`, `<level>`, `<n>` etc. as unsupported XML tags (71 warnings).
- Removed `README.md` from `Doxyfile` `INPUT` — its markdown anchors (`[Project Status](#project-status)`, etc.) and doc-folder links were all emitting `unable to resolve reference` \ref warnings (38 warnings). `docs/mainpage.dox` already serves as the landing page, so no reader-facing content is lost.
- Excluded `examples/integration_tests/README.md` via `EXCLUDE_PATTERNS` (same markdown-ref issue, 2 warnings).
- Bumped `DOT_GRAPH_MAX_NODES` from 50 to 300 to let Doxygen render the caller/included-by graphs Doxygen was skipping with "too many nodes" (10 warnings).
- Dropped stale `PROJECT_ICON` / `COPY_CLIPBOARD` template markers from `docs/header.html` and commented out the `HTML_COPY_CLIPBOARD` setting that this Doxygen rejects as an unsupported tag (5 warnings).
- Replaced 8 unresolvable `@ref <example-name>` links in `docs/mainpage.dox` with explicit source paths.
- Cleaned up a single `#XXX` placeholder in `examples/integration_tests/test_fixtures.h` (1 warning).

Lowered FLOOR in `.github/workflows/doxygen-warn-count.yml` from 160 to 40.

## Test Plan
- CI `Doxygen warning count` job verifies count ≤ FLOOR (40).
- Local measurement not possible in this environment (doxygen not installed in sandbox); based on artifact analysis of the previous develop-branch run (152 baseline, categorised by grep), the edits are projected to clear ~130 warnings. Remaining ~20 warnings are structural issues in `src/ai/ai_service_connector.cpp` (pimpl forwarding-method docstrings) and `src/storage/annotation_repository.cpp` (count() overload resolution against 8 sibling `*_repository::count()` candidates) that are better addressed by reworking the source-side doc comments in a follow-up PR.
- The FLOOR of 40 leaves a ~20-warning safety margin on top of the projected achieved count; if CI reports a lower number, a follow-up can tighten further toward the #1103 goal of <5.

## Files Touched
- `examples/**/*.{cpp,h}` (28 files) — @code blocks around Usage: sections
- `Doxyfile` — INPUT, EXCLUDE_PATTERNS, DOT_GRAPH_MAX_NODES, HTML_COPY_CLIPBOARD
- `docs/mainpage.dox` — \ref link cleanup
- `docs/header.html` — remove unused template markers
- `.github/workflows/doxygen-warn-count.yml` — FLOOR 160 → 40

Relates to #1103.