### PR TITLE
docs(compliance): add ISO 27799 control mapping and README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 - [Documentation](#documentation)
 - [Performance](#performance)
 - [Code Statistics](#code-statistics)
+- [Compliance](#compliance)
 - [Contributing](#contributing)
 - [License](#license)
 - [Contact](#contact)
@@ -548,6 +549,17 @@ cmake --build build --target run_full_benchmarks
 | **Last Updated** | 2026-04-09 |
 
 <!-- STATS_END -->
+
+---
+
+## Compliance
+
+`pacs_system` provides technical primitives that healthcare organizations may use as part of an Information Security Management System (ISMS). The library is not itself certified; adopters integrate it and supply the organizational controls (policy, training, incident response, business-continuity planning).
+
+- [ISO 27799 Control Mapping](docs/compliance/iso-27799.md) — how ATNA audit trail, audit log encryption, TLS policy, access control, and anonymization map to ISO 27799:2016 clauses 7.4–7.7
+- [DICOM Conformance Statement](docs/DICOM_CONFORMANCE_STATEMENT.md) — ISO 12052 / DICOM 2023e services, SOP classes, and transfer syntaxes implemented
+
+The ecosystem-level index at [common_system / ISO Standards Overview](https://github.com/kcenon/common_system/blob/develop/docs/compliance/ISO_OVERVIEW.md) lists all ISO standards the kcenon systems touch.
 
 ---
 

--- a/docs/compliance/iso-27799.md
+++ b/docs/compliance/iso-27799.md
@@ -1,0 +1,153 @@
+---
+doc_id: "PACS-COMP-001"
+doc_title: "ISO 27799 Control Mapping"
+doc_version: "1.0.0"
+doc_date: "2026-04-21"
+doc_status: "Released"
+project: "pacs_system"
+category: "Compliance"
+---
+
+# ISO 27799 Control Mapping
+
+> **Language:** **English**
+
+**Standard**: ISO 27799:2016 — Health informatics — Information security management in health using ISO/IEC 27002
+**Scope**: How `pacs_system` features support healthcare organizations aligning their PACS operations with ISO 27799. The library is not itself certified; adopters integrate it into their ISMS and supply the organizational controls.
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Applicability](#applicability)
+- [Control Mapping](#control-mapping)
+  - [Clause 7.4 — Operations security](#clause-74--operations-security)
+  - [Clause 7.5 — Incident management](#clause-75--incident-management)
+  - [Clause 7.6 — Business continuity](#clause-76--business-continuity)
+  - [Clause 7.7 — Compliance](#clause-77--compliance)
+- [DICOM and ISO 12052 cross-reference](#dicom-and-iso-12052-cross-reference)
+- [Configuration Checklist](#configuration-checklist)
+- [Evidence Collection](#evidence-collection)
+- [Related Standards](#related-standards)
+- [References](#references)
+
+## Overview
+
+ISO 27799 adapts the ISO/IEC 27002 control set to the healthcare domain. Relative to a generic PACS, the additional emphasis is on:
+
+- **Protected Health Information (PHI)** confidentiality throughout transmission, storage, and disposal.
+- **Tamper-evident audit trails** for every access to a patient record.
+- **Cross-system interoperability** (DICOM, HL7, IHE profiles) as a compliance obligation rather than a feature choice.
+- **Continuity of clinical operations** under degraded or attacked conditions.
+
+`pacs_system` supplies primitives that map to each of these obligations, listed below.
+
+| Feature area | ISO 27799 clause | Notes |
+|--------------|------------------|-------|
+| ATNA audit trail (`atna_audit_logger`, `atna_syslog_transport`) | 7.5 | IHE Audit Trail and Node Authentication profile; remote syslog supported. |
+| Audit log cipher (`audit_log_cipher`) | 7.4.4, 7.5 | At-rest encryption of audit log files (delivered by [#1102](https://github.com/kcenon/pacs_system/issues/1102)). |
+| TLS policy (`tls_policy`) | 7.4.4 | Cryptographic policy for DICOM associations and HTTP endpoints. |
+| Digital signatures (`digital_signature`) | 7.4.4 | Detached/embedded signatures for image objects where the workflow requires it. |
+| Access control (`access_control_manager`) | 7.4.2 | Role-based access over DIMSE and DICOMweb entry points. |
+| Anonymization (`anonymizer`, `uid_mapping`) | 7.4.5 | PHI removal or pseudonymization for research/test data flows. |
+| DICOM conformance (full service list in README) | 7.7 | ISO 12052 / DICOM 2023e conformance — see Conformance Statement. |
+
+## Applicability
+
+This mapping uses ISO 27799:2016 clause numbering. ISO 27799 inherits ISO/IEC 27002 control identifiers; where a clause maps to both, the ISO/IEC 27002 identifier is shown in parentheses.
+
+Controls are marked:
+
+- **Direct** — library provides a technical capability that implements the control.
+- **Supporting** — library provides a primitive that can be composed with other controls.
+- **Out of scope** — control is organizational (policy, training, contracts) and remains the adopter's responsibility.
+
+## Control Mapping
+
+### Clause 7.4 — Operations security
+
+| Clause (27799) | 27002 | Title | Support | How `pacs_system` helps |
+|----------------|-------|-------|---------|-------------------------|
+| 7.4.2 | A.9 (A.5.15–A.5.18, A.8.3) | Access control | Direct | `access_control_manager` gates DIMSE C-STORE/C-FIND/C-MOVE/C-GET and DICOMweb QIDO/WADO/STOW based on AE title, role, and optional mTLS identity. |
+| 7.4.4 | A.10 (A.8.24) | Cryptographic controls | Direct | `tls_policy` enforces TLS 1.2+ cipher suites for DICOM associations; `audit_log_cipher` applies authenticated encryption to audit log files at rest ([#1102](https://github.com/kcenon/pacs_system/issues/1102)); `digital_signature` provides detached/embedded image signatures where required. |
+| 7.4.5 | A.14.3 (A.8.11, A.5.34) | Test data protection | Direct | `anonymizer` and `uid_mapping` produce DICOM-conformant anonymized or pseudonymized datasets for non-production flows; `tag_action` exposes tag-by-tag policy control. |
+| 7.4.7 | A.12.4 (A.8.15) | Event logging | Direct | `atna_audit_logger` emits IHE ATNA audit messages for every PHI access and privilege-affecting operation; ATNA format is the ISO 27799-recommended standard. |
+| 7.4.8 | A.12.1.4 (A.8.31) | Separation of environments | Supporting | Anonymization pipeline and disjoint AE title configuration allow a test/dev AE to share the same binary with a production AE without leaking PHI. |
+
+### Clause 7.5 — Incident management
+
+| Clause (27799) | 27002 | Title | Support | How `pacs_system` helps |
+|----------------|-------|-------|---------|-------------------------|
+| 7.5 (all) | A.16 (A.5.24–A.5.28) | Incident management | Direct | `atna_audit_logger` produces the structured audit trail required by IRT investigators; `atna_syslog_transport` forwards to a centralized SIEM for correlation. |
+| 7.5 (integrity) | A.12.4 (A.8.15, A.8.34) | Protection of log information | Direct | `audit_log_cipher` protects the local copy of the audit trail with authenticated encryption; remote syslog delivery runs over TLS-capable transport. |
+
+### Clause 7.6 — Business continuity
+
+| Clause (27799) | 27002 | Title | Support | How `pacs_system` helps |
+|----------------|-------|-------|---------|-------------------------|
+| 7.6 (operational) | A.17 (A.5.29–A.5.30, A.8.13) | Information security continuity | Supporting | Storage backends (filesystem, database) plus standard DICOM C-MOVE/C-STORE replication paths provide the restore primitives; backup scheduling and RPO/RTO targets are organizational. |
+| 7.6 (degraded mode) | A.17.2 (A.5.30) | Redundancies | Supporting | Stateless DIMSE/DICOMweb services support horizontal scale; storage back-ends can be configured for replication. The library does not prescribe the DR topology. |
+
+### Clause 7.7 — Compliance
+
+| Clause (27799) | 27002 | Title | Support | How `pacs_system` helps |
+|----------------|-------|-------|---------|-------------------------|
+| 7.7.1 | A.18.1 (A.5.31) | Compliance with legal requirements | Supporting | DICOM conformance (ISO 12052) and ATNA (ISO 27799 recommended audit format) are implemented to standard; GDPR Art. 32 technical measures overlap with 7.4.4 above. |
+| 7.7.1.2 | A.18.1.3 (A.5.33) | Protection of records | Direct | Storage subsystem preserves DICOM objects with their metadata; audit logs are rotated with retention windows configurable per deployment. |
+| 7.7.1.5 | A.18.1.5 (A.5.12) | Regulation of cryptographic controls | Supporting | `tls_policy` allows cipher suites and protocol versions to be restricted to those permitted by the adopter's jurisdiction. |
+| 7.7.2 | A.18.2 (A.5.35) | Compliance reviews | Out of scope | Internal audits and independent reviews remain the organization's responsibility. |
+
+**Explicit non-coverage**:
+
+- 7.3 (Human resources security) — hiring, offboarding, training. Organizational.
+- 7.6 (plans and procedures) — BCP documentation, exercises, recovery procedures. Organizational.
+- 7.1, 7.2 (policy, organization) — ISMS scope and governance. Organizational.
+
+## DICOM and ISO 12052 cross-reference
+
+ISO 27799 Clause 7.7 references compliance with other legal and regulatory requirements, of which the DICOM standard (ISO 12052) is the most relevant for a PACS. `pacs_system` implements the full set of DIMSE services (Storage, Query/Retrieve, Worklist, MPPS, Storage Commitment, Print), the DICOMweb services (QIDO-RS, WADO-RS, STOW-RS), and the transfer syntaxes commonly required for cross-vendor interoperability.
+
+The authoritative conformance statement is [`docs/DICOM_CONFORMANCE_STATEMENT.md`](../DICOM_CONFORMANCE_STATEMENT.md). Reviewers who need ISO 27799 evidence should read that document alongside this one — ISO 12052 conformance is a clause 7.7 input, not a separate deliverable.
+
+## Configuration Checklist
+
+For an ISMS that treats `pacs_system` as a technical control, configure at least the following so the mapping above is defensible during audit:
+
+- [ ] **Audit log encryption**: enable `audit_log_cipher` for the ATNA local audit trail. Key stored outside the PACS process's working directory.
+- [ ] **Audit log forwarding**: configure `atna_syslog_transport` to deliver to a SIEM over TLS; verify delivery under network fault injection.
+- [ ] **Access control**: configure `access_control_manager` rules per AE title and per DIMSE service. Deny-by-default; explicitly allow expected consumers.
+- [ ] **TLS policy**: disable TLS ≤ 1.1 and any cipher suite without forward secrecy in `tls_policy`. Require server and, where possible, client certificates.
+- [ ] **Anonymization**: never route production PHI to a test/research workflow without running it through `anonymizer` with the organization's PHI pattern set.
+- [ ] **Retention**: configure storage retention windows and audit-log rotation aligned to the organization's record policy and the jurisdiction's health-data retention rules.
+- [ ] **Key rotation**: schedule `audit_log_cipher` key rotation per the organization's cryptographic policy. This is outside the library.
+- [ ] **Backup & DR**: schedule backups and DR drills per clause 7.6. The library provides restore primitives but not scheduling.
+
+## Evidence Collection
+
+Auditors typically request:
+
+1. **Conformance statement** — [`docs/DICOM_CONFORMANCE_STATEMENT.md`](../DICOM_CONFORMANCE_STATEMENT.md) with SOP class and transfer syntax tables.
+2. **ATNA audit log excerpt** — a non-sensitive extract demonstrating per-patient, per-access granularity.
+3. **Audit log encryption evidence** — configuration showing `audit_log_cipher` is enabled; decryption test using the adopter-managed key.
+4. **TLS policy snapshot** — the `tls_policy` configuration plus a passive scan (e.g., `testssl.sh`) output.
+5. **Access-control policy** — the rule set loaded by `access_control_manager`, mapped to named roles in the organization's access matrix.
+6. **Anonymization profile** — the tag-action policy used by `anonymizer`, mapped to the organization's PHI inventory.
+
+## Related Standards
+
+| Standard | Relationship |
+|----------|-------------|
+| ISO/IEC 27002:2022 | Baseline control set that ISO 27799 specializes. Same numeric identifiers where applicable. |
+| ISO 12052:2017 (DICOM) | Medical imaging interchange standard — implemented by `pacs_system` modules (see DICOM Conformance Statement). |
+| IHE ATNA | Audit Trail and Node Authentication integration profile — implemented by `atna_*` modules. |
+| GDPR Art. 32 | Technical and organizational measures — overlaps with clauses 7.4.4, 7.4.7, and 7.5 above. |
+| HIPAA § 164.312 | US healthcare technical safeguards — overlaps with clauses 7.4.2 (access control), 7.4.4 (encryption), 7.4.7 (audit). |
+| ISO/IEC 27001 | Umbrella ISMS standard — covered at the ecosystem level by [common_system ISO_OVERVIEW](https://github.com/kcenon/common_system/blob/develop/docs/compliance/ISO_OVERVIEW.md). |
+
+## References
+
+- ISO 27799:2016, *Health informatics — Information security management in health using ISO/IEC 27002*
+- ISO 12052:2017, *Health informatics — Digital imaging and communication in medicine (DICOM)*
+- [`docs/DICOM_CONFORMANCE_STATEMENT.md`](../DICOM_CONFORMANCE_STATEMENT.md)
+- [pacs_system#1102](https://github.com/kcenon/pacs_system/issues/1102) — audit log encryption implementation (closed)
+- [common_system#645](https://github.com/kcenon/common_system/issues/645) — ecosystem-wide ISO compliance EPIC
+- [common_system/docs/compliance/ISO_OVERVIEW.md](https://github.com/kcenon/common_system/blob/develop/docs/compliance/ISO_OVERVIEW.md) — ecosystem index


### PR DESCRIPTION
## What

Adds `docs/compliance/iso-27799.md` — a clause-by-clause mapping of `pacs_system` security primitives to ISO 27799:2016 (Health informatics — information security management). Adds README Compliance section and TOC entry.

### Change type

- [x] Documentation

### Affected files

- `docs/compliance/iso-27799.md` (new)
- `README.md` (Compliance section + TOC)

## Why

Closes #1126

- EPIC [common_system#645](https://github.com/kcenon/common_system/issues/645) — ecosystem-wide ISO compliance. pacs_system is the Planned entry for ISO 27799 in the new [ISO_OVERVIEW.md](https://github.com/kcenon/common_system/blob/develop/docs/compliance/ISO_OVERVIEW.md).
- Healthcare adopters explicitly require ISO 27799 evidence at procurement; "we encrypt audit logs" alone is insufficient.
- Consolidates existing security work (ATNA audit trail, audit log encryption from #1102, TLS policy, access control, anonymization) under a single auditable document.

## Where

| Path | Change |
|------|--------|
| `docs/compliance/iso-27799.md` | New file |
| `README.md` | Add Compliance section + TOC entry |

## How

### Clauses covered

- **7.4 Operations security** — 7.4.2 access control, 7.4.4 cryptographic controls, 7.4.5 test data protection, 7.4.7 event logging, 7.4.8 separation of environments
- **7.5 Incident management** — audit trail + protection of log information
- **7.6 Business continuity** — redundancy primitives (org retains plan ownership)
- **7.7 Compliance** — DICOM / ISO 12052 cross-reference, protection of records, cryptographic control regulation

### Evidence chain

- ATNA audit trail (`atna_audit_logger`, `atna_syslog_transport`)
- Audit log cipher from #1102 (`audit_log_cipher`) for clauses 7.4.4 + 7.5
- TLS policy (`tls_policy`) for 7.4.4
- Access control (`access_control_manager`) for 7.4.2
- Anonymization (`anonymizer`, `uid_mapping`, `tag_action`) for 7.4.5
- Existing [DICOM Conformance Statement](docs/DICOM_CONFORMANCE_STATEMENT.md) for 7.7 ISO 12052 cross-reference

Document includes a Configuration Checklist and Evidence Collection section so the mapping is auditable, not just aspirational, and an explicit non-coverage list.

### Breaking changes

None.

### Test plan

Docs-only. Anchor integrity validated locally. Inter-repo links point to `develop` branch URLs (e.g., common_system ISO_OVERVIEW.md which landed in [common_system#654](https://github.com/kcenon/common_system/pull/654)).

## Checklist

- [x] `docs/compliance/iso-27799.md` exists with control-by-control table
- [x] README has a Compliance section linking to the new doc
- [x] Doc references #1102 and existing DICOM/ISO 12052 work
- [x] Related issues linked (`Closes #1126`, `Part of #645`)