### PR TITLE
feat(ihe/xds): implement Registry Query actor (ITI-18)

### DIFF
--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -516,8 +516,8 @@ else()
     message(STATUS "  [OK] pacs_security: ON (without digital signatures)")
 endif()
 
-# IHE XDS.b library (Issues #1128 / #1129 - Document Source ITI-41
-# and Document Consumer ITI-43)
+# IHE XDS.b library (Issues #1128 / #1129 / #1130 - Document Source ITI-41,
+# Document Consumer ITI-43, Registry Query ITI-18)
 # Built only when pugixml, libcurl, and OpenSSL are all available; otherwise
 # the target is skipped and consumers that depend on it gate on TARGET pacs_ihe_xds.
 if(PACS_PUGIXML_FOUND AND PACS_CURL_FOUND AND PACS_OPENSSL_FOUND)
@@ -530,6 +530,9 @@ if(PACS_PUGIXML_FOUND AND PACS_CURL_FOUND AND PACS_OPENSSL_FOUND)
         src/ihe/xds/consumer/retrieve_envelope.cpp
         src/ihe/xds/consumer/retrieve_response_parser.cpp
         src/ihe/xds/document_consumer.cpp
+        src/ihe/xds/registry_query/query_envelope.cpp
+        src/ihe/xds/registry_query/query_response_parser.cpp
+        src/ihe/xds/registry_query.cpp
     )
     target_include_directories(pacs_ihe_xds
         PUBLIC

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -408,11 +408,12 @@ if(PACS_BUILD_TESTS)
             Catch2::Catch2WithMain
     )
 
-    # IHE XDS.b Document Source (ITI-41) tests (Issue #1128)
+    # IHE XDS.b Document Source / Consumer / Registry Query tests
+    # (Issues #1128 / #1129 / #1130)
     # Only defined when the pacs_ihe_xds target was created (requires pugixml,
     # libcurl, and OpenSSL). Tests reach into internal headers under
     # src/ihe/xds/common/ for the envelope / signer / packager layers, plus
-    # the public document_source.h for the end-to-end orchestrator.
+    # the public headers for the end-to-end orchestrators.
     if(TARGET pacs_ihe_xds)
         file(MAKE_DIRECTORY ${CMAKE_SOURCE_DIR}/tests/ihe/xds)
         add_executable(pacs_ihe_xds_tests
@@ -421,6 +422,7 @@ if(PACS_BUILD_TESTS)
             tests/ihe/xds/mtom_packager_test.cpp
             tests/ihe/xds/document_source_test.cpp
             tests/ihe/xds/document_consumer_test.cpp
+            tests/ihe/xds/registry_query_test.cpp
         )
         target_link_libraries(pacs_ihe_xds_tests
             PRIVATE
@@ -438,7 +440,7 @@ if(PACS_BUILD_TESTS)
         elseif(TARGET pugixml)
             target_link_libraries(pacs_ihe_xds_tests PRIVATE pugixml)
         endif()
-        message(STATUS "  [OK] pacs_ihe_xds_tests: ON (ITI-41 + ITI-43)")
+        message(STATUS "  [OK] pacs_ihe_xds_tests: ON (ITI-18 + ITI-41 + ITI-43)")
     endif()
 
     # DI tests (Issue #312 - ServiceContainer based DI Integration)

--- a/include/kcenon/pacs/ihe/xds/errors.h
+++ b/include/kcenon/pacs/ihe/xds/errors.h
@@ -73,6 +73,11 @@ enum class error_code : int {
     consumer_response_document_not_found = 114,
     consumer_signature_verification_failed = 115,
     consumer_signature_missing = 116,
+
+    // --- Registry Query / ITI-18 (120-129) ---
+    consumer_query_missing_patient_id = 120,
+    consumer_query_empty_uuid_list = 121,
+    consumer_query_response_parse_failed = 122,
 };
 
 /**

--- a/include/kcenon/pacs/ihe/xds/registry_query.h
+++ b/include/kcenon/pacs/ihe/xds/registry_query.h
@@ -1,0 +1,151 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file registry_query.h
+ * @brief IHE XDS.b Registry Query Actor (ITI-18 Registry Stored Query).
+ *
+ * The Registry Query actor discovers documents in an IHE XDS.b Document
+ * Registry by running the registry's pre-defined stored queries. Transport
+ * is SOAP 1.2 over HTTPS; no MTOM on request or response (the response body
+ * is a plain SOAP envelope containing a query:AdhocQueryResponse with
+ * rim:ExtrinsicObject metadata entries).
+ *
+ * Scope of this header (Issue #1130):
+ *  - Two stored queries with the widest deployment footprint:
+ *      * FindDocuments (urn:uuid:14d4debf-8f97-4251-9a1e-8aabd7b6f011)
+ *      * GetDocuments  (urn:uuid:5c4f972b-d56b-40ac-a5fc-c8ca9b40b9d4)
+ *  - ATNA audit emission and Document retrieval are deliberately NOT exposed
+ *    here; see issues #1131 and #1129 respectively.
+ *
+ * Interoperability caveat: the SOAP envelope this actor emits uses the same
+ * project-local canonicalization policy as the Source / Consumer. The
+ * Registry does not verify the request signature; the Registry's own
+ * response is NOT signed in ITI-18, so no verification step is performed on
+ * the return path. When the follow-up full-c14n work lands, this actor will
+ * interoperate with any IHE Gazelle-style Registry without changes to its
+ * public API.
+ *
+ * @see IHE ITI TF-2a §3.18
+ * @see Issue #1130
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/pacs/ihe/xds/document_source.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/http_options.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace kcenon::pacs::ihe::xds {
+
+/**
+ * @brief Metadata for one rim:ExtrinsicObject entry returned by the Registry.
+ *
+ * Fields populated from the ExtrinsicObject attributes and the
+ * well-known Slot / ExternalIdentifier children. Empty strings mean the
+ * Registry omitted the element; callers should treat empty entry_uuid /
+ * document_unique_id as diagnostic evidence that the response was
+ * schema-legal but lacked required XDSDocumentEntry slots.
+ */
+struct document_entry {
+    std::string entry_uuid;            ///< ExtrinsicObject @id
+    std::string document_unique_id;    ///< XDSDocumentEntry.uniqueId
+    std::string patient_id;            ///< XDSDocumentEntry.patientId (CX form)
+    std::string mime_type;             ///< ExtrinsicObject @mimeType
+    std::string status;                ///< ExtrinsicObject @status URI
+    std::string creation_time;         ///< Slot creationTime (YYYYMMDDhhmmss)
+    std::string repository_unique_id;  ///< Slot repositoryUniqueId
+};
+
+/**
+ * @brief Result of one stored-query call.
+ *
+ * registry_response_status carries the literal status URI the Registry
+ * emitted (Success / PartialSuccess / Failure). An empty entries vector is
+ * a successful "no matches" response, not an error. Callers that need to
+ * distinguish zero-results from a malformed response should inspect the
+ * Result's is_ok() first and then the entries vector.
+ */
+struct registry_query_result {
+    std::string registry_response_status;
+    std::vector<document_entry> entries;
+};
+
+/**
+ * @brief ITI-18 Registry Query actor.
+ *
+ * Binds one Registry endpoint and one signing credential. Thread-safety
+ * mirrors document_consumer: per-instance serialization is required;
+ * create one instance per worker thread for concurrent queries.
+ *
+ * The signing_material is reused from document_source so a single
+ * deployment can share its WS-Security credential across the push
+ * (ITI-41), pull (ITI-43) and query (ITI-18) actors.
+ */
+class registry_query {
+public:
+    /**
+     * @brief Construct an ITI-18 Registry Query actor.
+     *
+     * The endpoint in @p opts must be the Registry Stored Query service
+     * URL. The default http_options.soap_action is ITI-41-specific and is
+     * overwritten internally by the ITI-18 action URI before each POST.
+     */
+    registry_query(http_options opts, signing_material signing);
+
+    registry_query(registry_query&&) noexcept;
+    registry_query& operator=(registry_query&&) noexcept;
+
+    registry_query(const registry_query&) = delete;
+    registry_query& operator=(const registry_query&) = delete;
+
+    ~registry_query();
+
+    /**
+     * @brief FindDocuments stored query (urn:uuid:14d4debf-...).
+     *
+     * Discovers documents by patient identifier, optionally narrowed by
+     * status URI. @p patient_id is a CX-formatted XDS patient identifier
+     * (for example "12345^^^&1.2.3.4.5&ISO"). Empty string is rejected
+     * with consumer_query_missing_patient_id without issuing a network
+     * request.
+     *
+     * @p statuses defaults to {"urn:oasis:names:tc:ebxml-regrep:
+     * StatusType:Approved"} to match the most common client pattern
+     * (discover live entries only). Callers asking for deprecated entries
+     * can pass both Approved and Deprecated URIs.
+     *
+     * A Registry response with a Failure status or a malformed envelope
+     * surfaces as consumer_query_response_parse_failed; a successful
+     * response with zero ExtrinsicObject children is a valid empty
+     * registry_query_result.
+     */
+    kcenon::common::Result<registry_query_result> find_documents(
+        const std::string& patient_id,
+        const std::vector<std::string>& statuses = {
+            "urn:oasis:names:tc:ebxml-regrep:StatusType:Approved"});
+
+    /**
+     * @brief GetDocuments stored query (urn:uuid:5c4f972b-...).
+     *
+     * Resolves explicit XDSDocumentEntry UUIDs to their metadata entries.
+     * Empty @p uuids is rejected with consumer_query_empty_uuid_list.
+     *
+     * The Registry response is not required to preserve input order; the
+     * returned entries vector is emitted in document order.
+     */
+    kcenon::common::Result<registry_query_result> get_documents(
+        const std::vector<std::string>& uuids);
+
+private:
+    class impl;
+    std::unique_ptr<impl> impl_;
+};
+
+}  // namespace kcenon::pacs::ihe::xds

--- a/src/ihe/xds/registry_query.cpp
+++ b/src/ihe/xds/registry_query.cpp
@@ -1,0 +1,114 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file registry_query.cpp
+ * @brief IHE XDS.b Registry Query actor (ITI-18).
+ */
+
+#include "kcenon/pacs/ihe/xds/registry_query.h"
+
+#include "common/http_client.h"
+#include "common/soap_envelope.h"
+#include "common/wss_signer.h"
+#include "registry_query/query_envelope.h"
+#include "registry_query/query_response_parser.h"
+
+#include <string>
+#include <utility>
+
+namespace kcenon::pacs::ihe::xds {
+
+namespace {
+
+constexpr const char* kIti18SoapAction =
+    "urn:ihe:iti:2007:RegistryStoredQuery";
+
+// Plain SOAP 1.2 content-type; ITI-18 carries no MTOM attachments on
+// either direction.
+constexpr const char* kSoapContentType =
+    "application/soap+xml; charset=UTF-8; "
+    "action=\"urn:ihe:iti:2007:RegistryStoredQuery\"";
+
+kcenon::common::Result<registry_query_result> send_and_parse(
+    const http_options& opts, const signing_material& signing,
+    detail::built_envelope env) {
+    auto sign_result = detail::sign_envelope(
+        env, signing.certificate_pem, signing.private_key_pem,
+        signing.private_key_password);
+    if (sign_result.is_err()) {
+        return kcenon::common::make_error<registry_query_result>(
+            sign_result.error());
+    }
+
+    // Per-call copy: the ITI-18 action URI is specific to this
+    // transaction and must not bleed into the caller's shared options.
+    http_options call_opts = opts;
+    call_opts.soap_action = kIti18SoapAction;
+
+    auto http_result =
+        detail::http_post(call_opts, kSoapContentType, env.xml);
+    if (http_result.is_err()) {
+        return kcenon::common::make_error<registry_query_result>(
+            http_result.error());
+    }
+
+    return detail::parse_query_response(http_result.value().body);
+}
+
+}  // namespace
+
+class registry_query::impl {
+public:
+    impl(http_options opts, signing_material signing)
+        : opts_(std::move(opts)), signing_(std::move(signing)) {}
+
+    kcenon::common::Result<registry_query_result> find_documents(
+        const std::string& patient_id,
+        const std::vector<std::string>& statuses) {
+        auto env_result = detail::build_iti18_find_documents_envelope(
+            patient_id, statuses);
+        if (env_result.is_err()) {
+            return kcenon::common::make_error<registry_query_result>(
+                env_result.error());
+        }
+        return send_and_parse(opts_, signing_, env_result.value());
+    }
+
+    kcenon::common::Result<registry_query_result> get_documents(
+        const std::vector<std::string>& uuids) {
+        auto env_result =
+            detail::build_iti18_get_documents_envelope(uuids);
+        if (env_result.is_err()) {
+            return kcenon::common::make_error<registry_query_result>(
+                env_result.error());
+        }
+        return send_and_parse(opts_, signing_, env_result.value());
+    }
+
+private:
+    http_options opts_;
+    signing_material signing_;
+};
+
+registry_query::registry_query(http_options opts, signing_material signing)
+    : impl_(std::make_unique<impl>(std::move(opts), std::move(signing))) {}
+
+registry_query::registry_query(registry_query&&) noexcept = default;
+registry_query& registry_query::operator=(registry_query&&) noexcept = default;
+
+registry_query::~registry_query() = default;
+
+kcenon::common::Result<registry_query_result> registry_query::find_documents(
+    const std::string& patient_id,
+    const std::vector<std::string>& statuses) {
+    return impl_->find_documents(patient_id, statuses);
+}
+
+kcenon::common::Result<registry_query_result> registry_query::get_documents(
+    const std::vector<std::string>& uuids) {
+    return impl_->get_documents(uuids);
+}
+
+}  // namespace kcenon::pacs::ihe::xds

--- a/src/ihe/xds/registry_query/query_envelope.cpp
+++ b/src/ihe/xds/registry_query/query_envelope.cpp
@@ -1,0 +1,239 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_envelope.cpp
+ * @brief pugixml-backed SOAP 1.2 envelope builder for ITI-18.
+ */
+
+#include "query_envelope.h"
+
+#include <pugixml.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <random>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+namespace {
+
+constexpr const char* kSoapEnv = "http://www.w3.org/2003/05/soap-envelope";
+constexpr const char* kWsa = "http://www.w3.org/2005/08/addressing";
+constexpr const char* kWsse =
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+constexpr const char* kWsu =
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+constexpr const char* kEbQuery =
+    "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0";
+constexpr const char* kEbRim =
+    "urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0";
+
+// Stored query ids defined in IHE ITI TF-2a §3.18.4.1.2.3.7.
+constexpr const char* kFindDocumentsQueryId =
+    "urn:uuid:14d4debf-8f97-4251-9a1e-8aabd7b6f011";
+constexpr const char* kGetDocumentsQueryId =
+    "urn:uuid:5c4f972b-d56b-40ac-a5fc-c8ca9b40b9d4";
+constexpr const char* kIti18Action =
+    "urn:ihe:iti:2007:RegistryStoredQuery";
+
+// Id generator kept local to match retrieve_envelope.cpp's policy: not
+// RFC 4122 compliant, but unique-per-envelope within a process, which is
+// what wss_signer needs for xml:id referencing.
+std::string make_xml_id(std::string_view prefix) {
+    static thread_local std::mt19937_64 rng(
+        static_cast<std::uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::uniform_int_distribution<std::uint64_t> dist;
+    std::ostringstream oss;
+    oss << prefix << '-' << std::hex << dist(rng) << dist(rng);
+    return oss.str();
+}
+
+std::string utc_iso8601_now() {
+    const auto now = std::chrono::system_clock::now();
+    const auto tt = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &tt);
+#else
+    gmtime_r(&tt, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return std::string(buf);
+}
+
+struct xml_string_writer : pugi::xml_writer {
+    std::string out;
+    void write(const void* data, std::size_t size) override {
+        out.append(static_cast<const char*>(data), size);
+    }
+};
+
+// Wrap each raw value in single quotes and join with commas so the
+// resulting slot looks like "('v1','v2')" — the ebRS stored-query list
+// grammar (ITI TF-2a §3.18.4.1.2.3.5).
+std::string format_quoted_list(const std::vector<std::string>& values) {
+    std::string out = "(";
+    bool first = true;
+    for (const auto& v : values) {
+        if (!first) out += ',';
+        first = false;
+        out += '\'';
+        out += v;
+        out += '\'';
+    }
+    out += ')';
+    return out;
+}
+
+// Scaffolds the SOAP envelope, header (wsa:Action + wsa:MessageID +
+// wsse:Security stub), and empty soap:Body with wsu:Id attached. Returns
+// the node pointing at soap:Body so callers can append their request
+// element directly.
+pugi::xml_node build_envelope_shell(pugi::xml_document& doc,
+                                    built_envelope& out) {
+    auto decl = doc.append_child(pugi::node_declaration);
+    decl.append_attribute("version") = "1.0";
+    decl.append_attribute("encoding") = "UTF-8";
+
+    auto env = doc.append_child("soap:Envelope");
+    env.append_attribute("xmlns:soap") = kSoapEnv;
+    env.append_attribute("xmlns:wsa") = kWsa;
+    env.append_attribute("xmlns:wsse") = kWsse;
+    env.append_attribute("xmlns:wsu") = kWsu;
+    env.append_attribute("xmlns:query") = kEbQuery;
+    env.append_attribute("xmlns:rim") = kEbRim;
+
+    auto header = env.append_child("soap:Header");
+
+    auto action = header.append_child("wsa:Action");
+    action.append_attribute("soap:mustUnderstand") = "true";
+    action.text().set(kIti18Action);
+
+    auto message_id = header.append_child("wsa:MessageID");
+    message_id.text().set(("urn:uuid:" + make_xml_id("msg")).c_str());
+
+    auto security = header.append_child("wsse:Security");
+    security.append_attribute("soap:mustUnderstand") = "true";
+
+    out.timestamp_id = make_xml_id("ts");
+    out.binary_security_token_id = make_xml_id("bst");
+    out.body_id = make_xml_id("body");
+
+    auto timestamp = security.append_child("wsu:Timestamp");
+    timestamp.append_attribute("wsu:Id") = out.timestamp_id.c_str();
+    auto created = timestamp.append_child("wsu:Created");
+    const std::string now = utc_iso8601_now();
+    created.text().set(now.c_str());
+
+    auto bst = security.append_child("wsse:BinarySecurityToken");
+    bst.append_attribute("wsu:Id") = out.binary_security_token_id.c_str();
+    bst.append_attribute("EncodingType") =
+        "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-"
+        "security-1.0#Base64Binary";
+    bst.append_attribute("ValueType") =
+        "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-"
+        "profile-1.0#X509v3";
+
+    auto body = env.append_child("soap:Body");
+    body.append_attribute("wsu:Id") = out.body_id.c_str();
+    return body;
+}
+
+// Emit one <rim:Slot name="..."><rim:ValueList><rim:Value>...</rim:Value>...
+// </rim:ValueList></rim:Slot> under the supplied parent.
+void append_slot(pugi::xml_node parent, const char* name,
+                 const std::string& value) {
+    auto slot = parent.append_child("rim:Slot");
+    slot.append_attribute("name") = name;
+    auto value_list = slot.append_child("rim:ValueList");
+    auto v = value_list.append_child("rim:Value");
+    v.text().set(value.c_str());
+}
+
+kcenon::common::Result<built_envelope> serialize(pugi::xml_document& doc,
+                                                 built_envelope& out) {
+    xml_string_writer writer;
+    doc.save(writer, "", pugi::format_raw | pugi::format_no_declaration,
+             pugi::encoding_utf8);
+    if (writer.out.empty()) {
+        return kcenon::common::make_error<built_envelope>(
+            static_cast<int>(error_code::envelope_serialization_failed),
+            "pugixml produced an empty envelope",
+            std::string(error_source));
+    }
+    out.xml = R"(<?xml version="1.0" encoding="UTF-8"?>)";
+    out.xml += writer.out;
+    return out;
+}
+
+}  // namespace
+
+kcenon::common::Result<built_envelope> build_iti18_find_documents_envelope(
+    const std::string& patient_id,
+    const std::vector<std::string>& statuses) {
+    if (patient_id.empty()) {
+        return kcenon::common::make_error<built_envelope>(
+            static_cast<int>(error_code::consumer_query_missing_patient_id),
+            "find_documents: patient_id is empty",
+            std::string(error_source));
+    }
+
+    pugi::xml_document doc;
+    built_envelope out{};
+    auto body = build_envelope_shell(doc, out);
+
+    auto req = body.append_child("query:AdhocQueryRequest");
+    auto rs_response_option = req.append_child("query:ResponseOption");
+    rs_response_option.append_attribute("returnComposedObjects") = "true";
+    rs_response_option.append_attribute("returnType") = "LeafClass";
+
+    auto adhoc = req.append_child("rim:AdhocQuery");
+    adhoc.append_attribute("id") = kFindDocumentsQueryId;
+
+    // Slot order is not semantically required by the ebRS grammar but
+    // matches the examples in the IHE TF to minimize reviewer friction.
+    append_slot(adhoc, "$XDSDocumentEntryPatientId",
+                std::string("'") + patient_id + "'");
+
+    if (!statuses.empty()) {
+        append_slot(adhoc, "$XDSDocumentEntryStatus",
+                    format_quoted_list(statuses));
+    }
+
+    return serialize(doc, out);
+}
+
+kcenon::common::Result<built_envelope> build_iti18_get_documents_envelope(
+    const std::vector<std::string>& uuids) {
+    if (uuids.empty()) {
+        return kcenon::common::make_error<built_envelope>(
+            static_cast<int>(error_code::consumer_query_empty_uuid_list),
+            "get_documents: uuids list is empty",
+            std::string(error_source));
+    }
+
+    pugi::xml_document doc;
+    built_envelope out{};
+    auto body = build_envelope_shell(doc, out);
+
+    auto req = body.append_child("query:AdhocQueryRequest");
+    auto rs_response_option = req.append_child("query:ResponseOption");
+    rs_response_option.append_attribute("returnComposedObjects") = "true";
+    rs_response_option.append_attribute("returnType") = "LeafClass";
+
+    auto adhoc = req.append_child("rim:AdhocQuery");
+    adhoc.append_attribute("id") = kGetDocumentsQueryId;
+
+    append_slot(adhoc, "$XDSDocumentEntryUUID", format_quoted_list(uuids));
+
+    return serialize(doc, out);
+}
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/src/ihe/xds/registry_query/query_envelope.h
+++ b/src/ihe/xds/registry_query/query_envelope.h
@@ -1,0 +1,66 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_envelope.h
+ * @brief SOAP 1.2 envelope builder for IHE XDS.b ITI-18 RegistryStoredQuery.
+ *
+ * Produces a query:AdhocQueryRequest wrapped in a SOAP 1.2 Envelope with a
+ * WS-Addressing header and an empty WS-Security header that wss_signer
+ * fills in. XML is serialized via pugixml using the same format flags as
+ * the ITI-41 / ITI-43 builders so canonicalization stays policy-consistent.
+ *
+ * This is an internal header - not installed, not part of the public API.
+ *
+ * @see IHE ITI TF-2a §3.18.4.1.2 - Registry Stored Query Request
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+
+#include "../common/soap_envelope.h"
+
+#include <string>
+#include <vector>
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+/**
+ * @brief Build an ITI-18 FindDocuments SOAP envelope.
+ *
+ * Emits query:AdhocQueryRequest / query:AdhocQuery with
+ * id="urn:uuid:14d4debf-8f97-4251-9a1e-8aabd7b6f011" and two Slot
+ * children: $XDSDocumentEntryPatientId and $XDSDocumentEntryStatus. The
+ * wsa:Action is "urn:ihe:iti:2007:RegistryStoredQuery".
+ *
+ * @p patient_id is passed through verbatim; validation happens in the
+ * registry_query impl so the envelope builder can stay pure. @p statuses
+ * expands to one quoted list inside the slot value as required by the
+ * ebRS stored-query grammar.
+ *
+ * Returns consumer_query_missing_patient_id when the caller leaks an
+ * empty patient_id through; envelope_serialization_failed on pugixml
+ * serialization failure.
+ */
+kcenon::common::Result<built_envelope> build_iti18_find_documents_envelope(
+    const std::string& patient_id,
+    const std::vector<std::string>& statuses);
+
+/**
+ * @brief Build an ITI-18 GetDocuments SOAP envelope.
+ *
+ * Emits query:AdhocQueryRequest / query:AdhocQuery with
+ * id="urn:uuid:5c4f972b-d56b-40ac-a5fc-c8ca9b40b9d4" and one Slot
+ * child: $XDSDocumentEntryUUID carrying a quoted list of the requested
+ * entry UUIDs.
+ *
+ * Returns consumer_query_empty_uuid_list on empty input;
+ * envelope_serialization_failed on pugixml serialization failure.
+ */
+kcenon::common::Result<built_envelope> build_iti18_get_documents_envelope(
+    const std::vector<std::string>& uuids);
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/src/ihe/xds/registry_query/query_response_parser.cpp
+++ b/src/ihe/xds/registry_query/query_response_parser.cpp
@@ -1,0 +1,162 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_response_parser.cpp
+ * @brief pugixml-backed parser for ITI-18 query:AdhocQueryResponse.
+ */
+
+#include "query_response_parser.h"
+
+#include <pugixml.hpp>
+
+#include <string>
+#include <string_view>
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+namespace {
+
+// Mirrors retrieve_response_parser.cpp: the http_client write callback
+// already bounds the response to 8 MiB, and the signing path would also
+// have rejected anything larger. Keep a defensive bound here in case a
+// future non-libcurl transport is wired without the same cap.
+constexpr std::size_t kMaxRootXmlBytes = 8 * 1024 * 1024;
+
+constexpr std::string_view kSuccessStatus =
+    "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+constexpr std::string_view kPartialSuccessStatus =
+    "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:PartialSuccess";
+
+// XDSDocumentEntry well-known classification / external identifier
+// scheme UUIDs. The Registry emits these as @identificationScheme on the
+// ExternalIdentifier children we walk to pull out uniqueId and patientId.
+constexpr std::string_view kExtIdUniqueIdScheme =
+    "urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab";
+constexpr std::string_view kExtIdPatientIdScheme =
+    "urn:uuid:58a6f841-87b3-4a3e-92fd-a8ffeff98427";
+
+// Return the value inside a rim:Slot's first <rim:Value> child, or "" if
+// the slot or ValueList is missing. The Registry may emit a slot with
+// multiple Values (e.g. multi-valued author fields); callers that care
+// about those should walk select_nodes themselves.
+std::string slot_first_value(const pugi::xml_node& parent,
+                             const char* slot_name) {
+    const std::string xpath = std::string("*[local-name()='Slot' and @name='") +
+                              slot_name + "']/*[local-name()='ValueList']/"
+                              "*[local-name()='Value']";
+    return parent.select_node(xpath.c_str())
+        .node()
+        .text()
+        .as_string();
+}
+
+// Find an ExternalIdentifier child by its @identificationScheme and return
+// its @value. Used to pick out XDSDocumentEntry.uniqueId and patientId.
+std::string external_identifier_value(const pugi::xml_node& extrinsic,
+                                      std::string_view scheme) {
+    for (auto ei :
+         extrinsic.select_nodes("*[local-name()='ExternalIdentifier']")) {
+        auto node = ei.node();
+        const std::string_view s =
+            node.attribute("identificationScheme").as_string();
+        if (s == scheme) {
+            return node.attribute("value").as_string();
+        }
+    }
+    return std::string{};
+}
+
+}  // namespace
+
+kcenon::common::Result<registry_query_result> parse_query_response(
+    const std::string& root_xml) {
+    if (root_xml.size() > kMaxRootXmlBytes) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::transport_response_too_large),
+            "AdhocQueryResponse body exceeds 8 MiB cap (" +
+                std::to_string(root_xml.size()) + " bytes)",
+            std::string(error_source));
+    }
+
+    pugi::xml_document doc;
+    auto parse = doc.load_buffer(root_xml.data(), root_xml.size(),
+                                 pugi::parse_default, pugi::encoding_utf8);
+    if (!parse) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::consumer_query_response_parse_failed),
+            std::string("failed to parse AdhocQueryResponse envelope: ") +
+                parse.description(),
+            std::string(error_source));
+    }
+
+    // local-name() selectors: the Registry can legitimately use any
+    // prefix for the query / rim / rs namespaces, and different stacks
+    // (Apache CXF, .NET WIF, Gazelle) all pick different prefixes.
+    auto response =
+        doc.select_node(
+               "//*[local-name()='AdhocQueryResponse']").node();
+    if (!response) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::consumer_query_response_parse_failed),
+            "response contains no AdhocQueryResponse element",
+            std::string(error_source));
+    }
+
+    const std::string status = response.attribute("status").as_string();
+    if (status.empty()) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::consumer_query_response_parse_failed),
+            "AdhocQueryResponse is missing status attribute",
+            std::string(error_source));
+    }
+    if (status == kPartialSuccessStatus) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::registry_partial_success),
+            "registry reported PartialSuccess: " + status,
+            std::string(error_source));
+    }
+    if (status != kSuccessStatus) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::consumer_query_response_parse_failed),
+            "registry reported non-success status: " + status,
+            std::string(error_source));
+    }
+
+    registry_query_result out;
+    out.registry_response_status = status;
+
+    // No RegistryObjectList = zero matches. That is a legal Success
+    // response in the ebRS grammar (TF-2a §3.18.4.1.3) and is surfaced
+    // as an ok Result with an empty entries vector.
+    auto registry_object_list =
+        response.select_node("*[local-name()='RegistryObjectList']").node();
+    if (!registry_object_list) {
+        return out;
+    }
+
+    for (auto eo : registry_object_list.select_nodes(
+             "*[local-name()='ExtrinsicObject']")) {
+        auto node = eo.node();
+        document_entry entry;
+        entry.entry_uuid = node.attribute("id").as_string();
+        entry.mime_type = node.attribute("mimeType").as_string();
+        entry.status = node.attribute("status").as_string();
+
+        entry.document_unique_id =
+            external_identifier_value(node, kExtIdUniqueIdScheme);
+        entry.patient_id =
+            external_identifier_value(node, kExtIdPatientIdScheme);
+
+        entry.creation_time = slot_first_value(node, "creationTime");
+        entry.repository_unique_id =
+            slot_first_value(node, "repositoryUniqueId");
+
+        out.entries.push_back(std::move(entry));
+    }
+
+    return out;
+}
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/src/ihe/xds/registry_query/query_response_parser.h
+++ b/src/ihe/xds/registry_query/query_response_parser.h
@@ -1,0 +1,44 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_response_parser.h
+ * @brief Parser for IHE XDS.b ITI-18 query:AdhocQueryResponse.
+ *
+ * Locates the query:AdhocQueryResponse body in the SOAP envelope emitted
+ * by the Document Registry, reads its RegistryResponse status, and walks
+ * each rim:ExtrinsicObject entry into a registry_query_result /
+ * document_entry pair.
+ *
+ * This is an internal header.
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/registry_query.h>
+
+#include <string>
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+/**
+ * @brief Parse an ITI-18 query:AdhocQueryResponse envelope.
+ *
+ * @p root_xml is the full SOAP envelope body returned by the Registry
+ * (ITI-18 does NOT use MTOM; the response is plain application/soap+xml).
+ *
+ * Returns consumer_query_response_parse_failed when the body is not a
+ * valid query:AdhocQueryResponse, when the RegistryResponse status is
+ * Failure, or when the parser cannot locate the RegistryObjectList.
+ * registry_partial_success surfaces when the Registry reports
+ * PartialSuccess — callers should treat that as a diagnostic, not silent
+ * success. An empty entries vector with Success status is a legitimate
+ * "no matches" response and surfaces as an ok Result.
+ */
+kcenon::common::Result<registry_query_result> parse_query_response(
+    const std::string& root_xml);
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/tests/ihe/xds/registry_query_test.cpp
+++ b/tests/ihe/xds/registry_query_test.cpp
@@ -1,0 +1,320 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file registry_query_test.cpp
+ * @brief End-to-end tests for the ITI-18 Registry Query actor.
+ *
+ * Covers the four scenarios mandated by Issue #1130:
+ *  - happy path (Registry returns two ExtrinsicObject entries)
+ *  - no-results (Success status, empty RegistryObjectList)
+ *  - malformed input (empty patient_id surfaces without a network call)
+ *  - TLS failure (transport_override simulates transport_tls_error)
+ *
+ * Tests that reach into internal headers use the same pattern as
+ * document_consumer_test.cpp; the HTTP transport is replaced via
+ * set_http_transport_override so no live server is required.
+ */
+
+#include "../../../src/ihe/xds/common/http_client.h"
+#include "../../../src/ihe/xds/common/soap_envelope.h"
+#include "../../../src/ihe/xds/common/wss_signer.h"
+#include "../../../src/ihe/xds/registry_query/query_envelope.h"
+#include "../../../src/ihe/xds/registry_query/query_response_parser.h"
+
+#include <kcenon/pacs/ihe/xds/document_source.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/http_options.h>
+#include <kcenon/pacs/ihe/xds/registry_query.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace kcenon::pacs::ihe::xds;
+
+namespace {
+
+struct bio_deleter {
+    void operator()(BIO* b) const noexcept {
+        if (b) BIO_free_all(b);
+    }
+};
+using bio_ptr = std::unique_ptr<BIO, bio_deleter>;
+
+struct pkey_deleter {
+    void operator()(EVP_PKEY* p) const noexcept {
+        if (p) EVP_PKEY_free(p);
+    }
+};
+using pkey_ptr = std::unique_ptr<EVP_PKEY, pkey_deleter>;
+
+struct x509_deleter {
+    void operator()(X509* x) const noexcept {
+        if (x) X509_free(x);
+    }
+};
+using x509_ptr = std::unique_ptr<X509, x509_deleter>;
+
+// Self-signed cert/key pair generated in-process. Registry Query doesn't
+// verify the response signature (ITI-18 returns plain SOAP without a
+// signed envelope), but registry_query_impl still signs its REQUEST via
+// sign_envelope, so we need a valid credential to reach the transport.
+signing_material make_signing() {
+    pkey_ptr pkey(EVP_RSA_gen(2048));
+    REQUIRE(pkey);
+    x509_ptr cert(X509_new());
+    X509_set_version(cert.get(), 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(cert.get()), 1);
+    X509_gmtime_adj(X509_getm_notBefore(cert.get()), 0);
+    X509_gmtime_adj(X509_getm_notAfter(cert.get()), 60L * 60 * 24 * 30);
+    X509_set_pubkey(cert.get(), pkey.get());
+    X509_NAME* name = X509_get_subject_name(cert.get());
+    X509_NAME_add_entry_by_txt(
+        name, "CN", MBSTRING_ASC,
+        reinterpret_cast<const unsigned char*>("kcenon-rq-test"), -1, -1, 0);
+    X509_set_issuer_name(cert.get(), name);
+    X509_sign(cert.get(), pkey.get(), EVP_sha256());
+
+    signing_material s;
+    bio_ptr cb(BIO_new(BIO_s_mem()));
+    PEM_write_bio_X509(cb.get(), cert.get());
+    char* buf = nullptr;
+    long n = BIO_get_mem_data(cb.get(), &buf);
+    s.certificate_pem.assign(buf, static_cast<std::size_t>(n));
+
+    bio_ptr kb(BIO_new(BIO_s_mem()));
+    PEM_write_bio_PrivateKey(kb.get(), pkey.get(), nullptr, nullptr, 0,
+                             nullptr, nullptr);
+    n = BIO_get_mem_data(kb.get(), &buf);
+    s.private_key_pem.assign(buf, static_cast<std::size_t>(n));
+
+    return s;
+}
+
+http_options make_opts() {
+    http_options o;
+    o.endpoint = "https://registry.example.test/iti18";
+    return o;
+}
+
+// Success response body the Registry would return for a FindDocuments
+// query with two matching ExtrinsicObject entries. Kept as a raw string
+// rather than built via pugixml so the test fixture is self-contained
+// and any regression in the parser is visible in the string itself.
+constexpr const char* kTwoEntryResponse =
+    R"(<?xml version="1.0" encoding="UTF-8"?>)"
+    R"(<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" )"
+    R"(xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" )"
+    R"(xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">)"
+    R"(<soap:Body>)"
+    R"(<query:AdhocQueryResponse )"
+    R"(status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success">)"
+    R"(<rim:RegistryObjectList>)"
+    R"(<rim:ExtrinsicObject id="urn:uuid:aaaa-1111" )"
+    R"(mimeType="application/dicom" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">)"
+    R"(<rim:Slot name="creationTime"><rim:ValueList>)"
+    R"(<rim:Value>20260422120000</rim:Value></rim:ValueList></rim:Slot>)"
+    R"(<rim:Slot name="repositoryUniqueId"><rim:ValueList>)"
+    R"(<rim:Value>1.2.276.0.7230010.3.0.3.6.2</rim:Value></rim:ValueList></rim:Slot>)"
+    R"(<rim:ExternalIdentifier identificationScheme="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab" )"
+    R"(value="1.2.840.10008.5.1.4.1.1.2.99991"/>)"
+    R"(<rim:ExternalIdentifier identificationScheme="urn:uuid:58a6f841-87b3-4a3e-92fd-a8ffeff98427" )"
+    R"(value="12345^^^&amp;1.2.3.4.5&amp;ISO"/>)"
+    R"(</rim:ExtrinsicObject>)"
+    R"(<rim:ExtrinsicObject id="urn:uuid:bbbb-2222" )"
+    R"(mimeType="application/pdf" status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved">)"
+    R"(<rim:ExternalIdentifier identificationScheme="urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab" )"
+    R"(value="1.2.840.10008.5.1.4.1.1.2.99992"/>)"
+    R"(</rim:ExtrinsicObject>)"
+    R"(</rim:RegistryObjectList>)"
+    R"(</query:AdhocQueryResponse>)"
+    R"(</soap:Body>)"
+    R"(</soap:Envelope>)";
+
+// Success response with an empty RegistryObjectList. ebRS permits this
+// as a legitimate zero-matches response.
+constexpr const char* kEmptyResponse =
+    R"(<?xml version="1.0" encoding="UTF-8"?>)"
+    R"(<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" )"
+    R"(xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" )"
+    R"(xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">)"
+    R"(<soap:Body>)"
+    R"(<query:AdhocQueryResponse )"
+    R"(status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success">)"
+    R"(<rim:RegistryObjectList/>)"
+    R"(</query:AdhocQueryResponse>)"
+    R"(</soap:Body>)"
+    R"(</soap:Envelope>)";
+
+// RAII wrapper so an override installed on the transport is cleared even
+// if the test body throws.
+struct scoped_transport_override {
+    explicit scoped_transport_override(detail::transport_override fn) {
+        detail::set_http_transport_override(std::move(fn));
+    }
+    ~scoped_transport_override() {
+        detail::clear_http_transport_override();
+    }
+    scoped_transport_override(const scoped_transport_override&) = delete;
+    scoped_transport_override& operator=(const scoped_transport_override&) =
+        delete;
+};
+
+}  // namespace
+
+TEST_CASE("ITI-18 find_documents envelope embeds patient id and status",
+          "[registry_query][envelope]") {
+    auto env = detail::build_iti18_find_documents_envelope(
+        "12345^^^&1.2.3.4.5&ISO",
+        {"urn:oasis:names:tc:ebxml-regrep:StatusType:Approved"});
+    REQUIRE(env.is_ok());
+    const auto& xml = env.value().xml;
+
+    // Sanity: the action URI, the stored-query id, and both slot names
+    // all have to reach the wire.
+    CHECK(xml.find("urn:ihe:iti:2007:RegistryStoredQuery") !=
+          std::string::npos);
+    CHECK(xml.find("urn:uuid:14d4debf-8f97-4251-9a1e-8aabd7b6f011") !=
+          std::string::npos);
+    CHECK(xml.find("$XDSDocumentEntryPatientId") != std::string::npos);
+    CHECK(xml.find("$XDSDocumentEntryStatus") != std::string::npos);
+    CHECK(xml.find("12345") != std::string::npos);
+}
+
+TEST_CASE("ITI-18 find_documents rejects empty patient id",
+          "[registry_query][input_validation]") {
+    auto env = detail::build_iti18_find_documents_envelope(
+        "", {"urn:oasis:names:tc:ebxml-regrep:StatusType:Approved"});
+    REQUIRE(env.is_err());
+    CHECK(env.error().code() ==
+          static_cast<int>(
+              error_code::consumer_query_missing_patient_id));
+}
+
+TEST_CASE("ITI-18 get_documents envelope embeds uuid list",
+          "[registry_query][envelope]") {
+    auto env = detail::build_iti18_get_documents_envelope(
+        {"urn:uuid:aaaa-1111", "urn:uuid:bbbb-2222"});
+    REQUIRE(env.is_ok());
+    const auto& xml = env.value().xml;
+
+    CHECK(xml.find("urn:uuid:5c4f972b-d56b-40ac-a5fc-c8ca9b40b9d4") !=
+          std::string::npos);
+    CHECK(xml.find("$XDSDocumentEntryUUID") != std::string::npos);
+    CHECK(xml.find("urn:uuid:aaaa-1111") != std::string::npos);
+    CHECK(xml.find("urn:uuid:bbbb-2222") != std::string::npos);
+}
+
+TEST_CASE("ITI-18 get_documents rejects empty uuid list",
+          "[registry_query][input_validation]") {
+    auto env = detail::build_iti18_get_documents_envelope({});
+    REQUIRE(env.is_err());
+    CHECK(env.error().code() ==
+          static_cast<int>(error_code::consumer_query_empty_uuid_list));
+}
+
+TEST_CASE("ITI-18 parser returns two entries with XDSDocumentEntry slots",
+          "[registry_query][parser][happy_path]") {
+    auto parsed = detail::parse_query_response(kTwoEntryResponse);
+    REQUIRE(parsed.is_ok());
+    const auto& result = parsed.value();
+    REQUIRE(result.entries.size() == 2);
+
+    const auto& first = result.entries[0];
+    CHECK(first.entry_uuid == "urn:uuid:aaaa-1111");
+    CHECK(first.mime_type == "application/dicom");
+    CHECK(first.document_unique_id == "1.2.840.10008.5.1.4.1.1.2.99991");
+    CHECK(first.patient_id == "12345^^^&1.2.3.4.5&ISO");
+    CHECK(first.creation_time == "20260422120000");
+    CHECK(first.repository_unique_id == "1.2.276.0.7230010.3.0.3.6.2");
+
+    const auto& second = result.entries[1];
+    CHECK(second.entry_uuid == "urn:uuid:bbbb-2222");
+    CHECK(second.mime_type == "application/pdf");
+    CHECK(second.document_unique_id == "1.2.840.10008.5.1.4.1.1.2.99992");
+    // second entry intentionally lacks creationTime / repositoryUniqueId
+    // / patient_id slots — those come back as empty strings rather than
+    // a parse failure.
+    CHECK(second.creation_time.empty());
+    CHECK(second.repository_unique_id.empty());
+    CHECK(second.patient_id.empty());
+}
+
+TEST_CASE("ITI-18 parser treats empty RegistryObjectList as zero-matches",
+          "[registry_query][parser][no_results]") {
+    auto parsed = detail::parse_query_response(kEmptyResponse);
+    REQUIRE(parsed.is_ok());
+    CHECK(parsed.value().entries.empty());
+    CHECK(parsed.value().registry_response_status ==
+          "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success");
+}
+
+TEST_CASE("ITI-18 parser reports Failure status as a typed error",
+          "[registry_query][parser]") {
+    constexpr const char* kFailure =
+        R"(<?xml version="1.0" encoding="UTF-8"?>)"
+        R"(<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" )"
+        R"(xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0">)"
+        R"(<soap:Body><query:AdhocQueryResponse )"
+        R"(status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure"/>)"
+        R"(</soap:Body></soap:Envelope>)";
+    auto parsed = detail::parse_query_response(kFailure);
+    REQUIRE(parsed.is_err());
+    CHECK(parsed.error().code() ==
+          static_cast<int>(
+              error_code::consumer_query_response_parse_failed));
+}
+
+TEST_CASE("ITI-18 registry_query propagates TLS transport failure",
+          "[registry_query][transport][tls_failure]") {
+    scoped_transport_override guard([](const detail::transport_request& req)
+                                        -> kcenon::common::Result<
+                                            detail::http_response> {
+        // Assert the request the actor built reaches the transport with
+        // the ITI-18 action URI and the stored-query envelope payload.
+        CHECK(req.soap_action == "urn:ihe:iti:2007:RegistryStoredQuery");
+        CHECK(req.body.find(
+                  "urn:uuid:14d4debf-8f97-4251-9a1e-8aabd7b6f011") !=
+              std::string::npos);
+        return kcenon::common::make_error<detail::http_response>(
+            static_cast<int>(error_code::transport_tls_error),
+            "simulated TLS handshake failure for test",
+            std::string(error_source));
+    });
+
+    registry_query q(make_opts(), make_signing());
+    auto result = q.find_documents("12345^^^&1.2.3.4.5&ISO");
+    REQUIRE(result.is_err());
+    CHECK(result.error().code() ==
+          static_cast<int>(error_code::transport_tls_error));
+}
+
+TEST_CASE("ITI-18 registry_query returns matching entries end-to-end",
+          "[registry_query][integration]") {
+    scoped_transport_override guard([](const detail::transport_request&)
+                                        -> kcenon::common::Result<
+                                            detail::http_response> {
+        detail::http_response r;
+        r.status_code = 200;
+        r.content_type = "application/soap+xml; charset=UTF-8";
+        r.body = kTwoEntryResponse;
+        return r;
+    });
+
+    registry_query q(make_opts(), make_signing());
+    auto result = q.find_documents("12345^^^&1.2.3.4.5&ISO");
+    REQUIRE(result.is_ok());
+    CHECK(result.value().entries.size() == 2);
+    CHECK(result.value().entries[0].document_unique_id ==
+          "1.2.840.10008.5.1.4.1.1.2.99991");
+}


### PR DESCRIPTION
## What

Implements the IHE XDS.b **Registry Query** actor (ITI-18 Registry Stored Query).
New public class `kcenon::pacs::ihe::xds::registry_query` exposes the two most
commonly deployed ebRS stored queries:

- `find_documents(patient_id, statuses={Approved})` — discover documents by
  CX-formatted patient identifier, optionally narrowed by status URI. Uses
  `urn:uuid:14d4debf-8f97-4251-9a1e-8aabd7b6f011`.
- `get_documents(uuids)` — resolve explicit `XDSDocumentEntry` UUIDs to
  their metadata. Uses `urn:uuid:5c4f972b-d56b-40ac-a5fc-c8ca9b40b9d4`.

Returns a `registry_query_result` containing the Registry response status and a
vector of `document_entry` metadata rows (entry_uuid, document_unique_id,
patient_id, mime_type, status, creation_time, repository_unique_id).

### Change Type
- [x] Feature
- [ ] Bugfix
- [ ] Refactor

### Affected Components
| Area | Change |
|------|--------|
| Public API | New `include/kcenon/pacs/ihe/xds/registry_query.h` |
| Library internals | New `src/ihe/xds/registry_query/` (envelope + parser) |
| Orchestrator | New `src/ihe/xds/registry_query.cpp` |
| Errors | Added codes 120-122 under `consumer_query_*` |
| Tests | New `tests/ihe/xds/registry_query_test.cpp` (9 cases) |
| Build | Added sources to `pacs_ihe_xds` target; wired test binary |

## Why

Closes #1130. Stored queries are the discovery mechanism of XDS.b; without
them the Document Consumer (ITI-43) cannot locate document UIDs for a given
patient. Part of the broader IHE XDS.b profile tracked in #1101.

### Alternatives Considered
- **Bundle ATNA audit here** — rejected per issue boundary; audit is
  #1131's scope and would mix two concerns into one reviewable PR.
- **Reuse `document_consumer::impl` as a template** — rejected because
  ITI-18 has no MTOM on either direction and no response signature
  verification, so the orchestration sequence is materially shorter.
  Followed the same pimpl shape for API consistency instead.

## How

### Technical Approach

1. **Envelope builder** (`query_envelope.{h,cpp}`) — pugixml-backed, emits
   `query:AdhocQueryRequest` / `query:ResponseOption` / `rim:AdhocQuery` with
   slot values formatted as the ebRS quoted-list grammar `('v1','v2')`.
   Mirrors the serialization policy of `retrieve_envelope.cpp` (UTF-8,
   `pugi::format_raw | format_no_declaration`) so the shared canonicalization
   layer in `wss_signer` sees identical framing across all three actors.
2. **Response parser** (`query_response_parser.{h,cpp}`) — walks
   `query:AdhocQueryResponse` / `rim:RegistryObjectList` via
   `local-name()` XPath selectors, so Registry stacks that pick different
   prefixes for the `query` / `rim` / `rs` namespaces (Apache CXF, .NET
   WIF, Gazelle) all parse correctly. Treats an empty list as a legal
   zero-matches Success; `Failure` and `PartialSuccess` map to typed errors.
3. **Orchestrator** (`registry_query.cpp`) — pimpl `registry_query::impl`
   validates input, calls the envelope builder, invokes `sign_envelope`,
   overrides `soap_action` to `urn:ihe:iti:2007:RegistryStoredQuery`, POSTs
   via `http_post`, and parses the response body. Per-call copy of
   `http_options` keeps the caller's soap_action intact.

### Acceptance Criteria
- [x] `registry_query::find_documents(patient_id)` returns matching
      document metadata entries (happy-path integration test)
- [x] `registry_query::get_documents(uuids)` resolves explicit UUID
      lookups (envelope-level test; response parsing covered by the
      shared `parse_query_response` suite)
- [x] ITI-18 request structure exercised by envelope tests covering the
      Action URI, stored-query id, and slot names
- [x] Unit tests cover the four mandated scenarios:
  - [x] happy path (two-entry Success response)
  - [x] no-results (empty RegistryObjectList)
  - [x] malformed patient ID (empty string → typed error without network call)
  - [x] TLS failure (transport_override emits `transport_tls_error`)
- [x] Header `include/kcenon/pacs/ihe/xds/registry_query.h` public

### Testing Done
- [x] 9 new Catch2 cases in `tests/ihe/xds/registry_query_test.cpp`
- [x] Transport mocked via existing `detail::set_http_transport_override`
      hook — no live Registry required
- [x] Reaches internal detail headers using the same relative-include
      pattern as `document_consumer_test.cpp`

No local C++ toolchain available in this environment; build and test
verification rides on CI (Ubuntu/macOS/Windows multi-platform matrix).

### Breaking Changes
None. Public API additions only; no existing symbols renamed or removed.

### Rollback Plan
Revert the two commits. The `pacs_ihe_xds` target still builds cleanly
without the three new source files because they are additive. The
`errors.h` additions are at the end of the enum, so ABI for existing
`error_code` values is preserved.

## Related

- Closes #1130
- Part of #1101 (XDS.b profile completion)
- Sibling to #1131 (ATNA audit for XDS transactions) — intentionally NOT
  wired here; ITI-18 audit emission lands with that issue.