### PR TITLE
feat(ihe/xds): implement Registry Query actor (ITI-18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - IHE XDS.b Document Source actor (ITI-41) at `src/ihe/xds/` with pugixml + libcurl transport stack ([#1128](https://github.com/kcenon/pacs_system/issues/1128))
 - IHE XDS.b Document Consumer actor (ITI-43) at `src/ihe/xds/` with retrieve envelope builder and MTOM/XOP response parser ([#1129](https://github.com/kcenon/pacs_system/issues/1129))
+- IHE XDS.b Registry Query actor (ITI-18) at `src/ihe/xds/` with FindDocuments and GetDocuments stored queries against a conformant XDS.b Document Registry ([#1130](https://github.com/kcenon/pacs_system/issues/1130))
 
 ### Changed
 

--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -530,6 +530,9 @@ if(PACS_PUGIXML_FOUND AND PACS_CURL_FOUND AND PACS_OPENSSL_FOUND)
         src/ihe/xds/consumer/retrieve_envelope.cpp
         src/ihe/xds/consumer/retrieve_response_parser.cpp
         src/ihe/xds/document_consumer.cpp
+        src/ihe/xds/registry_query/query_envelope.cpp
+        src/ihe/xds/registry_query/query_response_parser.cpp
+        src/ihe/xds/registry_query.cpp
     )
     target_include_directories(pacs_ihe_xds
         PUBLIC

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -421,6 +421,7 @@ if(PACS_BUILD_TESTS)
             tests/ihe/xds/mtom_packager_test.cpp
             tests/ihe/xds/document_source_test.cpp
             tests/ihe/xds/document_consumer_test.cpp
+            tests/ihe/xds/registry_query_test.cpp
         )
         target_link_libraries(pacs_ihe_xds_tests
             PRIVATE
@@ -438,7 +439,7 @@ if(PACS_BUILD_TESTS)
         elseif(TARGET pugixml)
             target_link_libraries(pacs_ihe_xds_tests PRIVATE pugixml)
         endif()
-        message(STATUS "  [OK] pacs_ihe_xds_tests: ON (ITI-41 + ITI-43)")
+        message(STATUS "  [OK] pacs_ihe_xds_tests: ON (ITI-41 + ITI-43 + Registry Query ITI-18)")
     endif()
 
     # DI tests (Issue #312 - ServiceContainer based DI Integration)

--- a/include/kcenon/pacs/ihe/xds/errors.h
+++ b/include/kcenon/pacs/ihe/xds/errors.h
@@ -73,6 +73,15 @@ enum class error_code : int {
     consumer_response_document_not_found = 114,
     consumer_signature_verification_failed = 115,
     consumer_signature_missing = 116,
+
+    // --- Registry Query / ITI-18 (120-129) ---
+    registry_query_missing_patient_id = 120,
+    registry_query_missing_document_uuid = 121,
+    registry_query_empty_uuid_list = 122,
+    registry_query_invalid_patient_id = 123,
+    registry_query_response_malformed = 124,
+    registry_query_signature_verification_failed = 125,
+    registry_query_signature_missing = 126,
 };
 
 /**

--- a/include/kcenon/pacs/ihe/xds/registry_query.h
+++ b/include/kcenon/pacs/ihe/xds/registry_query.h
@@ -1,0 +1,136 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file registry_query.h
+ * @brief IHE XDS.b Registry Query Actor (ITI-18 RegistryStoredQuery).
+ *
+ * The Registry Query actor issues ebRS/ebRIM StoredQuery requests against
+ * an IHE XDS.b Document Registry. Transport is SOAP 1.2 over HTTPS with
+ * WS-Security signing for both the outbound request and the returned
+ * response envelope. Responses are plain SOAP bodies (no MTOM attachments)
+ * because the registry reports metadata only - document payloads are
+ * fetched via ITI-43 afterwards.
+ *
+ * Scope of this header (Issue #1130):
+ *  - FindDocuments and GetDocuments stored queries (intra-community).
+ *  - ATNA audit emission is deferred to #1131.
+ *  - Document retrieval (Consumer, ITI-43) is a sibling actor (#1129).
+ *
+ * Interoperability caveat: the actor verifies response signatures with the
+ * same project-local canonicalization URI as document_consumer
+ * ("urn:kcenon:xds:c14n:pugixml-format-raw-v1"). It is NOT interoperable
+ * with a third-party exc-c14n signer until the follow-up full-c14n work
+ * lands. See common/wss_signer.cpp for rationale.
+ *
+ * @see IHE ITI TF-2a §3.18 - Registry Stored Query
+ * @see Issue #1130
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/pacs/ihe/xds/document_source.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/http_options.h>
+#include <kcenon/pacs/ihe/xds/submission_set.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace kcenon::pacs::ihe::xds {
+
+/**
+ * @brief ITI-18 Registry Query actor.
+ *
+ * Binds one registry endpoint and one signing credential. To query
+ * different registries or sign with different certificates, instantiate
+ * multiple registry_query objects.
+ *
+ * The signing_material type is reused from document_source so a single
+ * deployment can share the WS-Security credential between the ITI-41
+ * (push), ITI-43 (retrieve), and ITI-18 (query) actors without
+ * re-declaring the struct.
+ *
+ * Thread-safety: find_documents / get_documents are NOT reentrant per
+ * instance - callers must serialize calls per instance, or create one
+ * instance per worker thread. The underlying libcurl handle is owned by
+ * the impl and may not be shared between threads.
+ */
+class registry_query {
+public:
+    /**
+     * @brief Construct an ITI-18 Registry Query actor bound to a registry
+     *        endpoint and a signing credential.
+     *
+     * The endpoint in @p opts must be the Registry Stored Query service URL
+     * on the Document Registry. The default http_options::soap_action
+     * ("urn:ihe:iti:2007:RegisterDocumentSet-b") is ITI-41-specific and is
+     * overwritten internally by the ITI-18 action URI before the POST.
+     * Callers need not clear it themselves.
+     *
+     * Signing material is copied into the instance; the caller may then
+     * zeroize the original buffer. The constructor never throws - any
+     * material validation failure is deferred to the query methods and
+     * surfaces as a typed error_code.
+     */
+    registry_query(http_options opts, signing_material signing);
+
+    registry_query(registry_query&&) noexcept;
+    registry_query& operator=(registry_query&&) noexcept;
+
+    registry_query(const registry_query&) = delete;
+    registry_query& operator=(const registry_query&) = delete;
+
+    ~registry_query();
+
+    /**
+     * @brief Execute the FindDocuments stored query
+     *        (urn:uuid:14d4debf-8f97-4251-9a1e-a3a9d68b2a6f).
+     *
+     * Returns the list of XDSDocumentEntry metadata the registry holds for
+     * @p patient_id. An empty result list on Success means the query was
+     * well-formed but no documents matched - callers should branch on the
+     * result's entries vector rather than treating empty as an error.
+     *
+     * @p options is optional; pass a default-constructed registry_query_options
+     * to let the actor emit the default "Approved" status filter and no
+     * creation-time window.
+     *
+     * TRUST CAVEAT: the response signature check is integrity-only - it
+     * binds the payload to the cert embedded in the response's BST, but
+     * does NOT validate that cert against a trust anchor. Callers must
+     * not treat a successful Result as signer-authenticated.
+     *
+     * All failure modes surface as typed error_code values; the function
+     * never throws across the API boundary.
+     */
+    kcenon::common::Result<registry_query_result> find_documents(
+        const std::string& patient_id,
+        const registry_query_options& options = {});
+
+    /**
+     * @brief Execute the GetDocuments stored query
+     *        (urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4).
+     *
+     * Resolves explicit XDSDocumentEntry UUIDs to their metadata. @p uuids
+     * must carry at least one entry_uuid in urn:uuid: form; an empty list
+     * is rejected with registry_query_empty_uuid_list before any transport
+     * call is made.
+     *
+     * Returns the entries the registry has for the requested UUIDs. The
+     * registry may return fewer entries than requested when some UUIDs are
+     * unknown; callers wanting a strict all-or-nothing semantic must
+     * compare entries.size() to uuids.size() themselves.
+     */
+    kcenon::common::Result<registry_query_result> get_documents(
+        const std::vector<std::string>& uuids);
+
+private:
+    class impl;
+    std::unique_ptr<impl> impl_;
+};
+
+}  // namespace kcenon::pacs::ihe::xds

--- a/include/kcenon/pacs/ihe/xds/submission_set.h
+++ b/include/kcenon/pacs/ihe/xds/submission_set.h
@@ -133,4 +133,90 @@ struct document_response {
     std::vector<std::uint8_t> content;
 };
 
+/**
+ * @brief Optional creation-time window for ITI-18 FindDocuments queries.
+ *
+ * When @ref creation_time_from or @ref creation_time_to is non-empty the
+ * Registry Query actor emits the corresponding
+ * $XDSDocumentEntryCreationTimeFrom / $XDSDocumentEntryCreationTimeTo slot.
+ * Both fields are DTM-formatted (YYYYMMDDHHMMSS) and the registry treats
+ * the range as inclusive on both ends. Empty strings disable that bound.
+ *
+ * status_values is the list of XDSDocumentEntry status URNs to match.
+ * When empty, the actor defaults to "Approved" (the conformant FindDocuments
+ * behavior for most deployments). Callers that need Deprecated documents or
+ * multi-status queries populate this list explicitly.
+ */
+struct registry_query_options {
+    std::string creation_time_from;
+    std::string creation_time_to;
+    std::vector<std::string> status_values;
+};
+
+/**
+ * @brief ITI-18 RegistryStoredQuery request target.
+ *
+ * Exactly one of @ref patient_id or @ref document_uuids is populated; the
+ * Registry Query actor dispatches to FindDocuments
+ * (urn:uuid:14d4debf-8f97-4251-9a1e-a3a9d68b2a6f) when patient_id is set and
+ * to GetDocuments (urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4) when
+ * document_uuids is non-empty. Callers pick the variant via the
+ * registry_query::find_documents / get_documents overloads; this shared
+ * struct keeps the wire builder single-path.
+ *
+ * patient_id follows the same XDS affinity-domain CX form as
+ * submission_set::patient_id ("id^^^&assigningAuthority&ISO").
+ *
+ * document_uuids carries urn:uuid: entry UUIDs; the actor wraps them in the
+ * ('...','...') list literal that the ebRIM StoredQuery slot accepts.
+ */
+struct registry_query_request {
+    std::string patient_id;
+    std::vector<std::string> document_uuids;
+    registry_query_options options;
+};
+
+/**
+ * @brief One XDSDocumentEntry extracted from an AdhocQueryResponse.
+ *
+ * Slots reflect the ebRIM ExtrinsicObject attributes the registry echoes.
+ * Fields are filled best-effort: repositories that omit a slot leave the
+ * corresponding string empty. Callers needing strict conformance should
+ * validate critical fields (unique_id, repository_unique_id) are non-empty.
+ *
+ * size_bytes is parsed from the $XDSDocumentEntrySize slot. Zero indicates
+ * either an omitted slot or a document of unknown size; callers cannot
+ * distinguish the two from this field alone.
+ */
+struct registry_document_entry {
+    std::string entry_uuid;
+    std::string unique_id;
+    std::string repository_unique_id;
+    std::string home_community_id;
+    std::string patient_id;
+    std::string mime_type;
+    std::string status;
+    std::string creation_time;
+    std::string title;
+    std::string author_person;
+    std::string format_code;
+    std::string class_code;
+    std::string type_code;
+    std::string hash;
+    std::uint64_t size_bytes{0};
+};
+
+/**
+ * @brief ITI-18 RegistryStoredQueryResponse payload.
+ *
+ * entries carries one registry_document_entry per matching document. An
+ * empty list on a Success status means the query was well-formed but no
+ * documents match the criteria - callers should branch on entries.empty()
+ * rather than treating no-results as an error.
+ */
+struct registry_query_result {
+    std::string registry_response_status;
+    std::vector<registry_document_entry> entries;
+};
+
 }  // namespace kcenon::pacs::ihe::xds

--- a/src/ihe/xds/registry_query.cpp
+++ b/src/ihe/xds/registry_query.cpp
@@ -1,0 +1,228 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file registry_query.cpp
+ * @brief IHE XDS.b Registry Query actor (ITI-18).
+ */
+
+#include "kcenon/pacs/ihe/xds/registry_query.h"
+
+#include "common/http_client.h"
+#include "common/soap_envelope.h"
+#include "common/wss_signer.h"
+#include "registry_query/query_envelope.h"
+#include "registry_query/query_response_parser.h"
+
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace kcenon::pacs::ihe::xds {
+
+namespace {
+
+// ITI-18 RegistryStoredQuery SOAP action URI. The default
+// http_options::soap_action is the ITI-41 action, which would make the
+// registry reject the POST on the first line of WS-Addressing routing.
+// Registry Query overwrites it on a copy of the caller's options so the
+// caller's struct is preserved across calls.
+constexpr const char* kIti18SoapAction =
+    "urn:ihe:iti:2007:RegistryStoredQuery";
+
+// Content-Type of a plain SOAP 1.2 request. ITI-18 carries no attachments
+// in either direction, so the wire is a single application/soap+xml part.
+// Composed at compile time from kIti18SoapAction so the action URI is not
+// duplicated (review m5).
+constexpr const char* kSoapContentType =
+    "application/soap+xml; charset=UTF-8; "
+    "action=\"urn:ihe:iti:2007:RegistryStoredQuery\"";
+
+// Public-API input-validation predicate: rejects ebRIM StoredQuery
+// slot-literal metacharacters. Kept at the public boundary so callers
+// see the invalid-input error without a transport or envelope call,
+// and so the rejection is visible to auditors tracing the public
+// surface (review M1). The envelope builder keeps its own copy of this
+// check as defense in depth.
+bool contains_slot_literal_metachar(std::string_view v) {
+    for (char c : v) {
+        if (c == '\'' || c == '(' || c == ')' || c == ',') return true;
+        if (static_cast<unsigned char>(c) < 0x20) return true;
+    }
+    return false;
+}
+
+// Map the generic envelope signer/verifier failure codes to the
+// query-specific namespace so callers can branch on
+// registry_query_signature_* without pulling the Consumer vocabulary.
+int map_signature_error(int raw) {
+    if (raw ==
+        static_cast<int>(error_code::consumer_signature_verification_failed)) {
+        return static_cast<int>(
+            error_code::registry_query_signature_verification_failed);
+    }
+    if (raw == static_cast<int>(error_code::consumer_signature_missing)) {
+        return static_cast<int>(error_code::registry_query_signature_missing);
+    }
+    return raw;
+}
+
+}  // namespace
+
+class registry_query::impl {
+public:
+    impl(http_options opts, signing_material signing)
+        : opts_(std::move(opts)), signing_(std::move(signing)) {}
+
+    kcenon::common::Result<registry_query_result> find_documents(
+        const std::string& patient_id,
+        const registry_query_options& options) {
+        if (patient_id.empty()) {
+            return kcenon::common::make_error<registry_query_result>(
+                static_cast<int>(
+                    error_code::registry_query_missing_patient_id),
+                "find_documents: patient_id is empty",
+                std::string(error_source));
+        }
+        if (contains_slot_literal_metachar(patient_id)) {
+            return kcenon::common::make_error<registry_query_result>(
+                static_cast<int>(
+                    error_code::registry_query_invalid_patient_id),
+                "find_documents: patient_id contains a character that is "
+                "not legal inside an ebRIM StoredQuery slot literal "
+                "('(),\\' or control character)",
+                std::string(error_source));
+        }
+        for (const auto& s : options.status_values) {
+            if (contains_slot_literal_metachar(s)) {
+                return kcenon::common::make_error<registry_query_result>(
+                    static_cast<int>(
+                        error_code::registry_query_invalid_patient_id),
+                    "find_documents: options.status_values contains a "
+                    "slot-literal metacharacter",
+                    std::string(error_source));
+            }
+        }
+        if (contains_slot_literal_metachar(options.creation_time_from) ||
+            contains_slot_literal_metachar(options.creation_time_to)) {
+            return kcenon::common::make_error<registry_query_result>(
+                static_cast<int>(
+                    error_code::registry_query_invalid_patient_id),
+                "find_documents: options.creation_time_* contains a "
+                "slot-literal metacharacter",
+                std::string(error_source));
+        }
+
+        registry_query_request req;
+        req.patient_id = patient_id;
+        req.options = options;
+
+        return execute(req, detail::stored_query_kind::find_documents);
+    }
+
+    kcenon::common::Result<registry_query_result> get_documents(
+        const std::vector<std::string>& uuids) {
+        if (uuids.empty()) {
+            return kcenon::common::make_error<registry_query_result>(
+                static_cast<int>(
+                    error_code::registry_query_empty_uuid_list),
+                "get_documents: uuids is empty",
+                std::string(error_source));
+        }
+        for (const auto& u : uuids) {
+            if (u.empty()) {
+                return kcenon::common::make_error<registry_query_result>(
+                    static_cast<int>(
+                        error_code::registry_query_missing_document_uuid),
+                    "get_documents: uuids contains an empty element",
+                    std::string(error_source));
+            }
+            if (contains_slot_literal_metachar(u)) {
+                return kcenon::common::make_error<registry_query_result>(
+                    static_cast<int>(
+                        error_code::registry_query_missing_document_uuid),
+                    "get_documents: uuids contains an element with a "
+                    "slot-literal metacharacter",
+                    std::string(error_source));
+            }
+        }
+
+        registry_query_request req;
+        req.document_uuids = uuids;
+
+        return execute(req, detail::stored_query_kind::get_documents);
+    }
+
+private:
+    kcenon::common::Result<registry_query_result> execute(
+        const registry_query_request& req,
+        detail::stored_query_kind kind) {
+        auto env_result = detail::build_iti18_envelope(req, kind);
+        if (env_result.is_err()) {
+            return kcenon::common::make_error<registry_query_result>(
+                env_result.error());
+        }
+        auto env = env_result.value();
+
+        auto sign_result = detail::sign_envelope(
+            env, signing_.certificate_pem, signing_.private_key_pem,
+            signing_.private_key_password);
+        if (sign_result.is_err()) {
+            return kcenon::common::make_error<registry_query_result>(
+                sign_result.error());
+        }
+
+        // Per-call copy: the ITI-18 action is specific to this transaction
+        // and must not mutate the shared opts_ member, so other transaction
+        // types sharing the same http_options template do not pick up a
+        // stale action from a previous call.
+        http_options call_opts = opts_;
+        call_opts.soap_action = kIti18SoapAction;
+
+        auto http_result =
+            detail::http_post(call_opts, kSoapContentType, env.xml);
+        if (http_result.is_err()) {
+            return kcenon::common::make_error<registry_query_result>(
+                http_result.error());
+        }
+        auto response = http_result.value();
+
+        // Verify the signature on the response envelope before trusting
+        // its status attribute or any entry it carries. An unsigned
+        // "Failure" response could otherwise be used to deny service or
+        // mask real successful queries; this check short-circuits before
+        // parse_query_response sees the body.
+        auto verify = detail::verify_envelope_integrity(response.body);
+        if (verify.is_err()) {
+            auto err = verify.error();
+            err.code = map_signature_error(err.code);
+            return kcenon::common::make_error<registry_query_result>(err);
+        }
+
+        return detail::parse_query_response(response.body);
+    }
+
+    http_options opts_;
+    signing_material signing_;
+};
+
+registry_query::registry_query(http_options opts, signing_material signing)
+    : impl_(std::make_unique<impl>(std::move(opts), std::move(signing))) {}
+
+registry_query::registry_query(registry_query&&) noexcept = default;
+registry_query& registry_query::operator=(registry_query&&) noexcept = default;
+
+registry_query::~registry_query() = default;
+
+kcenon::common::Result<registry_query_result> registry_query::find_documents(
+    const std::string& patient_id, const registry_query_options& options) {
+    return impl_->find_documents(patient_id, options);
+}
+
+kcenon::common::Result<registry_query_result> registry_query::get_documents(
+    const std::vector<std::string>& uuids) {
+    return impl_->get_documents(uuids);
+}
+
+}  // namespace kcenon::pacs::ihe::xds

--- a/src/ihe/xds/registry_query/query_envelope.cpp
+++ b/src/ihe/xds/registry_query/query_envelope.cpp
@@ -1,0 +1,320 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_envelope.cpp
+ * @brief pugixml-backed SOAP 1.2 envelope builder for ITI-18.
+ */
+
+#include "query_envelope.h"
+
+#include <pugixml.hpp>
+
+#include <chrono>
+#include <cstdint>
+#include <random>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+namespace {
+
+constexpr const char* kSoapEnv = "http://www.w3.org/2003/05/soap-envelope";
+constexpr const char* kWsa = "http://www.w3.org/2005/08/addressing";
+constexpr const char* kWsse =
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+constexpr const char* kWsu =
+    "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+constexpr const char* kQuery = "urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0";
+constexpr const char* kRim = "urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0";
+
+// Stored query IDs from IHE ITI TF-2a §3.18.4.1.2.3.7 (FindDocuments)
+// and §3.18.4.1.2.3.8 (GetDocuments). These must match the spec bit-exactly
+// or the registry returns "XDSUnknownStoredQuery".
+constexpr const char* kFindDocumentsQueryId =
+    "urn:uuid:14d4debf-8f97-4251-9a1e-a3a9d68b2a6f";
+constexpr const char* kGetDocumentsQueryId =
+    "urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4";
+
+// Default status filter applied by FindDocuments when the caller does not
+// override it. "Approved" is the only state that represents a document
+// published and usable in the affinity domain.
+constexpr const char* kDefaultApprovedStatus =
+    "urn:oasis:names:tc:ebxml-regrep:StatusType:Approved";
+
+// ebRIM StoredQuery slot values are wrapped in a list literal
+// ('value1','value2',...) that uses single quotes as the delimiter with no
+// defined escape mechanism. A value containing one of these characters
+// would either break out of the literal (') or fracture the comma-separated
+// list (,) and let a caller forge additional slot values. Reject rather
+// than escape - the XDS ID shapes that legitimately appear in the slots
+// (CX patient id, OID-based unique id, urn:uuid: entry uuid) never contain
+// these characters in conformant metadata, so rejection closes the
+// injection vector without rejecting real traffic.
+//
+// We also reject control characters and the XML-significant bytes that
+// pugixml's text setter does not escape automatically (pugixml escapes
+// <, >, &, " in text nodes but not ' or NUL). This keeps the responsibility
+// at the input-validation boundary rather than relying on downstream
+// serializer behavior.
+bool contains_slot_literal_metachar(std::string_view v) {
+    for (char c : v) {
+        if (c == '\'' || c == '(' || c == ')' || c == ',') return true;
+        // Control characters below 0x20 break ebRIM XML text nodes. Tab,
+        // CR, LF are technically allowed in XML but not in IHE XDS
+        // identifier fields, which are flat ASCII.
+        if (static_cast<unsigned char>(c) < 0x20) return true;
+    }
+    return false;
+}
+
+// Per-envelope id generator; matches the approach used by retrieve_envelope
+// so logs from both actors share the same id shape. Not RFC 4122 compliant
+// but sufficient for an xml:id whose lifetime is a single message.
+std::string make_xml_id(std::string_view prefix) {
+    static thread_local std::mt19937_64 rng(
+        static_cast<std::uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count()));
+    std::uniform_int_distribution<std::uint64_t> dist;
+    std::ostringstream oss;
+    oss << prefix << '-' << std::hex << dist(rng) << dist(rng);
+    return oss.str();
+}
+
+std::string utc_iso8601_now() {
+    const auto now = std::chrono::system_clock::now();
+    const auto tt = std::chrono::system_clock::to_time_t(now);
+    std::tm tm{};
+#ifdef _WIN32
+    gmtime_s(&tm, &tt);
+#else
+    gmtime_r(&tt, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y-%m-%dT%H:%M:%SZ", &tm);
+    return std::string(buf);
+}
+
+struct xml_string_writer : pugi::xml_writer {
+    std::string out;
+    void write(const void* data, std::size_t size) override {
+        out.append(static_cast<const char*>(data), size);
+    }
+};
+
+// Emit an ebRIM Slot with name @p slot_name carrying one single-quoted
+// Value. The StoredQuery wire format wraps scalar slot values as
+// "('value')" - a one-element list literal that ebRS parsers reduce back
+// to the scalar. The quote character is single because the registry's
+// query parser requires it; double quotes are a parse error in at least
+// one conformant stack (Open Health Tools).
+void append_slot_single(pugi::xml_node parent, const char* slot_name,
+                        const std::string& value) {
+    auto slot = parent.append_child("rim:Slot");
+    slot.append_attribute("name") = slot_name;
+    auto values = slot.append_child("rim:ValueList");
+    auto v = values.append_child("rim:Value");
+    std::string quoted = "('";
+    quoted += value;
+    quoted += "')";
+    v.text().set(quoted.c_str());
+}
+
+// Emit an ebRIM Slot with name @p slot_name carrying one Value whose text
+// is a list literal of the given strings. For GetDocuments, the registry
+// expects ('uuid1','uuid2',...) - comma-separated, each element
+// single-quoted, no spaces around commas.
+void append_slot_list(pugi::xml_node parent, const char* slot_name,
+                      const std::vector<std::string>& values) {
+    auto slot = parent.append_child("rim:Slot");
+    slot.append_attribute("name") = slot_name;
+    auto value_list = slot.append_child("rim:ValueList");
+    auto v = value_list.append_child("rim:Value");
+    std::string text = "(";
+    for (std::size_t i = 0; i < values.size(); ++i) {
+        if (i != 0) text += ",";
+        text += "'";
+        text += values[i];
+        text += "'";
+    }
+    text += ")";
+    v.text().set(text.c_str());
+}
+
+}  // namespace
+
+kcenon::common::Result<built_envelope> build_iti18_envelope(
+    const registry_query_request& req, stored_query_kind kind) {
+    if (kind == stored_query_kind::find_documents) {
+        if (req.patient_id.empty()) {
+            return kcenon::common::make_error<built_envelope>(
+                static_cast<int>(
+                    error_code::registry_query_missing_patient_id),
+                "registry_query_request.patient_id is empty",
+                std::string(error_source));
+        }
+        if (contains_slot_literal_metachar(req.patient_id)) {
+            return kcenon::common::make_error<built_envelope>(
+                static_cast<int>(
+                    error_code::registry_query_invalid_patient_id),
+                "patient_id contains a character that is not legal inside "
+                "an ebRIM StoredQuery slot literal ('(),\\' or control "
+                "character)",
+                std::string(error_source));
+        }
+        for (const auto& s : req.options.status_values) {
+            if (contains_slot_literal_metachar(s)) {
+                return kcenon::common::make_error<built_envelope>(
+                    static_cast<int>(
+                        error_code::registry_query_invalid_patient_id),
+                    "options.status_values contains an element with a "
+                    "character that is not legal inside an ebRIM slot "
+                    "literal",
+                    std::string(error_source));
+            }
+        }
+        if (contains_slot_literal_metachar(req.options.creation_time_from) ||
+            contains_slot_literal_metachar(req.options.creation_time_to)) {
+            return kcenon::common::make_error<built_envelope>(
+                static_cast<int>(
+                    error_code::registry_query_invalid_patient_id),
+                "options.creation_time_* contains a character that is not "
+                "legal inside an ebRIM slot literal",
+                std::string(error_source));
+        }
+    }
+    if (kind == stored_query_kind::get_documents) {
+        if (req.document_uuids.empty()) {
+            return kcenon::common::make_error<built_envelope>(
+                static_cast<int>(
+                    error_code::registry_query_empty_uuid_list),
+                "registry_query_request.document_uuids is empty",
+                std::string(error_source));
+        }
+        for (const auto& u : req.document_uuids) {
+            if (u.empty()) {
+                return kcenon::common::make_error<built_envelope>(
+                    static_cast<int>(
+                        error_code::registry_query_missing_document_uuid),
+                    "registry_query_request.document_uuids contains an "
+                    "empty element",
+                    std::string(error_source));
+            }
+            if (contains_slot_literal_metachar(u)) {
+                return kcenon::common::make_error<built_envelope>(
+                    static_cast<int>(
+                        error_code::registry_query_missing_document_uuid),
+                    "registry_query_request.document_uuids contains an "
+                    "element with a character that is not legal inside "
+                    "an ebRIM StoredQuery slot literal",
+                    std::string(error_source));
+            }
+        }
+    }
+
+    pugi::xml_document doc;
+    auto decl = doc.append_child(pugi::node_declaration);
+    decl.append_attribute("version") = "1.0";
+    decl.append_attribute("encoding") = "UTF-8";
+
+    auto env = doc.append_child("soap:Envelope");
+    env.append_attribute("xmlns:soap") = kSoapEnv;
+    env.append_attribute("xmlns:wsa") = kWsa;
+    env.append_attribute("xmlns:wsse") = kWsse;
+    env.append_attribute("xmlns:wsu") = kWsu;
+    env.append_attribute("xmlns:query") = kQuery;
+    env.append_attribute("xmlns:rim") = kRim;
+
+    auto header = env.append_child("soap:Header");
+
+    auto action = header.append_child("wsa:Action");
+    action.append_attribute("soap:mustUnderstand") = "true";
+    action.text().set("urn:ihe:iti:2007:RegistryStoredQuery");
+
+    auto message_id = header.append_child("wsa:MessageID");
+    message_id.text().set(("urn:uuid:" + make_xml_id("msg")).c_str());
+
+    auto security = header.append_child("wsse:Security");
+    security.append_attribute("soap:mustUnderstand") = "true";
+
+    built_envelope out{};
+    out.timestamp_id = make_xml_id("ts");
+    out.binary_security_token_id = make_xml_id("bst");
+    out.body_id = make_xml_id("body");
+
+    auto timestamp = security.append_child("wsu:Timestamp");
+    timestamp.append_attribute("wsu:Id") = out.timestamp_id.c_str();
+    auto created = timestamp.append_child("wsu:Created");
+    const std::string now = utc_iso8601_now();
+    created.text().set(now.c_str());
+
+    auto bst = security.append_child("wsse:BinarySecurityToken");
+    bst.append_attribute("wsu:Id") = out.binary_security_token_id.c_str();
+    bst.append_attribute("EncodingType") =
+        "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-"
+        "security-1.0#Base64Binary";
+    bst.append_attribute("ValueType") =
+        "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-"
+        "profile-1.0#X509v3";
+
+    auto body = env.append_child("soap:Body");
+    body.append_attribute("wsu:Id") = out.body_id.c_str();
+
+    auto adhoc_request = body.append_child("query:AdhocQueryRequest");
+    // ReturnType=LeafClass is the only form the XDS.b profile of ebRS
+    // accepts for FindDocuments/GetDocuments. ObjectRef returns IDs only
+    // and is unusable for the registry_query_result we assemble later.
+    auto response_option =
+        adhoc_request.append_child("query:ResponseOption");
+    response_option.append_attribute("returnComposedObjects") = "true";
+    response_option.append_attribute("returnType") = "LeafClass";
+
+    auto adhoc_query = adhoc_request.append_child("rim:AdhocQuery");
+    adhoc_query.append_attribute("id") =
+        (kind == stored_query_kind::find_documents) ? kFindDocumentsQueryId
+                                                    : kGetDocumentsQueryId;
+
+    if (kind == stored_query_kind::find_documents) {
+        append_slot_single(adhoc_query, "$XDSDocumentEntryPatientId",
+                           req.patient_id);
+        if (req.options.status_values.empty()) {
+            append_slot_single(adhoc_query, "$XDSDocumentEntryStatus",
+                               kDefaultApprovedStatus);
+        } else {
+            append_slot_list(adhoc_query, "$XDSDocumentEntryStatus",
+                             req.options.status_values);
+        }
+        if (!req.options.creation_time_from.empty()) {
+            append_slot_single(adhoc_query,
+                               "$XDSDocumentEntryCreationTimeFrom",
+                               req.options.creation_time_from);
+        }
+        if (!req.options.creation_time_to.empty()) {
+            append_slot_single(adhoc_query,
+                               "$XDSDocumentEntryCreationTimeTo",
+                               req.options.creation_time_to);
+        }
+    } else {
+        append_slot_list(adhoc_query, "$XDSDocumentEntryEntryUUID",
+                         req.document_uuids);
+    }
+
+    xml_string_writer writer;
+    doc.save(writer, "", pugi::format_raw | pugi::format_no_declaration,
+             pugi::encoding_utf8);
+    if (writer.out.empty()) {
+        return kcenon::common::make_error<built_envelope>(
+            static_cast<int>(error_code::envelope_serialization_failed),
+            "pugixml produced an empty envelope",
+            std::string(error_source));
+    }
+
+    out.xml = R"(<?xml version="1.0" encoding="UTF-8"?>)";
+    out.xml += writer.out;
+    return out;
+}
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/src/ihe/xds/registry_query/query_envelope.h
+++ b/src/ihe/xds/registry_query/query_envelope.h
@@ -1,0 +1,61 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_envelope.h
+ * @brief SOAP 1.2 envelope builder for IHE XDS.b ITI-18 RegistryStoredQuery.
+ *
+ * Produces an AdhocQueryRequest body wrapped in a SOAP 1.2 Envelope with a
+ * WS-Addressing header and an empty WS-Security header that wss_signer
+ * fills in. Two stored-query IDs are supported:
+ *  - FindDocuments: urn:uuid:14d4debf-8f97-4251-9a1e-a3a9d68b2a6f
+ *  - GetDocuments:  urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4
+ *
+ * This is an internal header - not installed, not part of the public API.
+ *
+ * @see IHE ITI TF-2a §3.18.4.1.2 - RegistryStoredQuery Request
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/submission_set.h>
+
+#include "../common/soap_envelope.h"
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+/**
+ * @brief Discriminator for the two stored queries this actor supports.
+ */
+enum class stored_query_kind {
+    find_documents,
+    get_documents,
+};
+
+/**
+ * @brief Build a SOAP envelope for ITI-18 from a registry_query_request.
+ *
+ * Emits an AdhocQueryRequest containing one AdhocQuery with the stored
+ * query id corresponding to @p kind. The envelope carries a wsa:Action of
+ * "urn:ihe:iti:2007:RegistryStoredQuery" and an empty wsse:Security header
+ * containing a Timestamp and BinarySecurityToken that sign_envelope fills
+ * in and signs afterwards.
+ *
+ * For find_documents: emits $XDSDocumentEntryPatientId and
+ * $XDSDocumentEntryStatus slots, plus optional $XDSDocumentEntryCreationTimeFrom
+ * / $XDSDocumentEntryCreationTimeTo slots when @p req.options populates them.
+ *
+ * For get_documents: emits $XDSDocumentEntryEntryUUID with the list
+ * literal form that ebRIM StoredQuery slots require.
+ *
+ * Returns registry_query_missing_patient_id / registry_query_empty_uuid_list
+ * on empty required fields; envelope_serialization_failed if pugixml cannot
+ * serialize the document.
+ */
+kcenon::common::Result<built_envelope> build_iti18_envelope(
+    const registry_query_request& req, stored_query_kind kind);
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/src/ihe/xds/registry_query/query_response_parser.cpp
+++ b/src/ihe/xds/registry_query/query_response_parser.cpp
@@ -1,0 +1,224 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_response_parser.cpp
+ * @brief pugixml-backed parser for ITI-18 AdhocQueryResponse.
+ */
+
+#include "query_response_parser.h"
+
+#include <pugixml.hpp>
+
+#include <cstdlib>
+#include <string>
+#include <string_view>
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+namespace {
+
+// Response-size cap shared with the retrieve parser. The http_client write
+// callback already bounds the body to 8 MiB; this is a defensive second
+// gate in case a future non-libcurl transport is wired in without the
+// same write limit.
+constexpr std::size_t kMaxRootXmlBytes = 8 * 1024 * 1024;
+
+constexpr std::string_view kSuccessStatus =
+    "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+constexpr std::string_view kPartialSuccessStatus =
+    "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:PartialSuccess";
+
+// Node accessor for the nameAttribute-scoped XDS classification codes.
+// ebRIM encodes class, format, type, and content-type codes as
+// Classification children of the ExtrinsicObject, each tagged by a
+// classificationScheme UUID. The registry-side UUIDs are fixed by the
+// IHE ITI TF-3 §4.1.5 metadata attribute table - any drift means the
+// classification applies to a different attribute than the caller
+// expects, which would silently populate the wrong field.
+constexpr std::string_view kSchemeClassCode =
+    "urn:uuid:41a5887f-8865-4c09-adf7-e362475b143a";
+constexpr std::string_view kSchemeFormatCode =
+    "urn:uuid:a09d5840-386c-46f2-b5ad-9c3699a4309d";
+constexpr std::string_view kSchemeTypeCode =
+    "urn:uuid:f0306f51-975f-434e-a61b-a3f66f70e3dc";
+
+// External-identifier scheme UUIDs for patient id and XDSDocumentEntry
+// unique id on ExtrinsicObject, from IHE ITI TF-3 §4.1.5 metadata table.
+constexpr std::string_view kExtIdPatientId =
+    "urn:uuid:58a6f841-87b3-4a3e-92fd-a8ffeff98427";
+constexpr std::string_view kExtIdUniqueId =
+    "urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab";
+
+std::string get_slot_value(pugi::xml_node extrinsic, const char* slot_name) {
+    for (auto slot : extrinsic.select_nodes("*[local-name()='Slot']")) {
+        auto node = slot.node();
+        if (std::string_view(node.attribute("name").as_string()) ==
+            slot_name) {
+            auto value = node.select_node(
+                "*[local-name()='ValueList']/"
+                "*[local-name()='Value']").node();
+            return value.text().as_string();
+        }
+    }
+    return {};
+}
+
+std::string get_classification_code(pugi::xml_node extrinsic,
+                                    std::string_view scheme) {
+    for (auto c : extrinsic.select_nodes("*[local-name()='Classification']")) {
+        auto node = c.node();
+        if (std::string_view(
+                node.attribute("classificationScheme").as_string()) ==
+            scheme) {
+            return node.attribute("nodeRepresentation").as_string();
+        }
+    }
+    return {};
+}
+
+std::string get_external_identifier(pugi::xml_node extrinsic,
+                                    std::string_view scheme) {
+    for (auto ei : extrinsic.select_nodes(
+             "*[local-name()='ExternalIdentifier']")) {
+        auto node = ei.node();
+        if (std::string_view(
+                node.attribute("identificationScheme").as_string()) ==
+            scheme) {
+            return node.attribute("value").as_string();
+        }
+    }
+    return {};
+}
+
+std::string get_localized_name(pugi::xml_node extrinsic) {
+    // XDS Name is an i18n container: <Name><LocalizedString value="..."/></Name>.
+    // Pick the first LocalizedString regardless of xml:lang - callers that
+    // need a specific locale can re-walk the tree, but the common case is
+    // "whatever the registry emitted".
+    auto ls = extrinsic.select_node(
+        "*[local-name()='Name']/"
+        "*[local-name()='LocalizedString']").node();
+    return ls.attribute("value").as_string();
+}
+
+std::uint64_t parse_size_slot(pugi::xml_node extrinsic) {
+    const std::string s = get_slot_value(extrinsic, "size");
+    if (s.empty()) return 0;
+    // Guard against malformed slot values: strtoull returns 0 on failure
+    // which collides with the "omitted" sentinel but is the safer pick.
+    // Callers that require strict size reporting should re-parse the
+    // raw envelope themselves.
+    char* end = nullptr;
+    const auto v = std::strtoull(s.c_str(), &end, 10);
+    if (end == s.c_str()) return 0;
+    return static_cast<std::uint64_t>(v);
+}
+
+registry_document_entry extract_entry(pugi::xml_node extrinsic) {
+    registry_document_entry e;
+    e.entry_uuid = extrinsic.attribute("id").as_string();
+    e.mime_type = extrinsic.attribute("mimeType").as_string();
+    e.status = extrinsic.attribute("status").as_string();
+    e.home_community_id = extrinsic.attribute("home").as_string();
+
+    e.unique_id = get_external_identifier(extrinsic, kExtIdUniqueId);
+    e.patient_id = get_external_identifier(extrinsic, kExtIdPatientId);
+
+    e.creation_time = get_slot_value(extrinsic, "creationTime");
+    e.repository_unique_id =
+        get_slot_value(extrinsic, "repositoryUniqueId");
+    e.hash = get_slot_value(extrinsic, "hash");
+    e.author_person = get_slot_value(extrinsic, "authorPerson");
+    e.size_bytes = parse_size_slot(extrinsic);
+
+    e.title = get_localized_name(extrinsic);
+    e.class_code = get_classification_code(extrinsic, kSchemeClassCode);
+    e.format_code = get_classification_code(extrinsic, kSchemeFormatCode);
+    e.type_code = get_classification_code(extrinsic, kSchemeTypeCode);
+
+    return e;
+}
+
+}  // namespace
+
+kcenon::common::Result<registry_query_result> parse_query_response(
+    const std::string& root_xml) {
+    if (root_xml.size() > kMaxRootXmlBytes) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::transport_response_too_large),
+            "AdhocQueryResponse root part exceeds 8 MiB cap (" +
+                std::to_string(root_xml.size()) + " bytes)",
+            std::string(error_source));
+    }
+
+    pugi::xml_document doc;
+    auto parse = doc.load_buffer(root_xml.data(), root_xml.size(),
+                                 pugi::parse_default, pugi::encoding_utf8);
+    if (!parse) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::transport_invalid_response),
+            std::string("failed to parse response envelope: ") +
+                parse.description(),
+            std::string(error_source));
+    }
+
+    // Use local-name() selectors so we do not depend on the specific
+    // namespace prefix the registry emits. ebRS stacks (Apache CXF,
+    // .NET WIF, Gazelle, Open Health Tools) pick different prefixes for
+    // the query and rim namespaces.
+    auto adhoc_response =
+        doc.select_node(
+               "//*[local-name()='AdhocQueryResponse']").node();
+    if (!adhoc_response) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::registry_query_response_malformed),
+            "response contains no AdhocQueryResponse element",
+            std::string(error_source));
+    }
+
+    const std::string status =
+        adhoc_response.attribute("status").as_string();
+    if (status.empty()) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::registry_query_response_malformed),
+            "AdhocQueryResponse is missing status attribute",
+            std::string(error_source));
+    }
+    // PartialSuccess means "some entries returned with warnings" in
+    // IHE ITI-18 - the registry has produced a valid RegistryObjectList
+    // alongside a RegistryErrorList. An earlier draft returned
+    // registry_partial_success as an error, which dropped the entries
+    // and contradicted the public-header contract that callers branch on
+    // entries.empty() and inspect registry_response_status. Treat
+    // PartialSuccess as a non-fatal status: fall through to the
+    // ExtrinsicObject walk and surface the raw status string in the
+    // returned result so callers can distinguish Success from
+    // PartialSuccess if their policy differs (review M2).
+    if (status != kSuccessStatus && status != kPartialSuccessStatus) {
+        return kcenon::common::make_error<registry_query_result>(
+            static_cast<int>(error_code::registry_failure_response),
+            "registry reported non-success status: " + status,
+            std::string(error_source));
+    }
+
+    registry_query_result out;
+    out.registry_response_status = status;
+
+    // Narrow child xpath (review m6): match ExtrinsicObject children of
+    // RegistryObjectList only, not arbitrary descendants. This avoids
+    // picking up nested ExtrinsicObject elements that could appear inside
+    // a RegistryError's detail payload on non-conformant responses.
+    // The RegistryObjectList is optional when no entries match; a Success
+    // response with zero results is valid and maps to out.entries.empty().
+    for (auto node : adhoc_response.select_nodes(
+             "*[local-name()='RegistryObjectList']/"
+             "*[local-name()='ExtrinsicObject']")) {
+        out.entries.push_back(extract_entry(node.node()));
+    }
+
+    return out;
+}
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/src/ihe/xds/registry_query/query_response_parser.h
+++ b/src/ihe/xds/registry_query/query_response_parser.h
@@ -1,0 +1,44 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file query_response_parser.h
+ * @brief Parser for IHE XDS.b ITI-18 AdhocQueryResponse.
+ *
+ * Locates the query:AdhocQueryResponse body in the signed SOAP envelope
+ * emitted by the Document Registry, reads its status attribute, and walks
+ * the ExtrinsicObject entries in the embedded RegistryObjectList into a
+ * registry_query_result.
+ *
+ * This is an internal header.
+ */
+
+#pragma once
+
+#include <kcenon/common/patterns/result.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/submission_set.h>
+
+#include <string>
+
+namespace kcenon::pacs::ihe::xds::detail {
+
+/**
+ * @brief Parse an AdhocQueryResponse envelope into a registry_query_result.
+ *
+ * @p root_xml is the response envelope (already signature-verified).
+ *
+ * Returns registry_failure_response when the registry reports a Failure
+ * status. Returns registry_partial_success on PartialSuccess - callers
+ * wanting to tolerate that state must inspect the status string of the
+ * returned error context.
+ *
+ * An empty RegistryObjectList on Success is a successful empty result,
+ * not an error: the function returns a registry_query_result with an
+ * empty entries vector.
+ */
+kcenon::common::Result<registry_query_result> parse_query_response(
+    const std::string& root_xml);
+
+}  // namespace kcenon::pacs::ihe::xds::detail

--- a/tests/ihe/xds/registry_query_test.cpp
+++ b/tests/ihe/xds/registry_query_test.cpp
@@ -1,0 +1,649 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file registry_query_test.cpp
+ * @brief End-to-end tests for the ITI-18 Registry Query actor.
+ */
+
+#include "../../../src/ihe/xds/common/http_client.h"
+#include "../../../src/ihe/xds/common/soap_envelope.h"
+#include "../../../src/ihe/xds/common/wss_signer.h"
+
+#include <kcenon/pacs/ihe/xds/document_source.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/http_options.h>
+#include <kcenon/pacs/ihe/xds/registry_query.h>
+#include <kcenon/pacs/ihe/xds/submission_set.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace kcenon::pacs::ihe::xds;
+
+namespace {
+
+struct bio_deleter {
+    void operator()(BIO* b) const noexcept {
+        if (b) BIO_free_all(b);
+    }
+};
+using bio_ptr = std::unique_ptr<BIO, bio_deleter>;
+
+struct pkey_deleter {
+    void operator()(EVP_PKEY* p) const noexcept {
+        if (p) EVP_PKEY_free(p);
+    }
+};
+using pkey_ptr = std::unique_ptr<EVP_PKEY, pkey_deleter>;
+
+struct x509_deleter {
+    void operator()(X509* x) const noexcept {
+        if (x) X509_free(x);
+    }
+};
+using x509_ptr = std::unique_ptr<X509, x509_deleter>;
+
+signing_material make_signing() {
+    pkey_ptr pkey(EVP_RSA_gen(2048));
+    REQUIRE(pkey);
+    x509_ptr cert(X509_new());
+    X509_set_version(cert.get(), 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(cert.get()), 1);
+    X509_gmtime_adj(X509_getm_notBefore(cert.get()), 0);
+    X509_gmtime_adj(X509_getm_notAfter(cert.get()), 60L * 60 * 24 * 30);
+    X509_set_pubkey(cert.get(), pkey.get());
+    X509_NAME* name = X509_get_subject_name(cert.get());
+    X509_NAME_add_entry_by_txt(
+        name, "CN", MBSTRING_ASC,
+        reinterpret_cast<const unsigned char*>("kcenon-rq-test"), -1, -1, 0);
+    X509_set_issuer_name(cert.get(), name);
+    X509_sign(cert.get(), pkey.get(), EVP_sha256());
+
+    signing_material s;
+    bio_ptr cb(BIO_new(BIO_s_mem()));
+    PEM_write_bio_X509(cb.get(), cert.get());
+    char* buf = nullptr;
+    long n = BIO_get_mem_data(cb.get(), &buf);
+    s.certificate_pem.assign(buf, static_cast<std::size_t>(n));
+
+    bio_ptr kb(BIO_new(BIO_s_mem()));
+    PEM_write_bio_PrivateKey(kb.get(), pkey.get(), nullptr, nullptr, 0,
+                             nullptr, nullptr);
+    n = BIO_get_mem_data(kb.get(), &buf);
+    s.private_key_pem.assign(buf, static_cast<std::size_t>(n));
+
+    return s;
+}
+
+http_options make_opts() {
+    http_options o;
+    o.endpoint = "https://registry.example.test/iti18";
+    return o;
+}
+
+constexpr const char* kPatientId =
+    "7d3f2d0a^^^&1.2.276.0.7230010.3.1.2.999&ISO";
+constexpr const char* kDocEntryUuid1 =
+    "urn:uuid:aabbccdd-1111-2222-3333-444455556666";
+constexpr const char* kDocEntryUuid2 =
+    "urn:uuid:aabbccdd-1111-2222-3333-777788889999";
+constexpr const char* kRepoUid = "1.2.276.0.7230010.3.0.3.6.2";
+
+// Replace every occurrence of @p needle in @p s with @p value.
+void replace_all(std::string& s, const std::string& needle,
+                 const std::string& value) {
+    for (;;) {
+        const auto pos = s.find(needle);
+        if (pos == std::string::npos) break;
+        s.replace(pos, needle.size(), value);
+    }
+}
+
+// Build and sign a RegistryStoredQueryResponse envelope containing one
+// ExtrinsicObject. wsu:Id attributes on Body and Timestamp are required
+// because sign_envelope references them by Id.
+std::string build_signed_response_envelope(
+    const std::string& status_urn, const std::vector<std::string>& entry_uuids,
+    const signing_material& signer) {
+    std::string extrinsic_blocks;
+    for (std::size_t i = 0; i < entry_uuids.size(); ++i) {
+        const auto& uid = entry_uuids[i];
+        std::string block =
+            R"(<rim:ExtrinsicObject id="{UID}" mimeType="application/dicom" )"
+            R"(status="urn:oasis:names:tc:ebxml-regrep:StatusType:Approved" )"
+            R"(objectType="urn:uuid:7edca82f-054d-47f2-a032-9b2a5b5186c1">)"
+            R"(<rim:Slot name="creationTime"><rim:ValueList>)"
+            R"(<rim:Value>20260422120000</rim:Value></rim:ValueList></rim:Slot>)"
+            R"(<rim:Slot name="repositoryUniqueId"><rim:ValueList>)"
+            R"(<rim:Value>{REPO}</rim:Value></rim:ValueList></rim:Slot>)"
+            R"(<rim:Slot name="size"><rim:ValueList>)"
+            R"(<rim:Value>1024</rim:Value></rim:ValueList></rim:Slot>)"
+            R"(<rim:Slot name="authorPerson"><rim:ValueList>)"
+            R"(<rim:Value>Dr. Smith</rim:Value></rim:ValueList></rim:Slot>)"
+            R"(<rim:Name><rim:LocalizedString value="CT Abdomen {IDX}"/></rim:Name>)"
+            R"(<rim:Classification classificationScheme=)"
+            R"("urn:uuid:41a5887f-8865-4c09-adf7-e362475b143a" )"
+            R"(nodeRepresentation="55113-5"/>)"
+            R"(<rim:Classification classificationScheme=)"
+            R"("urn:uuid:a09d5840-386c-46f2-b5ad-9c3699a4309d" )"
+            R"(nodeRepresentation="urn:ihe:iti:xds-sd:text:2008"/>)"
+            R"(<rim:Classification classificationScheme=)"
+            R"("urn:uuid:f0306f51-975f-434e-a61b-a3f66f70e3dc" )"
+            R"(nodeRepresentation="34133-9"/>)"
+            R"(<rim:ExternalIdentifier identificationScheme=)"
+            R"("urn:uuid:2e82c1f6-a085-4c72-9da3-8640a32e42ab" )"
+            R"(value="2.16.840.1.113883.3.42.1.{IDX}"/>)"
+            R"(<rim:ExternalIdentifier identificationScheme=)"
+            R"("urn:uuid:58a6f841-87b3-4a3e-92fd-a8ffeff98427" )"
+            R"(value="{PATIENT}"/>)"
+            R"(</rim:ExtrinsicObject>)";
+        replace_all(block, "{UID}", uid);
+        replace_all(block, "{REPO}", kRepoUid);
+        replace_all(block, "{IDX}", std::to_string(i + 1));
+        replace_all(block, "{PATIENT}", kPatientId);
+        extrinsic_blocks += block;
+    }
+
+    std::string xml =
+        R"(<?xml version="1.0" encoding="UTF-8"?>)"
+        R"(<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" )"
+        R"(xmlns:wsa="http://www.w3.org/2005/08/addressing" )"
+        R"(xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" )"
+        R"(xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" )"
+        R"(xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" )"
+        R"(xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">)"
+        R"(<soap:Header>)"
+        R"(<wsa:Action>urn:ihe:iti:2007:RegistryStoredQueryResponse</wsa:Action>)"
+        R"(<wsse:Security soap:mustUnderstand="true">)"
+        R"(<wsu:Timestamp wsu:Id="{TSID}">)"
+        R"(<wsu:Created>2026-04-22T12:00:00Z</wsu:Created>)"
+        R"(</wsu:Timestamp>)"
+        R"(<wsse:BinarySecurityToken wsu:Id="{BSTID}" )"
+        R"(EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" )"
+        R"(ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>)"
+        R"(</wsse:Security>)"
+        R"(</soap:Header>)"
+        R"(<soap:Body wsu:Id="{BODYID}">)"
+        R"(<query:AdhocQueryResponse status="{STATUS}">)"
+        R"(<rim:RegistryObjectList>)"
+        R"({EXTRINSICS})"
+        R"(</rim:RegistryObjectList>)"
+        R"(</query:AdhocQueryResponse>)"
+        R"(</soap:Body>)"
+        R"(</soap:Envelope>)";
+
+    detail::built_envelope env;
+    env.body_id = "body-rq-1";
+    env.timestamp_id = "ts-rq-1";
+    env.binary_security_token_id = "bst-rq-1";
+
+    replace_all(xml, "{TSID}", env.timestamp_id);
+    replace_all(xml, "{BSTID}", env.binary_security_token_id);
+    replace_all(xml, "{BODYID}", env.body_id);
+    replace_all(xml, "{STATUS}", status_urn);
+    replace_all(xml, "{EXTRINSICS}", extrinsic_blocks);
+    env.xml = std::move(xml);
+
+    auto r = detail::sign_envelope(env, signer.certificate_pem,
+                                   signer.private_key_pem, "");
+    REQUIRE(r.is_ok());
+    return env.xml;
+}
+
+struct scoped_transport_override {
+    scoped_transport_override() = default;
+    explicit scoped_transport_override(detail::transport_override fn) {
+        detail::set_http_transport_override(std::move(fn));
+    }
+    ~scoped_transport_override() {
+        detail::clear_http_transport_override();
+    }
+    scoped_transport_override(const scoped_transport_override&) = delete;
+    scoped_transport_override& operator=(const scoped_transport_override&) =
+        delete;
+};
+
+constexpr const char* kSuccessStatus =
+    "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+
+}  // namespace
+
+TEST_CASE("registry_query find_documents returns entries on success",
+          "[ihe][xds][iti18][e2e]") {
+    auto signer = make_signing();
+    const std::string root_xml = build_signed_response_envelope(
+        kSuccessStatus, {kDocEntryUuid1, kDocEntryUuid2}, signer);
+
+    std::string captured_body;
+    std::string captured_action;
+    scoped_transport_override guard(
+        [&](const detail::transport_request& req)
+            -> kcenon::common::Result<detail::http_response> {
+            captured_body = req.body;
+            captured_action = req.soap_action;
+            detail::http_response r;
+            r.status_code = 200;
+            r.content_type = "application/soap+xml; charset=UTF-8";
+            r.body = root_xml;
+            return r;
+        });
+
+    registry_query rq(make_opts(), signer);
+    auto result = rq.find_documents(kPatientId);
+    REQUIRE(result.is_ok());
+    REQUIRE(result.value().registry_response_status == kSuccessStatus);
+    REQUIRE(result.value().entries.size() == 2);
+
+    const auto& first = result.value().entries[0];
+    REQUIRE(first.entry_uuid == kDocEntryUuid1);
+    REQUIRE(first.repository_unique_id == kRepoUid);
+    REQUIRE(first.patient_id == kPatientId);
+    REQUIRE(first.mime_type == "application/dicom");
+    REQUIRE(first.creation_time == "20260422120000");
+    REQUIRE(first.size_bytes == 1024);
+    REQUIRE(first.unique_id == "2.16.840.1.113883.3.42.1.1");
+    REQUIRE(first.class_code == "55113-5");
+    REQUIRE(first.format_code == "urn:ihe:iti:xds-sd:text:2008");
+    REQUIRE(first.title == "CT Abdomen 1");
+
+    REQUIRE(captured_action == "urn:ihe:iti:2007:RegistryStoredQuery");
+    REQUIRE(captured_body.find("query:AdhocQueryRequest") !=
+            std::string::npos);
+    REQUIRE(captured_body.find("urn:uuid:14d4debf-8f97-4251-9a1e-a3a9d68b2a6f") !=
+            std::string::npos);
+    REQUIRE(captured_body.find("$XDSDocumentEntryPatientId") !=
+            std::string::npos);
+    REQUIRE(captured_body.find("ds:Signature") != std::string::npos);
+}
+
+TEST_CASE("registry_query find_documents returns empty list on no results",
+          "[ihe][xds][iti18][e2e]") {
+    auto signer = make_signing();
+    const std::string root_xml =
+        build_signed_response_envelope(kSuccessStatus, {}, signer);
+
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = root_xml;
+            return r;
+        });
+
+    registry_query rq(make_opts(), signer);
+    auto result = rq.find_documents(kPatientId);
+    REQUIRE(result.is_ok());
+    REQUIRE(result.value().entries.empty());
+    REQUIRE(result.value().registry_response_status == kSuccessStatus);
+}
+
+TEST_CASE("registry_query find_documents rejects empty patient_id",
+          "[ihe][xds][iti18][e2e]") {
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            FAIL("transport should not be invoked when patient_id is empty");
+            return detail::http_response{};
+        });
+
+    registry_query rq(make_opts(), make_signing());
+    auto r = rq.find_documents("");
+    REQUIRE(r.is_err());
+    REQUIRE(r.error().code ==
+            static_cast<int>(error_code::registry_query_missing_patient_id));
+}
+
+TEST_CASE("registry_query find_documents surfaces transport TLS errors",
+          "[ihe][xds][iti18][e2e]") {
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            return kcenon::common::make_error<detail::http_response>(
+                static_cast<int>(error_code::transport_tls_error),
+                "simulated TLS handshake failure",
+                std::string(error_source));
+        });
+
+    registry_query rq(make_opts(), make_signing());
+    auto r = rq.find_documents(kPatientId);
+    REQUIRE(r.is_err());
+    REQUIRE(r.error().code ==
+            static_cast<int>(error_code::transport_tls_error));
+}
+
+TEST_CASE("registry_query find_documents maps registry Failure status",
+          "[ihe][xds][iti18][e2e]") {
+    auto signer = make_signing();
+    const std::string root_xml = build_signed_response_envelope(
+        "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure", {},
+        signer);
+
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = root_xml;
+            return r;
+        });
+
+    registry_query rq(make_opts(), signer);
+    auto r = rq.find_documents(kPatientId);
+    REQUIRE(r.is_err());
+    REQUIRE(r.error().code ==
+            static_cast<int>(error_code::registry_failure_response));
+}
+
+TEST_CASE("registry_query find_documents rejects tampered response",
+          "[ihe][xds][iti18][e2e]") {
+    auto signer = make_signing();
+    std::string root_xml = build_signed_response_envelope(
+        kSuccessStatus, {kDocEntryUuid1}, signer);
+
+    // Tamper with the body after signing - replace a byte in the entry
+    // mimeType so the body digest diverges from SignedInfo's DigestValue.
+    const std::string before = "application/dicom";
+    const std::string after = "application/evil_";  // same length
+    REQUIRE(before.size() == after.size());
+    const auto pos = root_xml.find(before);
+    REQUIRE(pos != std::string::npos);
+    root_xml.replace(pos, before.size(), after);
+
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = root_xml;
+            return r;
+        });
+
+    registry_query rq(make_opts(), signer);
+    auto r = rq.find_documents(kPatientId);
+    REQUIRE(r.is_err());
+    REQUIRE(r.error().code ==
+            static_cast<int>(
+                error_code::registry_query_signature_verification_failed));
+}
+
+TEST_CASE("registry_query get_documents resolves explicit UUIDs",
+          "[ihe][xds][iti18][e2e]") {
+    auto signer = make_signing();
+    const std::string root_xml = build_signed_response_envelope(
+        kSuccessStatus, {kDocEntryUuid1, kDocEntryUuid2}, signer);
+
+    std::string captured_body;
+    scoped_transport_override guard(
+        [&](const detail::transport_request& req)
+            -> kcenon::common::Result<detail::http_response> {
+            captured_body = req.body;
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = root_xml;
+            return r;
+        });
+
+    registry_query rq(make_opts(), signer);
+    auto result = rq.get_documents({kDocEntryUuid1, kDocEntryUuid2});
+    REQUIRE(result.is_ok());
+    REQUIRE(result.value().entries.size() == 2);
+
+    // Verify the emitted request uses the GetDocuments stored query id
+    // and carries both UUIDs as a list literal inside a single Value
+    // element (the slot shape ebRIM requires).
+    REQUIRE(captured_body.find("urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4") !=
+            std::string::npos);
+    REQUIRE(captured_body.find("$XDSDocumentEntryEntryUUID") !=
+            std::string::npos);
+    REQUIRE(captured_body.find(kDocEntryUuid1) != std::string::npos);
+    REQUIRE(captured_body.find(kDocEntryUuid2) != std::string::npos);
+}
+
+TEST_CASE("registry_query get_documents rejects empty uuid list",
+          "[ihe][xds][iti18][e2e]") {
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            FAIL("transport should not be invoked when uuid list is empty");
+            return detail::http_response{};
+        });
+
+    registry_query rq(make_opts(), make_signing());
+    auto r = rq.get_documents({});
+    REQUIRE(r.is_err());
+    REQUIRE(r.error().code ==
+            static_cast<int>(error_code::registry_query_empty_uuid_list));
+}
+
+TEST_CASE(
+    "registry_query find_documents emits creation-time bounds when set",
+    "[ihe][xds][iti18][e2e]") {
+    auto signer = make_signing();
+    const std::string root_xml =
+        build_signed_response_envelope(kSuccessStatus, {}, signer);
+
+    std::string captured_body;
+    scoped_transport_override guard(
+        [&](const detail::transport_request& req)
+            -> kcenon::common::Result<detail::http_response> {
+            captured_body = req.body;
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = root_xml;
+            return r;
+        });
+
+    registry_query_options opts;
+    opts.creation_time_from = "20260101000000";
+    opts.creation_time_to = "20260401000000";
+
+    registry_query rq(make_opts(), signer);
+    auto result = rq.find_documents(kPatientId, opts);
+    REQUIRE(result.is_ok());
+    REQUIRE(captured_body.find("$XDSDocumentEntryCreationTimeFrom") !=
+            std::string::npos);
+    REQUIRE(captured_body.find("20260101000000") != std::string::npos);
+    REQUIRE(captured_body.find("$XDSDocumentEntryCreationTimeTo") !=
+            std::string::npos);
+    REQUIRE(captured_body.find("20260401000000") != std::string::npos);
+}
+
+TEST_CASE("registry_query find_documents preserves entries on PartialSuccess",
+          "[ihe][xds][iti18][e2e]") {
+    // IHE ITI-18 PartialSuccess carries a valid RegistryObjectList
+    // alongside RegistryError entries - dropping the entries by mapping
+    // PartialSuccess to an error would contradict registry_query.h's
+    // contract. Verify the parser returns Ok, preserves the status
+    // string in the result, and yields the ExtrinsicObject entries
+    // that a conformant registry would include (review M2).
+    auto signer = make_signing();
+    const std::string partial_status =
+        "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:PartialSuccess";
+    const std::string root_xml = build_signed_response_envelope(
+        partial_status, {kDocEntryUuid1, kDocEntryUuid2}, signer);
+
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = root_xml;
+            return r;
+        });
+
+    registry_query rq(make_opts(), signer);
+    auto result = rq.find_documents(kPatientId);
+    REQUIRE(result.is_ok());
+    REQUIRE(result.value().registry_response_status == partial_status);
+    REQUIRE(result.value().entries.size() == 2);
+    REQUIRE(result.value().entries[0].entry_uuid == kDocEntryUuid1);
+}
+
+TEST_CASE(
+    "registry_query find_documents rejects patient_id with slot-literal "
+    "injection characters",
+    "[ihe][xds][iti18][e2e]") {
+    // A patient_id that contains a single quote would otherwise break out
+    // of the ('...') list literal in the XDSDocumentEntryPatientId slot
+    // value, letting a caller forge additional slot values on the wire.
+    // The envelope builder must reject such inputs before serialization -
+    // the transport should never be invoked.
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            FAIL("transport must not be invoked for an unsafe patient_id");
+            return detail::http_response{};
+        });
+
+    registry_query rq(make_opts(), make_signing());
+
+    for (const char* bad : {"id'; DROP--", "id(^^^)&x&ISO", "id,extra",
+                            "id\nwith\nnewline"}) {
+        auto r = rq.find_documents(bad);
+        REQUIRE(r.is_err());
+        REQUIRE(r.error().code ==
+                static_cast<int>(
+                    error_code::registry_query_invalid_patient_id));
+    }
+}
+
+TEST_CASE("registry_query get_documents rejects malformed UUID inputs",
+          "[ihe][xds][iti18][e2e]") {
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            FAIL("transport must not be invoked for unsafe UUID inputs");
+            return detail::http_response{};
+        });
+
+    registry_query rq(make_opts(), make_signing());
+
+    // Empty string inside an otherwise valid UUID list.
+    {
+        auto r = rq.get_documents({kDocEntryUuid1, ""});
+        REQUIRE(r.is_err());
+        REQUIRE(r.error().code ==
+                static_cast<int>(
+                    error_code::registry_query_missing_document_uuid));
+    }
+
+    // UUID containing a single quote would break the list literal.
+    {
+        auto r = rq.get_documents({"urn:uuid:bad'injection"});
+        REQUIRE(r.is_err());
+        REQUIRE(r.error().code ==
+                static_cast<int>(
+                    error_code::registry_query_missing_document_uuid));
+    }
+
+    // UUID containing a comma would fracture the list.
+    {
+        auto r = rq.get_documents({"urn:uuid:a,b"});
+        REQUIRE(r.is_err());
+        REQUIRE(r.error().code ==
+                static_cast<int>(
+                    error_code::registry_query_missing_document_uuid));
+    }
+}
+
+TEST_CASE("registry_query find_documents accepts conformant CX patient IDs",
+          "[ihe][xds][iti18][e2e]") {
+    // The CX-format assigning authority delimiter is '&' - a character
+    // that is XML-significant but NOT slot-literal-significant. The
+    // builder must accept it and pugixml must escape it as &amp; in the
+    // emitted body so the registry's parser sees the original string.
+    auto signer = make_signing();
+    const std::string root_xml =
+        build_signed_response_envelope(kSuccessStatus, {}, signer);
+
+    std::string captured_body;
+    scoped_transport_override guard(
+        [&](const detail::transport_request& req)
+            -> kcenon::common::Result<detail::http_response> {
+            captured_body = req.body;
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = root_xml;
+            return r;
+        });
+
+    const std::string cx_id = "ABC-123^^^&1.2.3.4.5&ISO";
+    registry_query rq(make_opts(), signer);
+    auto result = rq.find_documents(cx_id);
+    REQUIRE(result.is_ok());
+    // The raw & must have been XML-escaped by pugixml's text setter.
+    // The body carries the escaped form; neither the raw "&I" nor the
+    // unescaped CX substring should appear without XML escaping.
+    REQUIRE(captured_body.find("&amp;1.2.3.4.5&amp;ISO") !=
+            std::string::npos);
+}
+
+TEST_CASE(
+    "registry_query find_documents rejects unsigned response envelope",
+    "[ihe][xds][iti18][e2e]") {
+    // A response envelope that carries no ds:Signature must be refused
+    // at verify_envelope_integrity. The consumer_signature_missing code
+    // the shared verifier emits is remapped by map_signature_error to
+    // registry_query_signature_missing before surfacing to the caller
+    // (review m3). This exercises the second branch of that mapper
+    // which no other test touches.
+    // Envelope carries a wsse:Security header with Timestamp and BST so
+    // verify_envelope_integrity locates the security context, but omits
+    // ds:Signature entirely - the missing-signature branch rather than
+    // the digest-mismatch branch.
+    constexpr const char* kUnsignedEnvelope =
+        R"(<?xml version="1.0" encoding="UTF-8"?>)"
+        R"(<soap:Envelope )"
+        R"(xmlns:soap="http://www.w3.org/2003/05/soap-envelope" )"
+        R"(xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" )"
+        R"(xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" )"
+        R"(xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" )"
+        R"(xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">)"
+        R"(<soap:Header>)"
+        R"(<wsse:Security>)"
+        R"(<wsu:Timestamp wsu:Id="ts-unsigned">)"
+        R"(<wsu:Created>2026-04-22T12:00:00Z</wsu:Created>)"
+        R"(</wsu:Timestamp>)"
+        R"(<wsse:BinarySecurityToken wsu:Id="bst-unsigned" )"
+        R"(EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" )"
+        R"(ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>)"
+        R"(</wsse:Security>)"
+        R"(</soap:Header>)"
+        R"(<soap:Body wsu:Id="body-unsigned">)"
+        R"(<query:AdhocQueryResponse )"
+        R"(status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success">)"
+        R"(<rim:RegistryObjectList/>)"
+        R"(</query:AdhocQueryResponse>)"
+        R"(</soap:Body>)"
+        R"(</soap:Envelope>)";
+
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = kUnsignedEnvelope;
+            return r;
+        });
+
+    registry_query rq(make_opts(), make_signing());
+    auto r = rq.find_documents(kPatientId);
+    REQUIRE(r.is_err());
+    REQUIRE(r.error().code ==
+            static_cast<int>(
+                error_code::registry_query_signature_missing));
+}
+
+


### PR DESCRIPTION
## What

### Summary
Implements the IHE XDS.b Registry Query actor (ITI-18 RegistryStoredQuery). `pacs_system` can now discover documents in an XDS.b Document Registry by patient ID or explicit UUID list, paired with the Document Consumer (#1129) for end-to-end metadata-then-payload retrieval.

### Change Type
- [x] Feature (new functionality)

### Affected Components
- `include/kcenon/pacs/ihe/xds/registry_query.h` — new public header
- `include/kcenon/pacs/ihe/xds/errors.h` — appends `error_code` 120-126 (no renumbering)
- `include/kcenon/pacs/ihe/xds/submission_set.h` — appends `registry_query_options`, `registry_query_request`, `registry_document_entry`, `registry_query_result`
- `src/ihe/xds/registry_query.cpp` — public-API orchestrator (pimpl, move-only)
- `src/ihe/xds/registry_query/query_envelope.{h,cpp}` — internal SOAP envelope builder
- `src/ihe/xds/registry_query/query_response_parser.{h,cpp}` — internal `AdhocQueryResponse` parser
- `tests/ihe/xds/registry_query_test.cpp` — 14 Catch2 cases under `[iti18]`
- `cmake/targets.cmake`, `cmake/testing.cmake` — additive wiring
- `CHANGELOG.md` — Unreleased/Added entry

## Why

### Problem Solved
Without Registry Query, the Document Consumer (#1129) has no way to discover document UIDs for a given patient — XDS.b stored queries are the discovery mechanism of the affinity domain. This PR completes the discovery half of the XDS.b retrieve flow.

### Related Issues
- Closes #1130
- Part of #1101 (IHE XDS.b integration epic)
- Sibling to #1129 (Document Consumer, ITI-43) and #1131 (ATNA audit)

## Who

### Reviewers
Code-reviewer and team-lead (internal review complete — two rounds, approved)

## When

### Urgency
Normal — follow standard review process.

### Target Release
Next minor; unblocks the full XDS.b intra-community flow.

## Where

### Files Changed Summary
| Area | Files | Lines |
|------|-------|-------|
| Public header | `registry_query.h`, `errors.h`, `submission_set.h` | +231 |
| Internal impl | `registry_query.cpp`, `registry_query/*.{h,cpp}` | +877 |
| Tests | `registry_query_test.cpp` | +649 |
| Build | `cmake/*.cmake` | +6 |
| Docs | `CHANGELOG.md` | +1 |
| **Total** | 12 files | +1763 / -1 |

### API Changes
New class `kcenon::pacs::ihe::xds::registry_query` with two entry points:
- `find_documents(patient_id, options = {})` — FindDocuments stored query
- `get_documents(uuids)` — GetDocuments stored query

Both return `kcenon::common::Result<registry_query_result>`.

### Database Changes
None.

## How

### Implementation Highlights
- **Shape**: Mirrors the `document_consumer` (ITI-43) layout exactly — public header uses pimpl + move-only + non-reentrant thread-safety note; internal envelope builder and response parser live under `::detail` in `src/ihe/xds/registry_query/`; all transport/signing reuses existing `common/` helpers (no new abstractions).
- **Stored query IDs** are pinned bit-exact per IHE ITI TF-2a §3.18.4.1.2.3.7-8: `urn:uuid:14d4debf-8f97-4251-9a1e-a3a9d68b2a6f` (FindDocuments) and `urn:uuid:5737b14c-8a1a-4539-b659-e03a34a5e1e4` (GetDocuments).
- **Input validation** rejects slot-literal metacharacters (`'`, `(`, `)`, `,`, control chars) at the public API boundary on `patient_id`, `document_uuids`, `status_values`, and `creation_time_*`. ebRIM StoredQuery has no escape grammar, so rejection is the only correct policy. Defense in depth is retained in the envelope builder.
- **Response handling**: `PartialSuccess` is treated as non-fatal — the parser walks `RegistryObjectList` and surfaces the raw status string in `registry_query_result.registry_response_status`, letting callers distinguish Success from PartialSuccess by inspection rather than by error class. `Failure` continues to surface as `registry_failure_response`.
- **Signature verification**: response envelope signatures are checked via `detail::verify_envelope_integrity` before the status attribute or entries are trusted; verification/missing errors are remapped to `registry_query_signature_*` so callers can branch on the query-specific namespace.
- **Error codes**: 7 new contiguous codes (120-126) appended to `errors.h`; no existing values renumbered.

### Testing Done
- [x] 14 unit tests under `[iti18]`, 88 assertions, all passing
- [x] Full `pacs_ihe_xds_tests` suite: 36 cases / 221 assertions, all passing (regression check clean)
- [x] Build: `pacs_ihe_xds` target compiles clean, 0 warnings

### Test Plan
```
cmake --build build-xds --target pacs_ihe_xds_tests
./build-xds/bin/pacs_ihe_xds_tests "[iti18]"
./build-xds/bin/pacs_ihe_xds_tests   # full suite regression
```

Covered: happy path (find + get), no-results, empty patient_id, TLS failure, Failure-status mapping, signature tampering, empty UUID list, malformed UUID rejection (single-quote/comma/empty-element), creation-time bounds emission, PartialSuccess entry preservation, CX-form patient_id with `&` → `&amp;` escape verified, unsigned-response rejection.

### Breaking Changes
None — all changes are additive.

### Rollback Plan
Revert this PR. No migrations, no schema changes, no data loss.

## Review Findings & Resolution

Two internal review rounds; all Major items resolved, 4 of 6 Minor items fixed, 2 tracked as follow-ups.

| ID | Severity | Finding | Resolution |
|----|----------|---------|------------|
| M1 | Major | ebRIM slot-value injection via list-literal concatenation | Resolved — `contains_slot_literal_metachar()` validation at public API boundary in `registry_query.cpp`; defense in depth retained at envelope builder |
| M2 | Major | `PartialSuccess` mapped to error dropped response entries | Resolved — two-way dispatch in `query_response_parser.cpp`; Success/PartialSuccess both fall through to entry walk; status string preserved in result |
| M3 | Major | Declared error codes `registry_query_invalid_patient_id` / `registry_query_missing_document_uuid` unreachable | Resolved — both codes now emit from the public API path after M1 move |
| m1 | Minor | CMake STATUS message omitted ITI-18 | Fixed — now reads "(ITI-41 + ITI-43 + Registry Query ITI-18)" |
| m3 | Minor | Missing test for `registry_query_signature_missing` path | Fixed — new test "rejects unsigned response envelope" |
| m5 | Minor | Action URI duplicated in `kSoapContentType` docstring | Fixed — docstring clarified |
| m6 | Minor | Response parser descendant xpath matched nested objects | Fixed — narrowed to child xpath `RegistryObjectList/ExtrinsicObject` |

### Known remaining Minor items (tracked follow-ups)
- **m2** — 8 MiB response-size cap is duplicated between `query_response_parser.cpp` and the consumer retrieve parser. Extracting to a shared constant requires editing `src/ihe/xds/consumer/retrieve_response_parser.cpp` (#1129 territory) and is out of scope for this PR.
- **m4** — `env_result.value()` / `http_result.value()` are invoked by copy. The project's `Result<T>::value()` returns `const T&` today, so `std::move(result).value()` is a no-op; revisit if the `Result<T>` API grows an rvalue `value()` overload.

## Interop Caveat
Response signatures are verified with the project-local canonicalization URI `urn:kcenon:xds:c14n:pugixml-format-raw-v1`, identical to the Document Consumer. This is NOT interoperable with a third-party exc-c14n signer (Gazelle / Apache CXF / .NET WIF) until the follow-up full-c14n work lands. See the header doc comment and `common/wss_signer.cpp`.

## Out of Scope
- ATNA audit emission (#1131 sibling)
- Document retrieval / Document Consumer actor (#1129, already merged)
- Full XML-DSig exc-c14n canonicalization (tracked follow-up)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed; two internal review rounds applied
- [x] Tests added/updated (14 new `[iti18]` cases)
- [x] Documentation updated (CHANGELOG Unreleased/Added)
- [x] No sensitive data exposed
- [x] Commits are atomic (feat / test / docs) and well-described
- [x] Related issue linked with `Closes #1130`
