### PR TITLE
feat(ihe/xds): wire ATNA audit, integration tests, and IHE Conformance Statement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IHE XDS.b Document Source actor (ITI-41) at `src/ihe/xds/` with pugixml + libcurl transport stack ([#1128](https://github.com/kcenon/pacs_system/issues/1128))
 - IHE XDS.b Document Consumer actor (ITI-43) at `src/ihe/xds/` with retrieve envelope builder and MTOM/XOP response parser ([#1129](https://github.com/kcenon/pacs_system/issues/1129))
 - IHE XDS.b Registry Query actor (ITI-18) at `src/ihe/xds/` with FindDocuments and GetDocuments stored queries against a conformant XDS.b Document Registry ([#1130](https://github.com/kcenon/pacs_system/issues/1130))
+- ATNA audit emission for IHE XDS.b transactions (ITI-18/41/43) with Gazelle-lite integration test harness, and published `docs/IHE_CONFORMANCE.md` ([#1131](https://github.com/kcenon/pacs_system/issues/1131))
 
 ### Changed
 

--- a/cmake/targets.cmake
+++ b/cmake/targets.cmake
@@ -466,6 +466,7 @@ set(PACS_SECURITY_SOURCES
     src/security/atna_service_auditor.cpp
     src/security/atna_config.cpp
     src/security/tls_policy.cpp
+    src/security/xds_audit_events.cpp
 )
 
 # Audit log cipher (Issue #1102) - compiles without OpenSSL as a stub

--- a/cmake/testing.cmake
+++ b/cmake/testing.cmake
@@ -440,6 +440,26 @@ if(PACS_BUILD_TESTS)
             target_link_libraries(pacs_ihe_xds_tests PRIVATE pugixml)
         endif()
         message(STATUS "  [OK] pacs_ihe_xds_tests: ON (ITI-41 + ITI-43 + Registry Query ITI-18)")
+
+        # IHE XDS.b ATNA audit integration tests (Issue #1131)
+        # In-process Gazelle-lite harness: exercises the actor ->
+        # set_audit_sink() path end-to-end via the transport override hook
+        # and asserts exactly one audit event per success and failure case.
+        file(MAKE_DIRECTORY
+            ${CMAKE_SOURCE_DIR}/tests/integration/ihe/xds)
+        add_executable(pacs_xds_atna_integration_tests
+            tests/integration/ihe/xds/xds_atna_integration_test.cpp
+        )
+        target_link_libraries(pacs_xds_atna_integration_tests
+            PRIVATE
+                pacs_ihe_xds
+                pacs_security
+                OpenSSL::SSL
+                OpenSSL::Crypto
+                Catch2::Catch2WithMain
+        )
+        message(STATUS
+            "  [OK] pacs_xds_atna_integration_tests: ON (ITI-18/41/43 ATNA emission)")
     endif()
 
     # DI tests (Issue #312 - ServiceContainer based DI Integration)
@@ -634,6 +654,17 @@ if(PACS_BUILD_TESTS)
     if(TARGET pacs_ihe_xds_tests)
         catch_discover_tests(pacs_ihe_xds_tests
             PROPERTIES LABELS "unit"
+        )
+    endif()
+
+    # IHE XDS.b ATNA audit integration tests (Issue #1131).
+    # Registered under the pacs_xds_integration CTest label so CI can
+    # select this bucket with ctest -L pacs_xds_integration without
+    # pulling in the full integration suite.
+    if(TARGET pacs_xds_atna_integration_tests)
+        catch_discover_tests(pacs_xds_atna_integration_tests
+            TEST_PREFIX "integration::"
+            PROPERTIES LABELS "pacs_xds_integration"
         )
     endif()
 

--- a/docs/IHE_CONFORMANCE.md
+++ b/docs/IHE_CONFORMANCE.md
@@ -1,0 +1,268 @@
+---
+doc_id: "PAC-INTR-003"
+doc_title: "IHE XDS.b Conformance Statement"
+doc_version: "0.1.0"
+doc_date: "2026-04-24"
+doc_status: "Released"
+project: "pacs_system"
+category: "INTR"
+---
+
+# IHE XDS.b Conformance Statement
+
+> **SSOT**: This document is the single source of truth for **IHE ITI XDS.b
+> Integration Statement / Conformance Statement** at the text-document layer
+> (ITI-18/41/43).
+
+This document is structured according to the
+[IHE Integration Statement template](https://wiki.ihe.net/index.php/IHE_Integration_Statement)
+and covers only the **IT Infrastructure (ITI)** domain transactions implemented
+at `src/ihe/xds/`. For the **RAD** domain imaging profiles (XDS-I.b, AIRA,
+PIR), see the separate [IHE Integration Statement](IHE_INTEGRATION_STATEMENT.md).
+Those two documents are intentionally non-overlapping: ITI XDS.b here, RAD
+XDS-I.b there.
+
+For DICOM-level conformance details see the
+[DICOM Conformance Statement](DICOM_CONFORMANCE_STATEMENT.md). For the
+tracking of the XDS.b implementation gaps called out in
+[#1101](https://github.com/kcenon/pacs_system/issues/1101), see the
+[IHE XDS.b Completion Status](IHE_XDSB_COMPLETION_STATUS.md).
+
+---
+
+## 1. Vendor / Product Identification
+
+| Field | Value |
+|-------|-------|
+| Vendor Name | kcenon |
+| Product Name | PACS System |
+| Product Version | 0.1.0 |
+| Release Date | 2026-04-24 |
+| Statement Date | 2026-04-24 |
+| Statement Version | 0.1.0 |
+| Contact | see repository `README.md` |
+
+---
+
+## 2. Actors Implemented
+
+The PACS System implements the following IHE IT Infrastructure (ITI) actors at
+the text-document / registry layer. All three are **initiator** (client) side
+actors.
+
+| Actor | Role | Implementation |
+|-------|------|----------------|
+| Document Source | Publishes documents + submission metadata to an XDS.b Repository | `include/kcenon/pacs/ihe/xds/document_source.h`, `src/ihe/xds/document_source.cpp` |
+| Document Consumer | Retrieves documents from an XDS.b Repository by `{repositoryUniqueId, documentUniqueId}` | `include/kcenon/pacs/ihe/xds/document_consumer.h`, `src/ihe/xds/document_consumer.cpp` |
+| Document Consumer (Query side) | Executes stored queries against an XDS.b Document Registry | `include/kcenon/pacs/ihe/xds/registry_query.h`, `src/ihe/xds/registry_query.cpp` |
+
+The Repository and Registry actors are **not** implemented in this release;
+the PACS System is exclusively a client of conformant third-party Repository
+and Registry infrastructure.
+
+---
+
+## 3. Transactions Supported
+
+| Transaction | Actor (this side) | Direction | Options / Profile Pins |
+|-------------|-------------------|-----------|------------------------|
+| ITI-41 Provide and Register Document Set-b | Document Source | Outbound | SOAP 1.2; MTOM/XOP request body; WS-Security X.509 Token Profile signing on `<soap:Body>` + timestamp; `wsa:Action = urn:ihe:iti:2007:ProvideAndRegisterDocumentSet-b`. |
+| ITI-43 Retrieve Document Set | Document Consumer | Outbound | SOAP 1.2; MTOM/XOP response body parsed; WS-Security signature on response verified; `wsa:Action = urn:ihe:iti:2007:RetrieveDocumentSet`. |
+| ITI-18 Registry Stored Query | Document Consumer (Query side) | Outbound | SOAP 1.2; `wsa:Action = urn:ihe:iti:2007:RegistryStoredQuery`; stored queries `FindDocuments` and `GetDocuments`; response signature verification same as ITI-43. |
+
+Transactions are emitted over HTTP/1.1 TLS (see Section 5). No plain-HTTP
+fallback is available.
+
+---
+
+## 4. Integration Profiles
+
+| Profile | Profile Option | Support |
+|---------|----------------|---------|
+| ITI XDS.b (Cross-Enterprise Document Sharing) | Document Source actor | Yes (ITI-41 outbound) |
+| ITI XDS.b | Document Consumer actor | Yes (ITI-43 + ITI-18 outbound) |
+| ITI XDS.b | Document Registry / Repository | No (external infrastructure) |
+| ITI ATNA (Audit Trail and Node Authentication) | Secure Node, audit emission only | Partial — audit messages are emitted per RFC 3881 / IHE ATNA for all three transactions; the secure-node TLS side inherits the product's BCP-195 profile (see Section 5) |
+
+XDS.b here refers to the plain-document profile. For the imaging profile
+XDS-I.b (RAD-68 / RAD-69), see
+[IHE_INTEGRATION_STATEMENT.md §2.1](IHE_INTEGRATION_STATEMENT.md#21-xds-ib----cross-enterprise-document-sharing-for-imaging).
+
+---
+
+## 5. Configuration Parameters
+
+### 5.1 Endpoints
+
+Each actor is constructed with the URL of its remote counterpart; there is no
+single global registry. Endpoints are plain HTTPS URLs and must be configured
+by the deployment.
+
+| Actor | Configured Endpoint |
+|-------|---------------------|
+| Document Source | Repository ITI-41 endpoint |
+| Document Consumer | Repository ITI-43 endpoint |
+| Registry Query (Consumer) | Registry ITI-18 endpoint |
+
+### 5.2 WS-Security Signing
+
+All three actors sign their outbound request `<soap:Body>` (plus the
+`wsu:Timestamp` reference) using RSA-SHA256 with a BinarySecurityToken
+(X.509v3). The emitted `<ds:CanonicalizationMethod>` and reference `Transform`
+advertise a **project-local canonicalization URI** rather than the W3C
+Exclusive XML Canonicalization URI. See Section 7 for the interoperability
+implications.
+
+| Parameter | Value |
+|-----------|-------|
+| Signature Algorithm | `http://www.w3.org/2001/04/xmldsig-more#rsa-sha256` |
+| Digest Algorithm | `http://www.w3.org/2001/04/xmlenc#sha256` |
+| CanonicalizationMethod URI | `urn:kcenon:xds:c14n:pugixml-format-raw-v1` |
+| Reference Transform URI | `urn:kcenon:xds:c14n:pugixml-format-raw-v1` |
+| Signer Key Binding | PEM X.509 certificate + private key pair passed at actor construction; public key carried as `wsse:BinarySecurityToken` |
+
+The project-local URI is declared exactly once in
+`src/ihe/xds/common/wss_signer.cpp` (constant `kKcenonC14nUri`) so the
+signer and verifier cannot drift.
+
+### 5.3 TLS
+
+TLS transport is governed by the PACS System BCP-195 profile (`non_downgrading
+= true`, TLS 1.3 preferred). See
+[DICOM Conformance Statement §7](DICOM_CONFORMANCE_STATEMENT.md#7-security).
+No XDS.b-specific TLS settings are introduced by these actors; the transport
+stack (libcurl + OpenSSL) is shared with the rest of the product.
+
+### 5.4 ATNA Audit Destination
+
+Each actor exposes `set_audit_sink(std::shared_ptr<xds_audit_sink>)`. Sink
+factories are published in
+`include/kcenon/pacs/security/xds_audit_events.h`:
+
+| Factory | Emission Behaviour |
+|---------|--------------------|
+| `make_null_xds_audit_sink()` | Installed by default. No events emitted. Preserves pre-audit call semantics (single null-check per transaction, zero allocations). |
+| `make_atna_xds_audit_sink(atna_service_auditor&, ...)` | Forwards each event through `atna_service_auditor::submit_audit_message()`, which serialises to syslog over the auditor's configured `atna_syslog_transport` (UDP / TCP / TLS, per `syslog_transport_config`). |
+| `recording_xds_audit_sink` (class) | Captures events in-process for tests. Used by the integration suite under the `pacs_xds_integration` CTest label. |
+
+Audit emission fires on both success and failure paths of every transaction.
+On failure, the triggering `Result<T>` error message is attached as an
+`atna_object_detail` of type `FailureDescription` on the terminal participant
+object, per IHE ATNA.
+
+---
+
+## 6. Audit Trail and Node Authentication (ATNA)
+
+Each ITI transaction emits one audit message constructed by the builder in
+`src/security/xds_audit_events.cpp`. The vocabulary below is the **pinned
+final value** after the RFC 3881 alignment pass on this branch; it is locked
+in unit and integration tests under the `pacs_xds_integration` CTest label.
+
+| Transaction | Builder | EventID (RFC 3881) | EventActionCode | EventTypeCode | Local Participant Role |
+|-------------|---------|--------------------|-----------------|---------------|------------------------|
+| ITI-41 Provide and Register | `build_iti41_audit_message` | DCM 110106 `Export` | `C` (Create) | `ITI-41` (code system `IHETransactions`), display `Provide and Register Document Set-b` | Source (requestor) |
+| ITI-43 Retrieve Document Set | `build_iti43_audit_message` | DCM 110107 `Import` | `R` (Read) | `ITI-43` (code system `IHETransactions`), display `Retrieve Document Set` | Destination (requestor) — local consumer pulls from remote repository |
+| ITI-18 Registry Stored Query | `build_iti18_audit_message` | DCM 110112 `Query` | `E` (Execute) | `urn:ihe:iti:2007:RegistryStoredQuery` (code system `IHETransactions`), display `Registry Stored Query` | Source (requestor) |
+
+Each message carries:
+
+- Active participants: the two endpoints of the transaction, with RFC 3881
+  role-ID codes (`kcenon::pacs::security::atna_role_ids::source`,
+  `::destination`) and a single `user_is_requestor = true` flag on the local
+  actor.
+- Participant objects, where applicable:
+  - ITI-41: `XDSSubmissionSet.uniqueId`, one
+    `XDSDocumentEntry.uniqueId` per document, and patient number.
+  - ITI-43: `XDSDocumentEntry.uniqueId` plus the remote repository's node ID.
+  - ITI-18: patient number (for `FindDocuments`) and/or one
+    `XDSDocumentEntry.entryUUID` per queried UUID (for `GetDocuments`).
+- EventOutcomeIndicator: `success` (0) or `serious_failure` (8), matching
+  `atna_event_outcome`.
+
+References: RFC 3881 §5 (event vocabulary), IHE ITI TF-2a §3.20 (Record Audit
+Event), IHE ITI TF-1 §9 (ATNA profile), IHE ITI TF-2a §3.18 / §3.41 / §3.43.
+
+---
+
+## 7. Known Interoperability Limitations
+
+### 7.1 WS-Security Canonicalization
+
+The WS-Security signature produced by `src/ihe/xds/common/wss_signer.cpp`
+advertises
+
+```
+urn:kcenon:xds:c14n:pugixml-format-raw-v1
+```
+
+as both its `<ds:CanonicalizationMethod>` and each reference `Transform`,
+**not** the W3C Exclusive XML Canonicalization URI
+(`http://www.w3.org/2001/10/xml-exc-c14n#`). The byte stream is produced by
+pugixml's `format_raw` serialization against an envelope whose namespace
+prefixes are all declared on `<soap:Envelope>`, so it is deterministic and
+bit-reproducible under the paired verifier in the same file.
+
+Interoperability consequences:
+
+- **Self-to-self**: fully interoperable. Signatures produced and verified by
+  this codebase round-trip exactly.
+- **Against real IHE Gazelle / Apache CXF / .NET WIF peers**: the peer will
+  reject the signature at the Algorithm check, because it does not recognise
+  the project-local URI. This applies to both the ITI-41 request signature
+  (which a real Repository would reject) and the ITI-43 / ITI-18 response
+  signature verification (which will reject responses from a real Repository /
+  Registry).
+- **Fix**: a follow-up issue tracks implementing full namespace-rewriting
+  `exc-c14n`. Production deployments against real XDS.b infrastructure must
+  wait for that work.
+
+See the `@brief` on
+`include/kcenon/pacs/ihe/xds/document_source.h`,
+`document_consumer.h`, and `registry_query.h` for the caveat at the actor
+level, and the header comment of `wss_signer.cpp` for the rationale.
+
+### 7.2 Registry / Repository Actors Not Implemented
+
+The PACS System does not host an XDS.b Document Registry or Document
+Repository. Deployments must pair it with conformant third-party
+infrastructure.
+
+### 7.3 ATNA Secure Application / Secure Node
+
+The ATNA audit emission side (Section 6) is implemented for all three
+transactions. The full ATNA **Secure Application / Secure Node**
+conformance (node authentication via bidirectional TLS, consolidated audit
+record for every security-relevant event across the product) is tracked
+separately against the product-wide BCP-195 + audit pipeline; this XDS.b
+actor set contributes the XDS-specific audit events but does not, by itself,
+certify the whole node.
+
+### 7.4 Connectathon Testing
+
+IHE Connectathon testing has not yet been performed. Transaction conformance
+is validated by the Gazelle-lite integration harness registered under the
+`pacs_xds_integration` CTest label (see `cmake/testing.cmake` lines 660-669).
+
+---
+
+## 8. References
+
+| Document | Title |
+|----------|-------|
+| IHE ITI TF-1 §9 | IT Infrastructure Technical Framework Volume 1: Audit Trail and Node Authentication (ATNA) Integration Profile |
+| IHE ITI TF-1 §10 | IT Infrastructure Technical Framework Volume 1: Cross-Enterprise Document Sharing (XDS.b) Integration Profile |
+| IHE ITI TF-2a §3.18 | Registry Stored Query `[ITI-18]` |
+| IHE ITI TF-2a §3.20 | Record Audit Event `[ITI-20]` |
+| IHE ITI TF-2b §3.41 | Provide and Register Document Set-b `[ITI-41]` |
+| IHE ITI TF-2b §3.43 | Retrieve Document Set `[ITI-43]` |
+| RFC 3881 | Security Audit and Access Accountability Message XML Data Definitions for Healthcare Applications |
+| RFC 5246 / RFC 8446 | TLS 1.2 / TLS 1.3 |
+| BCP 195 | Recommendations for Secure Use of Transport Layer Security (TLS) |
+| W3C XML-DSig | XML Signature Syntax and Processing (Second Edition) |
+| W3C exc-c14n | Exclusive XML Canonicalization Version 1.0 |
+| OASIS WS-Security 1.1 | Web Services Security: SOAP Message Security (including X.509 Token Profile 1.1) |
+
+---
+
+*IHE is a registered trademark of IHE International.*

--- a/include/kcenon/pacs/ihe/xds/document_consumer.h
+++ b/include/kcenon/pacs/ihe/xds/document_consumer.h
@@ -43,6 +43,10 @@
 #include <memory>
 #include <string>
 
+namespace kcenon::pacs::security {
+class xds_audit_sink;
+}  // namespace kcenon::pacs::security
+
 namespace kcenon::pacs::ihe::xds {
 
 /**
@@ -116,6 +120,19 @@ public:
     kcenon::common::Result<document_response> retrieve(
         const std::string& document_unique_id,
         const std::string& repository_unique_id);
+
+    /**
+     * @brief Install an ATNA audit sink.
+     *
+     * When set, retrieve() emits exactly one audit event per invocation
+     * - success or failure - carrying the requested document uid,
+     * repository uid, source endpoint, and the outcome code.
+     *
+     * @see kcenon::pacs::security::xds_audit_sink
+     * @see Issue #1131
+     */
+    void set_audit_sink(
+        std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink);
 
 private:
     class impl;

--- a/include/kcenon/pacs/ihe/xds/document_source.h
+++ b/include/kcenon/pacs/ihe/xds/document_source.h
@@ -41,6 +41,10 @@
 #include <memory>
 #include <string>
 
+namespace kcenon::pacs::security {
+class xds_audit_sink;
+}  // namespace kcenon::pacs::security
+
 namespace kcenon::pacs::ihe::xds {
 
 /**
@@ -112,6 +116,22 @@ public:
      * submission set unique id.
      */
     kcenon::common::Result<submit_response> submit(const submission_set& s);
+
+    /**
+     * @brief Install an ATNA audit sink.
+     *
+     * When set, submit() emits exactly one audit event per invocation -
+     * success or failure - carrying the submission_set unique id, patient
+     * id, registry endpoint, and the outcome code. A null sink (the
+     * default) disables emission. The sink is shared ownership so the
+     * same sink instance can be installed on multiple actors feeding a
+     * single auditor.
+     *
+     * @see kcenon::pacs::security::xds_audit_sink
+     * @see Issue #1131
+     */
+    void set_audit_sink(
+        std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink);
 
 private:
     class impl;

--- a/include/kcenon/pacs/ihe/xds/registry_query.h
+++ b/include/kcenon/pacs/ihe/xds/registry_query.h
@@ -40,6 +40,10 @@
 #include <string>
 #include <vector>
 
+namespace kcenon::pacs::security {
+class xds_audit_sink;
+}  // namespace kcenon::pacs::security
+
 namespace kcenon::pacs::ihe::xds {
 
 /**
@@ -127,6 +131,20 @@ public:
      */
     kcenon::common::Result<registry_query_result> get_documents(
         const std::vector<std::string>& uuids);
+
+    /**
+     * @brief Install an ATNA audit sink.
+     *
+     * When set, find_documents() and get_documents() each emit one audit
+     * event per invocation - success or failure - carrying the query
+     * kind, query keys (patient_id or uuid list), registry endpoint,
+     * and the outcome code.
+     *
+     * @see kcenon::pacs::security::xds_audit_sink
+     * @see Issue #1131
+     */
+    void set_audit_sink(
+        std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink);
 
 private:
     class impl;

--- a/include/kcenon/pacs/security/atna_service_auditor.h
+++ b/include/kcenon/pacs/security/atna_service_auditor.h
@@ -255,6 +255,29 @@ public:
      */
     [[nodiscard]] const atna_syslog_transport& transport() const noexcept;
 
+    // =========================================================================
+    // Pre-built Message Emission
+    // =========================================================================
+
+    /**
+     * @brief Emit a pre-built RFC 3881 audit message.
+     *
+     * Allows callers with their own transaction-specific event code and
+     * EventTypeCode vocabulary (e.g., the XDS.b actors under
+     * xds_audit_events.h) to route a fully-formed message through the
+     * auditor's serialized transport and statistics path instead of
+     * opening a second socket. Respects the enabled() flag and updates
+     * the same events_sent/events_failed counters as the high-level
+     * audit_* methods.
+     *
+     * Thread safety: safe to call concurrently - delegation is through
+     * the same private send_audit() path as all other audit_* methods.
+     *
+     * @param message The audit message to serialize and send.
+     * @see Issue #1131
+     */
+    void submit_audit_message(const atna_audit_message& message);
+
 private:
     // =========================================================================
     // Private Helpers

--- a/include/kcenon/pacs/security/xds_audit_events.h
+++ b/include/kcenon/pacs/security/xds_audit_events.h
@@ -1,0 +1,193 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file xds_audit_events.h
+ * @brief ATNA audit event helpers for the IHE XDS.b actors (ITI-18/41/43).
+ *
+ * Provides a small sink interface that the three XDS.b actors
+ * (document_source, document_consumer, registry_query) call on every
+ * transaction attempt - success or failure. The sink abstracts the
+ * transport so the actors can remain decoupled from syslog / file /
+ * in-memory delivery and so tests can observe emission without a network.
+ *
+ * Mapping of IHE transactions to RFC 3881 / DICOM PS3.15 event codes:
+ *
+ *   ITI-41 Provide and Register  -> DCM 110106 "Export"
+ *                                    EventActionCode = 'C' (Create)
+ *                                    Event type code "ITI-41"
+ *
+ *   ITI-43 Retrieve Document Set -> DCM 110104 "DICOM Instances Transferred"
+ *                                    EventActionCode = 'R' (Read)
+ *                                    is_import=true, event type code "ITI-43"
+ *
+ *   ITI-18 RegistryStoredQuery   -> DCM 110112 "Query"
+ *                                    EventActionCode = 'E' (Execute)
+ *                                    Event type code "ITI-18"
+ *
+ * Success paths record atna_event_outcome::success.
+ * All error paths (metadata validation, signing, transport, parse,
+ * registry-reported Failure, signature verification) record
+ * atna_event_outcome::serious_failure.
+ *
+ * @see IHE ITI TF-1 Section 9 - Audit Trail and Node Authentication
+ * @see RFC 3881 - Security Audit and Access Accountability Message XML
+ * @see DICOM PS3.15 Annex A.5 - Audit Trail Message Format Profile
+ * @see Issue #1131
+ */
+
+#ifndef PACS_SECURITY_XDS_AUDIT_EVENTS_HPP
+#define PACS_SECURITY_XDS_AUDIT_EVENTS_HPP
+
+#include "kcenon/pacs/security/atna_audit_logger.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace kcenon::pacs::security {
+
+class atna_service_auditor;
+
+/**
+ * @brief Context captured for an ITI-41 Provide and Register attempt.
+ *
+ * All string fields are empty when unavailable; the sink implementation
+ * decides whether to emit a placeholder or omit the field from the
+ * generated audit message. source_id identifies the local Document
+ * Source actor and destination_endpoint is the registry URL.
+ */
+struct xds_iti41_event {
+    std::string source_id;
+    std::string destination_endpoint;
+    std::string patient_id;
+    std::string submission_set_unique_id;
+    std::vector<std::string> document_unique_ids;
+    atna_event_outcome outcome{atna_event_outcome::success};
+    std::string failure_description;
+};
+
+/**
+ * @brief Context captured for an ITI-43 Retrieve Document Set attempt.
+ */
+struct xds_iti43_event {
+    std::string consumer_id;
+    std::string source_endpoint;
+    std::string document_unique_id;
+    std::string repository_unique_id;
+    atna_event_outcome outcome{atna_event_outcome::success};
+    std::string failure_description;
+};
+
+/**
+ * @brief Context captured for an ITI-18 Registry Stored Query attempt.
+ *
+ * query_kind distinguishes FindDocuments from GetDocuments. When the
+ * query is FindDocuments, patient_id is populated; for GetDocuments it
+ * is empty and document_uuids carries the requested entry UUIDs.
+ */
+struct xds_iti18_event {
+    enum class kind : std::uint8_t {
+        find_documents,
+        get_documents
+    };
+
+    std::string querier_id;
+    std::string registry_endpoint;
+    kind query_kind{kind::find_documents};
+    std::string patient_id;
+    std::vector<std::string> document_uuids;
+    atna_event_outcome outcome{atna_event_outcome::success};
+    std::string failure_description;
+};
+
+/**
+ * @brief Abstract sink that receives one call per XDS.b transaction
+ *        attempt, regardless of outcome.
+ *
+ * Implementations map the event to an atna_audit_message and forward it
+ * to a transport. The default (null) implementation is available via
+ * make_null_xds_audit_sink() and is used when an actor is constructed
+ * without a sink - keeping the new feature opt-in and preserving the
+ * pre-audit-wiring semantics for existing callers.
+ *
+ * Thread safety: implementations must be safe for concurrent calls from
+ * multiple actor instances. The stock atna_sink satisfies this because
+ * atna_service_auditor uses atomic counters and a thread-safe transport.
+ */
+class xds_audit_sink {
+public:
+    virtual ~xds_audit_sink() = default;
+
+    virtual void on_iti41_submit(const xds_iti41_event& e) = 0;
+    virtual void on_iti43_retrieve(const xds_iti43_event& e) = 0;
+    virtual void on_iti18_query(const xds_iti18_event& e) = 0;
+};
+
+/**
+ * @brief Build a sink that discards every event.
+ *
+ * Used as the default when an actor is constructed without an explicit
+ * sink. Making the absence of a sink still produce a valid (no-op)
+ * object lets the actors call through unconditionally and avoids a
+ * null-check on every transaction.
+ */
+[[nodiscard]] std::shared_ptr<xds_audit_sink> make_null_xds_audit_sink();
+
+/**
+ * @brief Build a sink that forwards every event to the given
+ *        atna_service_auditor.
+ *
+ * The auditor instance must outlive the sink. The sink holds a raw
+ * pointer (not a shared ownership) because atna_service_auditor is
+ * typically a process-wide singleton owned by the service composition
+ * root - extending its ownership to every XDS actor would tangle the
+ * lifetime graph for no gain.
+ *
+ * @param auditor ATNA auditor that will emit the generated messages.
+ *                Must not be null.
+ * @param local_participant_id User/AE identifier to record in the
+ *                ActiveParticipant block for the local actor
+ *                (typically the Document Source / Consumer OID).
+ */
+[[nodiscard]] std::shared_ptr<xds_audit_sink> make_atna_xds_audit_sink(
+    atna_service_auditor& auditor, std::string local_participant_id);
+
+/**
+ * @brief Build a sink that captures every event into an in-memory
+ *        vector for inspection.
+ *
+ * Used by the integration test harness to assert that every success
+ * AND failure path emits exactly one event with the expected outcome
+ * and context fields. The returned sink exposes an events() accessor
+ * on the derived type; use std::dynamic_pointer_cast<recording_sink>
+ * to access it (header declares the recording type below so tests
+ * don't have to reach into implementation headers).
+ *
+ * @see recording_xds_audit_sink
+ */
+class recording_xds_audit_sink : public xds_audit_sink {
+public:
+    struct captured_event {
+        enum class kind : std::uint8_t { iti41, iti43, iti18 };
+        kind k{kind::iti41};
+        xds_iti41_event iti41;
+        xds_iti43_event iti43;
+        xds_iti18_event iti18;
+    };
+
+    void on_iti41_submit(const xds_iti41_event& e) override;
+    void on_iti43_retrieve(const xds_iti43_event& e) override;
+    void on_iti18_query(const xds_iti18_event& e) override;
+
+    [[nodiscard]] const std::vector<captured_event>& events() const noexcept;
+    void clear() noexcept;
+
+private:
+    std::vector<captured_event> events_;
+};
+
+}  // namespace kcenon::pacs::security
+
+#endif  // PACS_SECURITY_XDS_AUDIT_EVENTS_HPP

--- a/include/kcenon/pacs/security/xds_audit_events.h
+++ b/include/kcenon/pacs/security/xds_audit_events.h
@@ -188,6 +188,35 @@ private:
     std::vector<captured_event> events_;
 };
 
+// =============================================================================
+// Message-Build Helpers (testing surface)
+// =============================================================================
+
+/**
+ * @brief Build the RFC 3881 audit message for a given XDS.b event.
+ *
+ * Exposed so the integration tests can assert the exact event code /
+ * action / EventTypeCode against the IHE ATNA checklist without
+ * needing to spin up a syslog transport. Production code emits these
+ * via the atna_sink + atna_service_auditor::submit_audit_message path
+ * instead of calling these helpers directly.
+ *
+ * @param audit_source_id Value for AuditSourceIdentification/@code.
+ * @param event Transaction context captured by the XDS.b actor.
+ * @return Fully populated atna_audit_message ready for
+ *         atna_audit_logger::to_xml or submit_audit_message.
+ * @see Issue #1131
+ */
+[[nodiscard]] atna_audit_message build_iti41_audit_message(
+    const std::string& audit_source_id, const xds_iti41_event& event,
+    const std::string& local_participant_id = "");
+[[nodiscard]] atna_audit_message build_iti43_audit_message(
+    const std::string& audit_source_id, const xds_iti43_event& event,
+    const std::string& local_participant_id = "");
+[[nodiscard]] atna_audit_message build_iti18_audit_message(
+    const std::string& audit_source_id, const xds_iti18_event& event,
+    const std::string& local_participant_id = "");
+
 }  // namespace kcenon::pacs::security
 
 #endif  // PACS_SECURITY_XDS_AUDIT_EVENTS_HPP

--- a/src/ihe/xds/document_consumer.cpp
+++ b/src/ihe/xds/document_consumer.cpp
@@ -16,6 +16,9 @@
 #include "consumer/retrieve_envelope.h"
 #include "consumer/retrieve_response_parser.h"
 
+#include "kcenon/pacs/security/xds_audit_events.h"
+
+#include <memory>
 #include <string>
 #include <utility>
 
@@ -43,22 +46,33 @@ public:
     impl(http_options opts, signing_material signing)
         : opts_(std::move(opts)), signing_(std::move(signing)) {}
 
+    void set_audit_sink(
+        std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink) {
+        audit_sink_ = std::move(sink);
+    }
+
     kcenon::common::Result<document_response> retrieve(
         const std::string& document_unique_id,
         const std::string& repository_unique_id) {
+        auto do_audit =
+            [&](const kcenon::common::Result<document_response>& r) {
+                audit(document_unique_id, repository_unique_id, r);
+                return r;
+            };
+
         if (document_unique_id.empty()) {
-            return kcenon::common::make_error<document_response>(
+            return do_audit(kcenon::common::make_error<document_response>(
                 static_cast<int>(
                     error_code::consumer_retrieve_missing_document_id),
                 "retrieve: document_unique_id is empty",
-                std::string(error_source));
+                std::string(error_source)));
         }
         if (repository_unique_id.empty()) {
-            return kcenon::common::make_error<document_response>(
+            return do_audit(kcenon::common::make_error<document_response>(
                 static_cast<int>(
                     error_code::consumer_retrieve_missing_repository_id),
                 "retrieve: repository_unique_id is empty",
-                std::string(error_source));
+                std::string(error_source)));
         }
 
         retrieve_request req;
@@ -67,8 +81,8 @@ public:
 
         auto env_result = detail::build_iti43_envelope(req);
         if (env_result.is_err()) {
-            return kcenon::common::make_error<document_response>(
-                env_result.error());
+            return do_audit(kcenon::common::make_error<document_response>(
+                env_result.error()));
         }
         auto env = env_result.value();
 
@@ -76,8 +90,8 @@ public:
             env, signing_.certificate_pem, signing_.private_key_pem,
             signing_.private_key_password);
         if (sign_result.is_err()) {
-            return kcenon::common::make_error<document_response>(
-                sign_result.error());
+            return do_audit(kcenon::common::make_error<document_response>(
+                sign_result.error()));
         }
 
         // Per-call copy: the ITI-43 SOAP action is specific to this
@@ -91,32 +105,51 @@ public:
         auto http_result =
             detail::http_post(call_opts, kSoapContentType, env.xml);
         if (http_result.is_err()) {
-            return kcenon::common::make_error<document_response>(
-                http_result.error());
+            return do_audit(kcenon::common::make_error<document_response>(
+                http_result.error()));
         }
         auto response = http_result.value();
 
         auto parsed =
             detail::parse_mtom_response(response.content_type, response.body);
         if (parsed.is_err()) {
-            return kcenon::common::make_error<document_response>(
-                parsed.error());
+            return do_audit(kcenon::common::make_error<document_response>(
+                parsed.error()));
         }
         auto mtom = parsed.value();
 
         auto verify = detail::verify_envelope_integrity(mtom.root_xml);
         if (verify.is_err()) {
-            return kcenon::common::make_error<document_response>(
-                verify.error());
+            return do_audit(kcenon::common::make_error<document_response>(
+                verify.error()));
         }
 
-        return detail::parse_retrieve_response(mtom.root_xml, mtom.parts,
-                                               req);
+        return do_audit(detail::parse_retrieve_response(
+            mtom.root_xml, mtom.parts, req));
     }
 
 private:
+    void audit(const std::string& document_unique_id,
+               const std::string& repository_unique_id,
+               const kcenon::common::Result<document_response>& r) {
+        if (!audit_sink_) return;
+        kcenon::pacs::security::xds_iti43_event e;
+        e.source_endpoint = opts_.endpoint;
+        e.document_unique_id = document_unique_id;
+        e.repository_unique_id = repository_unique_id;
+        if (r.is_ok()) {
+            e.outcome = kcenon::pacs::security::atna_event_outcome::success;
+        } else {
+            e.outcome =
+                kcenon::pacs::security::atna_event_outcome::serious_failure;
+            e.failure_description = r.error().message;
+        }
+        audit_sink_->on_iti43_retrieve(e);
+    }
+
     http_options opts_;
     signing_material signing_;
+    std::shared_ptr<kcenon::pacs::security::xds_audit_sink> audit_sink_;
 };
 
 document_consumer::document_consumer(http_options opts,
@@ -133,6 +166,11 @@ kcenon::common::Result<document_response> document_consumer::retrieve(
     const std::string& document_unique_id,
     const std::string& repository_unique_id) {
     return impl_->retrieve(document_unique_id, repository_unique_id);
+}
+
+void document_consumer::set_audit_sink(
+    std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink) {
+    impl_->set_audit_sink(std::move(sink));
 }
 
 }  // namespace kcenon::pacs::ihe::xds

--- a/src/ihe/xds/document_source.cpp
+++ b/src/ihe/xds/document_source.cpp
@@ -14,6 +14,8 @@
 #include "common/soap_envelope.h"
 #include "common/wss_signer.h"
 
+#include "kcenon/pacs/security/xds_audit_events.h"
+
 #include <pugixml.hpp>
 
 #include <chrono>
@@ -45,7 +47,26 @@ public:
     impl(http_options opts, signing_material signing)
         : opts_(std::move(opts)), signing_(std::move(signing)) {}
 
+    void set_audit_sink(
+        std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink) {
+        audit_sink_ = std::move(sink);
+    }
+
     kcenon::common::Result<submit_response> submit(const submission_set& s) {
+        // Collect document unique ids up-front so an audit event can
+        // reference them even when submission fails before the wire
+        // payload is built.
+        std::vector<std::string> document_uids;
+        document_uids.reserve(s.documents.size());
+        for (const auto& d : s.documents) {
+            document_uids.push_back(d.unique_id);
+        }
+
+        auto do_audit = [&](const kcenon::common::Result<submit_response>& r) {
+            audit(s, document_uids, r);
+            return r;
+        };
+
         std::vector<std::string> cids;
         cids.reserve(s.documents.size());
         for (std::size_t i = 0; i < s.documents.size(); ++i) {
@@ -54,8 +75,8 @@ public:
 
         auto env_result = detail::build_iti41_envelope(s, cids);
         if (env_result.is_err()) {
-            return kcenon::common::make_error<submit_response>(
-                env_result.error());
+            return do_audit(kcenon::common::make_error<submit_response>(
+                env_result.error()));
         }
         auto env = env_result.value();
 
@@ -63,8 +84,8 @@ public:
             env, signing_.certificate_pem, signing_.private_key_pem,
             signing_.private_key_password);
         if (sign_result.is_err()) {
-            return kcenon::common::make_error<submit_response>(
-                sign_result.error());
+            return do_audit(kcenon::common::make_error<submit_response>(
+                sign_result.error()));
         }
 
         std::vector<detail::mtom_part> parts;
@@ -79,21 +100,21 @@ public:
 
         auto mtom_result = detail::package_mtom(env.xml, parts);
         if (mtom_result.is_err()) {
-            return kcenon::common::make_error<submit_response>(
-                mtom_result.error());
+            return do_audit(kcenon::common::make_error<submit_response>(
+                mtom_result.error()));
         }
         auto mtom = mtom_result.value();
 
         auto http_result =
             detail::http_post(opts_, mtom.content_type, mtom.body);
         if (http_result.is_err()) {
-            return kcenon::common::make_error<submit_response>(
-                http_result.error());
+            return do_audit(kcenon::common::make_error<submit_response>(
+                http_result.error()));
         }
         auto response = http_result.value();
 
-        return parse_registry_response(response.body,
-                                       s.submission_set_unique_id);
+        return do_audit(parse_registry_response(response.body,
+                                                s.submission_set_unique_id));
     }
 
 private:
@@ -170,8 +191,29 @@ private:
             std::string(error_source));
     }
 
+    void audit(const submission_set& s,
+               const std::vector<std::string>& document_uids,
+               const kcenon::common::Result<submit_response>& r) {
+        if (!audit_sink_) return;
+        kcenon::pacs::security::xds_iti41_event e;
+        e.source_id = s.source_id;
+        e.destination_endpoint = opts_.endpoint;
+        e.patient_id = s.patient_id;
+        e.submission_set_unique_id = s.submission_set_unique_id;
+        e.document_unique_ids = document_uids;
+        if (r.is_ok()) {
+            e.outcome = kcenon::pacs::security::atna_event_outcome::success;
+        } else {
+            e.outcome =
+                kcenon::pacs::security::atna_event_outcome::serious_failure;
+            e.failure_description = r.error().message;
+        }
+        audit_sink_->on_iti41_submit(e);
+    }
+
     http_options opts_;
     signing_material signing_;
+    std::shared_ptr<kcenon::pacs::security::xds_audit_sink> audit_sink_;
 };
 
 document_source::document_source(http_options opts, signing_material signing)
@@ -185,6 +227,11 @@ document_source::~document_source() = default;
 kcenon::common::Result<submit_response> document_source::submit(
     const submission_set& s) {
     return impl_->submit(s);
+}
+
+void document_source::set_audit_sink(
+    std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink) {
+    impl_->set_audit_sink(std::move(sink));
 }
 
 }  // namespace kcenon::pacs::ihe::xds

--- a/src/ihe/xds/registry_query.cpp
+++ b/src/ihe/xds/registry_query.cpp
@@ -15,6 +15,9 @@
 #include "registry_query/query_envelope.h"
 #include "registry_query/query_response_parser.h"
 
+#include "kcenon/pacs/security/xds_audit_events.h"
+
+#include <memory>
 #include <string>
 #include <utility>
 #include <vector>
@@ -75,83 +78,105 @@ public:
     impl(http_options opts, signing_material signing)
         : opts_(std::move(opts)), signing_(std::move(signing)) {}
 
+    void set_audit_sink(
+        std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink) {
+        audit_sink_ = std::move(sink);
+    }
+
     kcenon::common::Result<registry_query_result> find_documents(
         const std::string& patient_id,
         const registry_query_options& options) {
+        auto do_audit =
+            [&](const kcenon::common::Result<registry_query_result>& r) {
+                audit_find(patient_id, r);
+                return r;
+            };
+
         if (patient_id.empty()) {
-            return kcenon::common::make_error<registry_query_result>(
+            return do_audit(kcenon::common::make_error<registry_query_result>(
                 static_cast<int>(
                     error_code::registry_query_missing_patient_id),
                 "find_documents: patient_id is empty",
-                std::string(error_source));
+                std::string(error_source)));
         }
         if (contains_slot_literal_metachar(patient_id)) {
-            return kcenon::common::make_error<registry_query_result>(
+            return do_audit(kcenon::common::make_error<registry_query_result>(
                 static_cast<int>(
                     error_code::registry_query_invalid_patient_id),
                 "find_documents: patient_id contains a character that is "
                 "not legal inside an ebRIM StoredQuery slot literal "
                 "('(),\\' or control character)",
-                std::string(error_source));
+                std::string(error_source)));
         }
         for (const auto& s : options.status_values) {
             if (contains_slot_literal_metachar(s)) {
-                return kcenon::common::make_error<registry_query_result>(
-                    static_cast<int>(
-                        error_code::registry_query_invalid_patient_id),
-                    "find_documents: options.status_values contains a "
-                    "slot-literal metacharacter",
-                    std::string(error_source));
+                return do_audit(
+                    kcenon::common::make_error<registry_query_result>(
+                        static_cast<int>(
+                            error_code::registry_query_invalid_patient_id),
+                        "find_documents: options.status_values contains a "
+                        "slot-literal metacharacter",
+                        std::string(error_source)));
             }
         }
         if (contains_slot_literal_metachar(options.creation_time_from) ||
             contains_slot_literal_metachar(options.creation_time_to)) {
-            return kcenon::common::make_error<registry_query_result>(
+            return do_audit(kcenon::common::make_error<registry_query_result>(
                 static_cast<int>(
                     error_code::registry_query_invalid_patient_id),
                 "find_documents: options.creation_time_* contains a "
                 "slot-literal metacharacter",
-                std::string(error_source));
+                std::string(error_source)));
         }
 
         registry_query_request req;
         req.patient_id = patient_id;
         req.options = options;
 
-        return execute(req, detail::stored_query_kind::find_documents);
+        return do_audit(
+            execute(req, detail::stored_query_kind::find_documents));
     }
 
     kcenon::common::Result<registry_query_result> get_documents(
         const std::vector<std::string>& uuids) {
+        auto do_audit =
+            [&](const kcenon::common::Result<registry_query_result>& r) {
+                audit_get(uuids, r);
+                return r;
+            };
+
         if (uuids.empty()) {
-            return kcenon::common::make_error<registry_query_result>(
+            return do_audit(kcenon::common::make_error<registry_query_result>(
                 static_cast<int>(
                     error_code::registry_query_empty_uuid_list),
                 "get_documents: uuids is empty",
-                std::string(error_source));
+                std::string(error_source)));
         }
         for (const auto& u : uuids) {
             if (u.empty()) {
-                return kcenon::common::make_error<registry_query_result>(
-                    static_cast<int>(
-                        error_code::registry_query_missing_document_uuid),
-                    "get_documents: uuids contains an empty element",
-                    std::string(error_source));
+                return do_audit(
+                    kcenon::common::make_error<registry_query_result>(
+                        static_cast<int>(
+                            error_code::registry_query_missing_document_uuid),
+                        "get_documents: uuids contains an empty element",
+                        std::string(error_source)));
             }
             if (contains_slot_literal_metachar(u)) {
-                return kcenon::common::make_error<registry_query_result>(
-                    static_cast<int>(
-                        error_code::registry_query_missing_document_uuid),
-                    "get_documents: uuids contains an element with a "
-                    "slot-literal metacharacter",
-                    std::string(error_source));
+                return do_audit(
+                    kcenon::common::make_error<registry_query_result>(
+                        static_cast<int>(
+                            error_code::registry_query_missing_document_uuid),
+                        "get_documents: uuids contains an element with a "
+                        "slot-literal metacharacter",
+                        std::string(error_source)));
             }
         }
 
         registry_query_request req;
         req.document_uuids = uuids;
 
-        return execute(req, detail::stored_query_kind::get_documents);
+        return do_audit(
+            execute(req, detail::stored_query_kind::get_documents));
     }
 
 private:
@@ -203,8 +228,45 @@ private:
         return detail::parse_query_response(response.body);
     }
 
+    void audit_find(const std::string& patient_id,
+                    const kcenon::common::Result<registry_query_result>& r) {
+        if (!audit_sink_) return;
+        kcenon::pacs::security::xds_iti18_event e;
+        e.registry_endpoint = opts_.endpoint;
+        e.query_kind =
+            kcenon::pacs::security::xds_iti18_event::kind::find_documents;
+        e.patient_id = patient_id;
+        if (r.is_ok()) {
+            e.outcome = kcenon::pacs::security::atna_event_outcome::success;
+        } else {
+            e.outcome =
+                kcenon::pacs::security::atna_event_outcome::serious_failure;
+            e.failure_description = r.error().message;
+        }
+        audit_sink_->on_iti18_query(e);
+    }
+
+    void audit_get(const std::vector<std::string>& uuids,
+                   const kcenon::common::Result<registry_query_result>& r) {
+        if (!audit_sink_) return;
+        kcenon::pacs::security::xds_iti18_event e;
+        e.registry_endpoint = opts_.endpoint;
+        e.query_kind =
+            kcenon::pacs::security::xds_iti18_event::kind::get_documents;
+        e.document_uuids = uuids;
+        if (r.is_ok()) {
+            e.outcome = kcenon::pacs::security::atna_event_outcome::success;
+        } else {
+            e.outcome =
+                kcenon::pacs::security::atna_event_outcome::serious_failure;
+            e.failure_description = r.error().message;
+        }
+        audit_sink_->on_iti18_query(e);
+    }
+
     http_options opts_;
     signing_material signing_;
+    std::shared_ptr<kcenon::pacs::security::xds_audit_sink> audit_sink_;
 };
 
 registry_query::registry_query(http_options opts, signing_material signing)
@@ -223,6 +285,11 @@ kcenon::common::Result<registry_query_result> registry_query::find_documents(
 kcenon::common::Result<registry_query_result> registry_query::get_documents(
     const std::vector<std::string>& uuids) {
     return impl_->get_documents(uuids);
+}
+
+void registry_query::set_audit_sink(
+    std::shared_ptr<kcenon::pacs::security::xds_audit_sink> sink) {
+    impl_->set_audit_sink(std::move(sink));
 }
 
 }  // namespace kcenon::pacs::ihe::xds

--- a/src/security/atna_service_auditor.cpp
+++ b/src/security/atna_service_auditor.cpp
@@ -300,6 +300,14 @@ const atna_syslog_transport& atna_service_auditor::transport() const noexcept {
     return transport_;
 }
 
+void atna_service_auditor::submit_audit_message(
+    const atna_audit_message& message) {
+    if (!enabled_.load(std::memory_order_relaxed)) {
+        return;
+    }
+    send_audit(message);
+}
+
 // =============================================================================
 // Private Helpers
 // =============================================================================

--- a/src/security/xds_audit_events.cpp
+++ b/src/security/xds_audit_events.cpp
@@ -1,0 +1,166 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file xds_audit_events.cpp
+ * @brief Implementation of the XDS.b audit event sinks.
+ */
+
+#include "kcenon/pacs/security/xds_audit_events.h"
+
+#include "kcenon/pacs/security/atna_service_auditor.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace kcenon::pacs::security {
+
+namespace {
+
+class null_sink : public xds_audit_sink {
+public:
+    void on_iti41_submit(const xds_iti41_event&) override {}
+    void on_iti43_retrieve(const xds_iti43_event&) override {}
+    void on_iti18_query(const xds_iti18_event&) override {}
+};
+
+// Concrete sink that forwards each XDS.b event to an atna_service_auditor.
+// The auditor already knows how to turn transaction context into well-formed
+// RFC 3881 audit messages with the right DCM event codes (Export for ITI-41,
+// DICOM Instances Transferred for ITI-43, Query for ITI-18) and already owns
+// the syslog transport plus statistics counters, so this sink is pure glue.
+class atna_sink : public xds_audit_sink {
+public:
+    atna_sink(atna_service_auditor& auditor, std::string local_participant_id)
+        : auditor_(&auditor),
+          local_participant_id_(std::move(local_participant_id)) {}
+
+    void on_iti41_submit(const xds_iti41_event& e) override {
+        const std::string source =
+            local_participant_id_.empty() ? e.source_id : local_participant_id_;
+        // ITI-41 is a source-side XDS transaction: the existing facade
+        // method emits the DCM 110106 Export event tagged with the
+        // ITI-41 transaction code. study_uid has no natural value at
+        // the XDS layer, so we pass the submission set UID as a stable
+        // grouping key that auditors can correlate across multiple
+        // documents in one submission.
+        auditor_->audit_xds_provide_and_register(
+            atna_service_auditor::xds_source_transaction::iti_41,
+            source,
+            e.destination_endpoint,
+            e.submission_set_unique_id,
+            e.patient_id,
+            e.document_unique_ids,
+            e.outcome == atna_event_outcome::success);
+    }
+
+    void on_iti43_retrieve(const xds_iti43_event& e) override {
+        const std::string dest =
+            local_participant_id_.empty() ? e.consumer_id
+                                          : local_participant_id_;
+        // ITI-43 is a consumer-side XDS transaction: the facade method
+        // emits DCM 110104 "DICOM Instances Transferred" with is_import
+        // true, tagged with the ITI-43 transaction code. Use the
+        // document unique id as the per-transaction object reference.
+        std::vector<std::string> refs;
+        if (!e.document_unique_id.empty()) {
+            refs.push_back(e.document_unique_id);
+        }
+        auditor_->audit_xds_retrieve(
+            atna_service_auditor::xds_consumer_transaction::iti_43,
+            e.source_endpoint,
+            dest,
+            /*study_uid=*/"",
+            /*patient_id=*/"",
+            refs,
+            e.outcome == atna_event_outcome::success);
+    }
+
+    void on_iti18_query(const xds_iti18_event& e) override {
+        // ITI-18 is a registry metadata query. atna_service_auditor has
+        // no XDS-specific query method, so we route through the generic
+        // audit_query facade which emits DCM 110112. The query_level
+        // string captures the FindDocuments / GetDocuments distinction
+        // plus the query keys so an auditor can reconstruct the query
+        // context without pulling the wire body.
+        std::string query_level;
+        if (e.query_kind == xds_iti18_event::kind::find_documents) {
+            query_level = "ITI-18 FindDocuments PatientID=" + e.patient_id;
+        } else {
+            query_level = "ITI-18 GetDocuments UUIDs=";
+            bool first = true;
+            for (const auto& u : e.document_uuids) {
+                if (!first) query_level += ',';
+                first = false;
+                query_level += u;
+            }
+        }
+        const std::string caller =
+            local_participant_id_.empty() ? e.querier_id
+                                          : local_participant_id_;
+        auditor_->audit_query(
+            caller,
+            e.registry_endpoint,
+            query_level,
+            e.outcome == atna_event_outcome::success);
+    }
+
+private:
+    atna_service_auditor* auditor_;
+    std::string local_participant_id_;
+};
+
+}  // namespace
+
+// -----------------------------------------------------------------------------
+// Factories
+// -----------------------------------------------------------------------------
+
+std::shared_ptr<xds_audit_sink> make_null_xds_audit_sink() {
+    return std::make_shared<null_sink>();
+}
+
+std::shared_ptr<xds_audit_sink> make_atna_xds_audit_sink(
+    atna_service_auditor& auditor, std::string local_participant_id) {
+    return std::make_shared<atna_sink>(auditor,
+                                       std::move(local_participant_id));
+}
+
+// -----------------------------------------------------------------------------
+// recording_xds_audit_sink
+// -----------------------------------------------------------------------------
+
+void recording_xds_audit_sink::on_iti41_submit(const xds_iti41_event& e) {
+    captured_event c;
+    c.k = captured_event::kind::iti41;
+    c.iti41 = e;
+    events_.push_back(std::move(c));
+}
+
+void recording_xds_audit_sink::on_iti43_retrieve(const xds_iti43_event& e) {
+    captured_event c;
+    c.k = captured_event::kind::iti43;
+    c.iti43 = e;
+    events_.push_back(std::move(c));
+}
+
+void recording_xds_audit_sink::on_iti18_query(const xds_iti18_event& e) {
+    captured_event c;
+    c.k = captured_event::kind::iti18;
+    c.iti18 = e;
+    events_.push_back(std::move(c));
+}
+
+const std::vector<recording_xds_audit_sink::captured_event>&
+recording_xds_audit_sink::events() const noexcept {
+    return events_;
+}
+
+void recording_xds_audit_sink::clear() noexcept {
+    events_.clear();
+}
+
+}  // namespace kcenon::pacs::security

--- a/src/security/xds_audit_events.cpp
+++ b/src/security/xds_audit_events.cpp
@@ -5,18 +5,258 @@
 /**
  * @file xds_audit_events.cpp
  * @brief Implementation of the XDS.b audit event sinks.
+ *
+ * RFC 3881 / DICOM PS3.15 A.5 / IHE ITI TF-2 event code mapping used
+ * here (aligned with the reviewer's Task-2 checklist):
+ *
+ *   ITI-18 RegistryStoredQuery
+ *     EventID         DCM 110112 Query
+ *     EventAction     E (Execute)
+ *     EventTypeCode   urn:ihe:iti:2007:RegistryStoredQuery
+ *                     (code system "IHETransactions")
+ *
+ *   ITI-41 Provide and Register Document Set-b (Source-side)
+ *     EventID         DCM 110106 Export
+ *     EventAction     C (Create)
+ *     EventTypeCode   ITI-41 (code system "IHETransactions")
+ *
+ *   ITI-43 Retrieve Document Set (Consumer-side)
+ *     EventID         DCM 110107 Import
+ *     EventAction     R (Read)
+ *     EventTypeCode   ITI-43 (code system "IHETransactions")
+ *
+ * Messages are built by free functions (build_iti18/41/43_audit_message)
+ * so the integration tests can assert the exact codes without spinning
+ * up a syslog transport. The atna_sink delegates to those builders and
+ * routes the result through atna_service_auditor::submit_audit_message
+ * so emission stays serialized and the enabled-flag / statistics path
+ * is shared with every other audit method (reviewer cross-cut §3).
  */
 
 #include "kcenon/pacs/security/xds_audit_events.h"
 
 #include "kcenon/pacs/security/atna_service_auditor.h"
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
 #include <vector>
 
 namespace kcenon::pacs::security {
+
+namespace {
+
+// -----------------------------------------------------------------------------
+// RFC 3881 coded-value constants
+// -----------------------------------------------------------------------------
+
+// EventID values the reviewer's Task-2 checklist pins per transaction.
+// DCM 110107 Import is not in atna_event_ids (only Export 110106 is), so
+// both are declared here to keep the vocabulary in one place.
+const atna_coded_value kEventIdExport{
+    "110106", "DCM", "Export"};
+const atna_coded_value kEventIdImport{
+    "110107", "DCM", "Import"};
+const atna_coded_value kEventIdQuery{
+    "110112", "DCM", "Query"};
+
+// EventTypeCodes - code system "IHETransactions" per IHE ITI TF-2a
+// Audit Trail Profile. The ITI-18 code uses the full URN form the
+// reviewer specified; ITI-41/43 use the short transaction label that
+// matches the existing atna_service_auditor convention.
+const atna_coded_value kEventTypeIti18{
+    "urn:ihe:iti:2007:RegistryStoredQuery",
+    "IHETransactions",
+    "Registry Stored Query"};
+const atna_coded_value kEventTypeIti41{
+    "ITI-41", "IHETransactions",
+    "Provide and Register Document Set-b"};
+const atna_coded_value kEventTypeIti43{
+    "ITI-43", "IHETransactions", "Retrieve Document Set"};
+
+// Object ID type codes for participant objects.
+const atna_coded_value kXdsDocumentUniqueIdType{
+    "urn:ihe:iti:xds:2013:uniqueId", "IHE XDS Metadata",
+    "XDSDocumentEntry.uniqueId"};
+const atna_coded_value kXdsEntryUuidType{
+    "urn:ihe:iti:xds:2013:entryUUID", "IHE XDS Metadata",
+    "XDSDocumentEntry.entryUUID"};
+const atna_coded_value kXdsSubmissionSetUidType{
+    "urn:ihe:iti:xds:2013:submissionSet.uniqueId", "IHE XDS Metadata",
+    "XDSSubmissionSet.uniqueId"};
+
+// -----------------------------------------------------------------------------
+// Helpers
+// -----------------------------------------------------------------------------
+
+atna_active_participant make_participant(const std::string& user_id,
+                                         bool is_requestor,
+                                         const atna_coded_value& role) {
+    atna_active_participant p;
+    p.user_id = user_id;
+    p.user_is_requestor = is_requestor;
+    p.network_access_point_type = atna_network_access_type::machine_name;
+    p.role_id_codes.push_back(role);
+    return p;
+}
+
+void attach_failure_detail(atna_audit_message& msg,
+                           const std::string& description) {
+    if (description.empty()) return;
+    atna_object_detail d;
+    d.type = "FailureDescription";
+    d.value = description;
+    if (msg.participant_objects.empty()) {
+        atna_participant_object synth;
+        synth.object_type = atna_object_type::system_object;
+        synth.object_role = atna_object_role::report;
+        synth.object_id_type_code = kXdsDocumentUniqueIdType;
+        synth.object_id = "(no object context)";
+        synth.object_details.push_back(std::move(d));
+        msg.participant_objects.push_back(std::move(synth));
+    } else {
+        msg.participant_objects.back().object_details.push_back(std::move(d));
+    }
+}
+
+}  // namespace
+
+// -----------------------------------------------------------------------------
+// Message builders (public, testing surface)
+// -----------------------------------------------------------------------------
+
+atna_audit_message build_iti41_audit_message(
+    const std::string& audit_source_id, const xds_iti41_event& e,
+    const std::string& local_participant_id) {
+    atna_audit_message msg;
+    msg.event_id = kEventIdExport;
+    msg.event_action = atna_event_action::create;  // 'C'
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = e.outcome;
+    msg.event_type_codes.push_back(kEventTypeIti41);
+    msg.audit_source.audit_source_id = audit_source_id;
+
+    const std::string source =
+        local_participant_id.empty() ? e.source_id : local_participant_id;
+    msg.active_participants.push_back(
+        make_participant(source, true, atna_role_ids::source));
+    msg.active_participants.push_back(make_participant(
+        e.destination_endpoint, false, atna_role_ids::destination));
+
+    if (!e.submission_set_unique_id.empty()) {
+        atna_participant_object ss;
+        ss.object_type = atna_object_type::system_object;
+        ss.object_role = atna_object_role::report;
+        ss.object_id_type_code = kXdsSubmissionSetUidType;
+        ss.object_id = e.submission_set_unique_id;
+        msg.participant_objects.push_back(std::move(ss));
+    }
+    for (const auto& uid : e.document_unique_ids) {
+        if (uid.empty()) continue;
+        atna_participant_object d;
+        d.object_type = atna_object_type::system_object;
+        d.object_role = atna_object_role::report;
+        d.object_id_type_code = kXdsDocumentUniqueIdType;
+        d.object_id = uid;
+        msg.participant_objects.push_back(std::move(d));
+    }
+    if (!e.patient_id.empty()) {
+        atna_participant_object p;
+        p.object_type = atna_object_type::person;
+        p.object_role = atna_object_role::patient;
+        p.object_id_type_code = atna_object_id_types::patient_number;
+        p.object_id = e.patient_id;
+        msg.participant_objects.push_back(std::move(p));
+    }
+    attach_failure_detail(msg, e.failure_description);
+    return msg;
+}
+
+atna_audit_message build_iti43_audit_message(
+    const std::string& audit_source_id, const xds_iti43_event& e,
+    const std::string& local_participant_id) {
+    atna_audit_message msg;
+    msg.event_id = kEventIdImport;
+    msg.event_action = atna_event_action::read;  // 'R'
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = e.outcome;
+    msg.event_type_codes.push_back(kEventTypeIti43);
+    msg.audit_source.audit_source_id = audit_source_id;
+
+    const std::string consumer =
+        local_participant_id.empty() ? e.consumer_id : local_participant_id;
+    // Consumer side: the local actor is the requestor pulling from a
+    // remote repository. Source role = remote repository (not
+    // requestor), destination role = local consumer (requestor).
+    msg.active_participants.push_back(
+        make_participant(e.source_endpoint, false, atna_role_ids::source));
+    msg.active_participants.push_back(
+        make_participant(consumer, true, atna_role_ids::destination));
+
+    if (!e.document_unique_id.empty()) {
+        atna_participant_object d;
+        d.object_type = atna_object_type::system_object;
+        d.object_role = atna_object_role::report;
+        d.object_id_type_code = kXdsDocumentUniqueIdType;
+        d.object_id = e.document_unique_id;
+        msg.participant_objects.push_back(std::move(d));
+    }
+    if (!e.repository_unique_id.empty()) {
+        atna_participant_object r;
+        r.object_type = atna_object_type::system_object;
+        r.object_role = atna_object_role::resource;
+        r.object_id_type_code = atna_object_id_types::node_id;
+        r.object_id = e.repository_unique_id;
+        msg.participant_objects.push_back(std::move(r));
+    }
+    attach_failure_detail(msg, e.failure_description);
+    return msg;
+}
+
+atna_audit_message build_iti18_audit_message(
+    const std::string& audit_source_id, const xds_iti18_event& e,
+    const std::string& local_participant_id) {
+    atna_audit_message msg;
+    msg.event_id = kEventIdQuery;
+    msg.event_action = atna_event_action::execute;  // 'E'
+    msg.event_date_time = std::chrono::system_clock::now();
+    msg.event_outcome = e.outcome;
+    msg.event_type_codes.push_back(kEventTypeIti18);
+    msg.audit_source.audit_source_id = audit_source_id;
+
+    const std::string caller =
+        local_participant_id.empty() ? e.querier_id : local_participant_id;
+    msg.active_participants.push_back(
+        make_participant(caller, true, atna_role_ids::source));
+    msg.active_participants.push_back(make_participant(
+        e.registry_endpoint, false, atna_role_ids::destination));
+
+    if (e.query_kind == xds_iti18_event::kind::find_documents &&
+        !e.patient_id.empty()) {
+        atna_participant_object p;
+        p.object_type = atna_object_type::person;
+        p.object_role = atna_object_role::patient;
+        p.object_id_type_code = atna_object_id_types::patient_number;
+        p.object_id = e.patient_id;
+        msg.participant_objects.push_back(std::move(p));
+    }
+    for (const auto& u : e.document_uuids) {
+        if (u.empty()) continue;
+        atna_participant_object obj;
+        obj.object_type = atna_object_type::system_object;
+        obj.object_role = atna_object_role::query;
+        obj.object_id_type_code = kXdsEntryUuidType;
+        obj.object_id = u;
+        msg.participant_objects.push_back(std::move(obj));
+    }
+    attach_failure_detail(msg, e.failure_description);
+    return msg;
+}
+
+// -----------------------------------------------------------------------------
+// Sinks
+// -----------------------------------------------------------------------------
 
 namespace {
 
@@ -27,11 +267,6 @@ public:
     void on_iti18_query(const xds_iti18_event&) override {}
 };
 
-// Concrete sink that forwards each XDS.b event to an atna_service_auditor.
-// The auditor already knows how to turn transaction context into well-formed
-// RFC 3881 audit messages with the right DCM event codes (Export for ITI-41,
-// DICOM Instances Transferred for ITI-43, Query for ITI-18) and already owns
-// the syslog transport plus statistics counters, so this sink is pure glue.
 class atna_sink : public xds_audit_sink {
 public:
     atna_sink(atna_service_auditor& auditor, std::string local_participant_id)
@@ -39,73 +274,16 @@ public:
           local_participant_id_(std::move(local_participant_id)) {}
 
     void on_iti41_submit(const xds_iti41_event& e) override {
-        const std::string source =
-            local_participant_id_.empty() ? e.source_id : local_participant_id_;
-        // ITI-41 is a source-side XDS transaction: the existing facade
-        // method emits the DCM 110106 Export event tagged with the
-        // ITI-41 transaction code. study_uid has no natural value at
-        // the XDS layer, so we pass the submission set UID as a stable
-        // grouping key that auditors can correlate across multiple
-        // documents in one submission.
-        auditor_->audit_xds_provide_and_register(
-            atna_service_auditor::xds_source_transaction::iti_41,
-            source,
-            e.destination_endpoint,
-            e.submission_set_unique_id,
-            e.patient_id,
-            e.document_unique_ids,
-            e.outcome == atna_event_outcome::success);
+        auditor_->submit_audit_message(build_iti41_audit_message(
+            auditor_->audit_source_id(), e, local_participant_id_));
     }
-
     void on_iti43_retrieve(const xds_iti43_event& e) override {
-        const std::string dest =
-            local_participant_id_.empty() ? e.consumer_id
-                                          : local_participant_id_;
-        // ITI-43 is a consumer-side XDS transaction: the facade method
-        // emits DCM 110104 "DICOM Instances Transferred" with is_import
-        // true, tagged with the ITI-43 transaction code. Use the
-        // document unique id as the per-transaction object reference.
-        std::vector<std::string> refs;
-        if (!e.document_unique_id.empty()) {
-            refs.push_back(e.document_unique_id);
-        }
-        auditor_->audit_xds_retrieve(
-            atna_service_auditor::xds_consumer_transaction::iti_43,
-            e.source_endpoint,
-            dest,
-            /*study_uid=*/"",
-            /*patient_id=*/"",
-            refs,
-            e.outcome == atna_event_outcome::success);
+        auditor_->submit_audit_message(build_iti43_audit_message(
+            auditor_->audit_source_id(), e, local_participant_id_));
     }
-
     void on_iti18_query(const xds_iti18_event& e) override {
-        // ITI-18 is a registry metadata query. atna_service_auditor has
-        // no XDS-specific query method, so we route through the generic
-        // audit_query facade which emits DCM 110112. The query_level
-        // string captures the FindDocuments / GetDocuments distinction
-        // plus the query keys so an auditor can reconstruct the query
-        // context without pulling the wire body.
-        std::string query_level;
-        if (e.query_kind == xds_iti18_event::kind::find_documents) {
-            query_level = "ITI-18 FindDocuments PatientID=" + e.patient_id;
-        } else {
-            query_level = "ITI-18 GetDocuments UUIDs=";
-            bool first = true;
-            for (const auto& u : e.document_uuids) {
-                if (!first) query_level += ',';
-                first = false;
-                query_level += u;
-            }
-        }
-        const std::string caller =
-            local_participant_id_.empty() ? e.querier_id
-                                          : local_participant_id_;
-        auditor_->audit_query(
-            caller,
-            e.registry_endpoint,
-            query_level,
-            e.outcome == atna_event_outcome::success);
+        auditor_->submit_audit_message(build_iti18_audit_message(
+            auditor_->audit_source_id(), e, local_participant_id_));
     }
 
 private:

--- a/tests/integration/ihe/xds/xds_atna_integration_test.cpp
+++ b/tests/integration/ihe/xds/xds_atna_integration_test.cpp
@@ -1,0 +1,608 @@
+// BSD 3-Clause License
+// Copyright (c) 2021-2025, 🍀☀🌕🌥 🌊
+// See the LICENSE file in the project root for full license information.
+
+/**
+ * @file xds_atna_integration_test.cpp
+ * @brief Gazelle-lite integration harness for IHE XDS.b ATNA audit
+ *        emission (Issue #1131).
+ *
+ * Exercises each of the three XDS.b actors end-to-end through the
+ * detail::set_http_transport_override hook, wiring a
+ * recording_xds_audit_sink to the actor and asserting that:
+ *
+ *   1. Every success AND failure path emits exactly one audit event.
+ *   2. The event carries the expected outcome code
+ *      (atna_event_outcome::success or serious_failure).
+ *   3. The event captures transaction context - patient id, document
+ *      uids, endpoint - so a downstream ATNA aggregator can reconstruct
+ *      the transaction without re-parsing the wire.
+ *
+ * Scope: in-process. The transport override returns canned SOAP
+ * envelopes the real parsers accept, so no docker-compose registry is
+ * needed. This is the cheapest CI shape that still exercises the full
+ * Result<T> -> audit-sink plumbing, and matches the "gazelle-lite"
+ * framing from the issue body.
+ *
+ * CTest label: pacs_xds_integration
+ */
+
+#include "../../../../src/ihe/xds/common/http_client.h"
+#include "../../../../src/ihe/xds/common/soap_envelope.h"
+#include "../../../../src/ihe/xds/common/wss_signer.h"
+
+#include <kcenon/pacs/ihe/xds/document_consumer.h>
+#include <kcenon/pacs/ihe/xds/document_source.h>
+#include <kcenon/pacs/ihe/xds/errors.h>
+#include <kcenon/pacs/ihe/xds/http_options.h>
+#include <kcenon/pacs/ihe/xds/registry_query.h>
+#include <kcenon/pacs/ihe/xds/submission_set.h>
+#include <kcenon/pacs/security/xds_audit_events.h>
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <openssl/bio.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
+#include <openssl/x509.h>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace kcenon::pacs::ihe::xds;
+using kcenon::pacs::security::atna_event_outcome;
+using kcenon::pacs::security::recording_xds_audit_sink;
+using kcenon::pacs::security::xds_iti18_event;
+
+namespace {
+
+// -- Crypto helpers ----------------------------------------------------------
+
+struct bio_deleter {
+    void operator()(BIO* b) const noexcept {
+        if (b) BIO_free_all(b);
+    }
+};
+using bio_ptr = std::unique_ptr<BIO, bio_deleter>;
+
+struct pkey_deleter {
+    void operator()(EVP_PKEY* p) const noexcept {
+        if (p) EVP_PKEY_free(p);
+    }
+};
+using pkey_ptr = std::unique_ptr<EVP_PKEY, pkey_deleter>;
+
+struct x509_deleter {
+    void operator()(X509* x) const noexcept {
+        if (x) X509_free(x);
+    }
+};
+using x509_ptr = std::unique_ptr<X509, x509_deleter>;
+
+signing_material make_signing(const char* subject_cn) {
+    pkey_ptr pkey(EVP_RSA_gen(2048));
+    REQUIRE(pkey);
+    x509_ptr cert(X509_new());
+    X509_set_version(cert.get(), 2);
+    ASN1_INTEGER_set(X509_get_serialNumber(cert.get()), 1);
+    X509_gmtime_adj(X509_getm_notBefore(cert.get()), 0);
+    X509_gmtime_adj(X509_getm_notAfter(cert.get()), 60L * 60 * 24 * 30);
+    X509_set_pubkey(cert.get(), pkey.get());
+    X509_NAME* name = X509_get_subject_name(cert.get());
+    X509_NAME_add_entry_by_txt(
+        name, "CN", MBSTRING_ASC,
+        reinterpret_cast<const unsigned char*>(subject_cn), -1, -1, 0);
+    X509_set_issuer_name(cert.get(), name);
+    X509_sign(cert.get(), pkey.get(), EVP_sha256());
+
+    signing_material s;
+    bio_ptr cb(BIO_new(BIO_s_mem()));
+    PEM_write_bio_X509(cb.get(), cert.get());
+    char* buf = nullptr;
+    long n = BIO_get_mem_data(cb.get(), &buf);
+    s.certificate_pem.assign(buf, static_cast<std::size_t>(n));
+
+    bio_ptr kb(BIO_new(BIO_s_mem()));
+    PEM_write_bio_PrivateKey(kb.get(), pkey.get(), nullptr, nullptr, 0,
+                             nullptr, nullptr);
+    n = BIO_get_mem_data(kb.get(), &buf);
+    s.private_key_pem.assign(buf, static_cast<std::size_t>(n));
+
+    return s;
+}
+
+// -- Transport override scope guard -----------------------------------------
+
+struct scoped_transport_override {
+    scoped_transport_override() = default;
+    explicit scoped_transport_override(detail::transport_override fn) {
+        detail::set_http_transport_override(std::move(fn));
+    }
+    ~scoped_transport_override() {
+        detail::clear_http_transport_override();
+    }
+    scoped_transport_override(const scoped_transport_override&) = delete;
+    scoped_transport_override& operator=(const scoped_transport_override&) =
+        delete;
+};
+
+// -- Shared fixture data -----------------------------------------------------
+
+constexpr const char* kPatientId =
+    "P12345^^^&1.2.276.0.7230010.3.1.2.999&ISO";
+constexpr const char* kDocUid = "1.2.840.10008.5.1.4.1.1.2.99999";
+constexpr const char* kRepoUid = "1.2.276.0.7230010.3.0.3.6.2";
+constexpr const char* kEntryUuid =
+    "urn:uuid:aabbccdd-1111-2222-3333-444455556666";
+
+constexpr const char* kIti41Endpoint = "https://registry.example.test/iti41";
+constexpr const char* kIti43Endpoint = "https://repo.example.test/iti43";
+constexpr const char* kIti18Endpoint = "https://registry.example.test/iti18";
+
+constexpr const char* kSuccessStatus =
+    "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success";
+constexpr const char* kFailureStatus =
+    "urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure";
+
+submission_set make_submission() {
+    submission_set ss;
+    ss.submission_set_unique_id = "1.2.3.4.5";
+    ss.entry_uuid = "urn:uuid:00000000-0000-0000-0000-000000000001";
+    ss.source_id = "1.2.276.0.7230010.3.0.3.6.1";
+    ss.patient_id = kPatientId;
+    ss.submission_time = "20260422120000";
+
+    xds_document d;
+    d.entry_uuid = "urn:uuid:00000000-0000-0000-0000-000000000002";
+    d.unique_id = kDocUid;
+    d.mime_type = "application/dicom";
+    d.content = std::vector<std::uint8_t>{0x44, 0x49, 0x43, 0x4D};
+    ss.documents.push_back(std::move(d));
+    return ss;
+}
+
+// -- ITI-41 stock responses --------------------------------------------------
+
+std::string iti41_registry_response(bool success) {
+    return std::string(
+               R"(<?xml version="1.0" encoding="UTF-8"?>)"
+               R"(<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">)"
+               R"(<soap:Body>)"
+               R"(<rs:RegistryResponse xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" status=")") +
+           (success ? kSuccessStatus : kFailureStatus) +
+           R"("/></soap:Body></soap:Envelope>)";
+}
+
+// -- ITI-43 signed response + MTOM wrapper ----------------------------------
+
+std::string build_signed_iti43_response(const std::string& cid,
+                                        const signing_material& signer) {
+    std::string xml =
+        R"(<?xml version="1.0" encoding="UTF-8"?>)"
+        R"(<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" )"
+        R"(xmlns:xdsb="urn:ihe:iti:xds-b:2007" )"
+        R"(xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:3.0" )"
+        R"(xmlns:xop="http://www.w3.org/2004/08/xop/include" )"
+        R"(xmlns:wsa="http://www.w3.org/2005/08/addressing" )"
+        R"(xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" )"
+        R"(xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">)"
+        R"(<soap:Header>)"
+        R"(<wsa:Action>urn:ihe:iti:2007:RetrieveDocumentSetResponse</wsa:Action>)"
+        R"(<wsse:Security soap:mustUnderstand="true">)"
+        R"(<wsu:Timestamp wsu:Id="ts-1">)"
+        R"(<wsu:Created>2026-04-22T12:00:00Z</wsu:Created>)"
+        R"(</wsu:Timestamp>)"
+        R"(<wsse:BinarySecurityToken wsu:Id="bst-1" )"
+        R"(EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" )"
+        R"(ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>)"
+        R"(</wsse:Security>)"
+        R"(</soap:Header>)"
+        R"(<soap:Body wsu:Id="body-1">)"
+        R"(<xdsb:RetrieveDocumentSetResponse>)"
+        R"(<rs:RegistryResponse status=")" +
+        std::string(kSuccessStatus) +
+        R"("/>)"
+        R"(<xdsb:DocumentResponse>)"
+        R"(<xdsb:RepositoryUniqueId>)" +
+        std::string(kRepoUid) +
+        R"(</xdsb:RepositoryUniqueId>)"
+        R"(<xdsb:DocumentUniqueId>)" +
+        std::string(kDocUid) +
+        R"(</xdsb:DocumentUniqueId>)"
+        R"(<xdsb:mimeType>application/dicom</xdsb:mimeType>)"
+        R"(<xdsb:Document>)"
+        R"(<xop:Include href="cid:)" +
+        cid +
+        R"("/>)"
+        R"(</xdsb:Document>)"
+        R"(</xdsb:DocumentResponse>)"
+        R"(</xdsb:RetrieveDocumentSetResponse>)"
+        R"(</soap:Body>)"
+        R"(</soap:Envelope>)";
+
+    detail::built_envelope env;
+    env.body_id = "body-1";
+    env.timestamp_id = "ts-1";
+    env.binary_security_token_id = "bst-1";
+    env.xml = std::move(xml);
+
+    auto r = detail::sign_envelope(env, signer.certificate_pem,
+                                   signer.private_key_pem, "");
+    REQUIRE(r.is_ok());
+    return env.xml;
+}
+
+std::string pack_iti43_mtom(const std::string& root_xml,
+                            const std::string& cid,
+                            const std::string& bytes,
+                            std::string& out_content_type) {
+    constexpr const char* kBoundary = "----=_Part_atna_integration_boundary";
+    out_content_type = std::string(
+                           "multipart/related; boundary=\"") +
+                       kBoundary +
+                       "\"; type=\"application/xop+xml\"; "
+                       "start=\"<root.message@kcenon.test>\"";
+    std::string out;
+    out.reserve(root_xml.size() + bytes.size() + 512);
+    out += "--";
+    out += kBoundary;
+    out += "\r\nContent-Type: application/xop+xml; charset=UTF-8; "
+           "type=\"application/soap+xml\"\r\n";
+    out += "Content-Transfer-Encoding: 8bit\r\n";
+    out += "Content-ID: <root.message@kcenon.test>\r\n\r\n";
+    out += root_xml;
+    out += "\r\n--";
+    out += kBoundary;
+    out += "\r\nContent-Type: application/dicom\r\n";
+    out += "Content-Transfer-Encoding: binary\r\n";
+    out += "Content-ID: <";
+    out += cid;
+    out += ">\r\n\r\n";
+    out += bytes;
+    out += "\r\n--";
+    out += kBoundary;
+    out += "--\r\n";
+    return out;
+}
+
+// -- ITI-18 signed response --------------------------------------------------
+
+std::string build_signed_iti18_response(const std::string& status_urn,
+                                        const signing_material& signer) {
+    std::string xml =
+        R"(<?xml version="1.0" encoding="UTF-8"?>)"
+        R"(<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" )"
+        R"(xmlns:wsa="http://www.w3.org/2005/08/addressing" )"
+        R"(xmlns:wsse="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd" )"
+        R"(xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd" )"
+        R"(xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:3.0" )"
+        R"(xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:3.0">)"
+        R"(<soap:Header>)"
+        R"(<wsa:Action>urn:ihe:iti:2007:RegistryStoredQueryResponse</wsa:Action>)"
+        R"(<wsse:Security soap:mustUnderstand="true">)"
+        R"(<wsu:Timestamp wsu:Id="ts-q1">)"
+        R"(<wsu:Created>2026-04-22T12:00:00Z</wsu:Created>)"
+        R"(</wsu:Timestamp>)"
+        R"(<wsse:BinarySecurityToken wsu:Id="bst-q1" )"
+        R"(EncodingType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary" )"
+        R"(ValueType="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3"/>)"
+        R"(</wsse:Security>)"
+        R"(</soap:Header>)"
+        R"(<soap:Body wsu:Id="body-q1">)"
+        R"(<query:AdhocQueryResponse status=")" +
+        status_urn +
+        R"(">)"
+        R"(<rim:RegistryObjectList/>)"
+        R"(</query:AdhocQueryResponse>)"
+        R"(</soap:Body>)"
+        R"(</soap:Envelope>)";
+
+    detail::built_envelope env;
+    env.body_id = "body-q1";
+    env.timestamp_id = "ts-q1";
+    env.binary_security_token_id = "bst-q1";
+    env.xml = std::move(xml);
+
+    auto r = detail::sign_envelope(env, signer.certificate_pem,
+                                   signer.private_key_pem, "");
+    REQUIRE(r.is_ok());
+    return env.xml;
+}
+
+}  // namespace
+
+// =============================================================================
+// ITI-41 Document Source
+// =============================================================================
+
+TEST_CASE("ITI-41 emits a success audit event on successful submit",
+          "[ihe][xds][atna][integration][iti41]") {
+    auto signer = make_signing("atna-iti41-success");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = iti41_registry_response(true);
+            return r;
+        });
+
+    http_options opts;
+    opts.endpoint = kIti41Endpoint;
+    document_source ds(opts, signer);
+    ds.set_audit_sink(sink);
+
+    auto result = ds.submit(make_submission());
+    REQUIRE(result.is_ok());
+
+    REQUIRE(sink->events().size() == 1);
+    const auto& ev = sink->events()[0];
+    REQUIRE(ev.k == recording_xds_audit_sink::captured_event::kind::iti41);
+    CHECK(ev.iti41.outcome == atna_event_outcome::success);
+    CHECK(ev.iti41.patient_id == kPatientId);
+    CHECK(ev.iti41.destination_endpoint == kIti41Endpoint);
+    CHECK(ev.iti41.submission_set_unique_id == "1.2.3.4.5");
+    REQUIRE(ev.iti41.document_unique_ids.size() == 1);
+    CHECK(ev.iti41.document_unique_ids[0] == kDocUid);
+    CHECK(ev.iti41.failure_description.empty());
+}
+
+TEST_CASE("ITI-41 emits a failure audit event when the registry rejects",
+          "[ihe][xds][atna][integration][iti41]") {
+    auto signer = make_signing("atna-iti41-failure");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = iti41_registry_response(false);
+            return r;
+        });
+
+    http_options opts;
+    opts.endpoint = kIti41Endpoint;
+    document_source ds(opts, signer);
+    ds.set_audit_sink(sink);
+
+    auto result = ds.submit(make_submission());
+    REQUIRE(result.is_err());
+    CHECK(result.error().code ==
+          static_cast<int>(error_code::registry_failure_response));
+
+    REQUIRE(sink->events().size() == 1);
+    const auto& ev = sink->events()[0];
+    REQUIRE(ev.k == recording_xds_audit_sink::captured_event::kind::iti41);
+    CHECK(ev.iti41.outcome == atna_event_outcome::serious_failure);
+    CHECK(ev.iti41.patient_id == kPatientId);
+    CHECK(!ev.iti41.failure_description.empty());
+}
+
+TEST_CASE("ITI-41 emits a failure audit event when metadata validation fails",
+          "[ihe][xds][atna][integration][iti41]") {
+    auto signer = make_signing("atna-iti41-metadata");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    scoped_transport_override guard([](const detail::transport_request&)
+                                        -> kcenon::common::Result<
+                                            detail::http_response> {
+        FAIL("transport should not be invoked for metadata-level rejection");
+        return detail::http_response{};
+    });
+
+    http_options opts;
+    opts.endpoint = kIti41Endpoint;
+    document_source ds(opts, signer);
+    ds.set_audit_sink(sink);
+
+    auto bad = make_submission();
+    bad.patient_id.clear();
+    auto result = ds.submit(bad);
+    REQUIRE(result.is_err());
+
+    REQUIRE(sink->events().size() == 1);
+    CHECK(sink->events()[0].iti41.outcome ==
+          atna_event_outcome::serious_failure);
+}
+
+// =============================================================================
+// ITI-43 Document Consumer
+// =============================================================================
+
+TEST_CASE("ITI-43 emits a success audit event on successful retrieve",
+          "[ihe][xds][atna][integration][iti43]") {
+    auto signer = make_signing("atna-iti43-success");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    const std::string cid = "doc-atna-payload@kcenon.test";
+    const std::string payload = "DICM\x00\x01\x02\x03integration-body";
+    const std::string root = build_signed_iti43_response(cid, signer);
+    std::string content_type;
+    const std::string mtom = pack_iti43_mtom(root, cid, payload, content_type);
+
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.content_type = content_type;
+            r.body = mtom;
+            return r;
+        });
+
+    http_options opts;
+    opts.endpoint = kIti43Endpoint;
+    document_consumer dc(opts, signer);
+    dc.set_audit_sink(sink);
+
+    auto result = dc.retrieve(kDocUid, kRepoUid);
+    REQUIRE(result.is_ok());
+
+    REQUIRE(sink->events().size() == 1);
+    const auto& ev = sink->events()[0];
+    REQUIRE(ev.k == recording_xds_audit_sink::captured_event::kind::iti43);
+    CHECK(ev.iti43.outcome == atna_event_outcome::success);
+    CHECK(ev.iti43.document_unique_id == kDocUid);
+    CHECK(ev.iti43.repository_unique_id == kRepoUid);
+    CHECK(ev.iti43.source_endpoint == kIti43Endpoint);
+    CHECK(ev.iti43.failure_description.empty());
+}
+
+TEST_CASE("ITI-43 emits a failure audit event on transport TLS error",
+          "[ihe][xds][atna][integration][iti43]") {
+    auto signer = make_signing("atna-iti43-tls");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    scoped_transport_override guard(
+        [](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            return kcenon::common::make_error<detail::http_response>(
+                static_cast<int>(error_code::transport_tls_error),
+                "integration harness: simulated TLS handshake failure",
+                std::string(error_source));
+        });
+
+    http_options opts;
+    opts.endpoint = kIti43Endpoint;
+    document_consumer dc(opts, signer);
+    dc.set_audit_sink(sink);
+
+    auto result = dc.retrieve(kDocUid, kRepoUid);
+    REQUIRE(result.is_err());
+    CHECK(result.error().code ==
+          static_cast<int>(error_code::transport_tls_error));
+
+    REQUIRE(sink->events().size() == 1);
+    const auto& ev = sink->events()[0];
+    REQUIRE(ev.k == recording_xds_audit_sink::captured_event::kind::iti43);
+    CHECK(ev.iti43.outcome == atna_event_outcome::serious_failure);
+    CHECK(ev.iti43.document_unique_id == kDocUid);
+    CHECK(ev.iti43.repository_unique_id == kRepoUid);
+    CHECK(!ev.iti43.failure_description.empty());
+}
+
+TEST_CASE("ITI-43 emits a failure audit event on empty input validation",
+          "[ihe][xds][atna][integration][iti43]") {
+    auto signer = make_signing("atna-iti43-input");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    scoped_transport_override guard([](const detail::transport_request&)
+                                        -> kcenon::common::Result<
+                                            detail::http_response> {
+        FAIL("transport should not be invoked for empty document uid");
+        return detail::http_response{};
+    });
+
+    http_options opts;
+    opts.endpoint = kIti43Endpoint;
+    document_consumer dc(opts, signer);
+    dc.set_audit_sink(sink);
+
+    auto result = dc.retrieve("", kRepoUid);
+    REQUIRE(result.is_err());
+
+    REQUIRE(sink->events().size() == 1);
+    CHECK(sink->events()[0].iti43.outcome ==
+          atna_event_outcome::serious_failure);
+}
+
+// =============================================================================
+// ITI-18 Registry Query
+// =============================================================================
+
+TEST_CASE("ITI-18 FindDocuments emits a success audit event",
+          "[ihe][xds][atna][integration][iti18]") {
+    auto signer = make_signing("atna-iti18-find-success");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    const std::string body = build_signed_iti18_response(kSuccessStatus, signer);
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = body;
+            return r;
+        });
+
+    http_options opts;
+    opts.endpoint = kIti18Endpoint;
+    registry_query rq(opts, signer);
+    rq.set_audit_sink(sink);
+
+    auto result = rq.find_documents(kPatientId);
+    REQUIRE(result.is_ok());
+
+    REQUIRE(sink->events().size() == 1);
+    const auto& ev = sink->events()[0];
+    REQUIRE(ev.k == recording_xds_audit_sink::captured_event::kind::iti18);
+    CHECK(ev.iti18.outcome == atna_event_outcome::success);
+    CHECK(ev.iti18.query_kind == xds_iti18_event::kind::find_documents);
+    CHECK(ev.iti18.patient_id == kPatientId);
+    CHECK(ev.iti18.registry_endpoint == kIti18Endpoint);
+}
+
+TEST_CASE("ITI-18 GetDocuments emits a failure audit event when response "
+          "reports Failure",
+          "[ihe][xds][atna][integration][iti18]") {
+    auto signer = make_signing("atna-iti18-get-failure");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    const std::string body = build_signed_iti18_response(kFailureStatus, signer);
+    scoped_transport_override guard(
+        [&](const detail::transport_request&)
+            -> kcenon::common::Result<detail::http_response> {
+            detail::http_response r;
+            r.status_code = 200;
+            r.body = body;
+            return r;
+        });
+
+    http_options opts;
+    opts.endpoint = kIti18Endpoint;
+    registry_query rq(opts, signer);
+    rq.set_audit_sink(sink);
+
+    auto result = rq.get_documents({kEntryUuid});
+    REQUIRE(result.is_err());
+
+    REQUIRE(sink->events().size() == 1);
+    const auto& ev = sink->events()[0];
+    REQUIRE(ev.k == recording_xds_audit_sink::captured_event::kind::iti18);
+    CHECK(ev.iti18.outcome == atna_event_outcome::serious_failure);
+    CHECK(ev.iti18.query_kind == xds_iti18_event::kind::get_documents);
+    REQUIRE(ev.iti18.document_uuids.size() == 1);
+    CHECK(ev.iti18.document_uuids[0] == kEntryUuid);
+    CHECK(!ev.iti18.failure_description.empty());
+}
+
+TEST_CASE("ITI-18 emits a failure audit event for slot-literal injection",
+          "[ihe][xds][atna][integration][iti18]") {
+    auto signer = make_signing("atna-iti18-injection");
+    auto sink = std::make_shared<recording_xds_audit_sink>();
+
+    scoped_transport_override guard([](const detail::transport_request&)
+                                        -> kcenon::common::Result<
+                                            detail::http_response> {
+        FAIL("transport should not be invoked for malformed patient_id");
+        return detail::http_response{};
+    });
+
+    http_options opts;
+    opts.endpoint = kIti18Endpoint;
+    registry_query rq(opts, signer);
+    rq.set_audit_sink(sink);
+
+    auto result = rq.find_documents("bad'injection");
+    REQUIRE(result.is_err());
+
+    REQUIRE(sink->events().size() == 1);
+    CHECK(sink->events()[0].iti18.outcome ==
+          atna_event_outcome::serious_failure);
+}

--- a/tests/integration/ihe/xds/xds_atna_integration_test.cpp
+++ b/tests/integration/ihe/xds/xds_atna_integration_test.cpp
@@ -53,9 +53,15 @@
 #include <vector>
 
 using namespace kcenon::pacs::ihe::xds;
+using kcenon::pacs::security::atna_event_action;
 using kcenon::pacs::security::atna_event_outcome;
+using kcenon::pacs::security::build_iti18_audit_message;
+using kcenon::pacs::security::build_iti41_audit_message;
+using kcenon::pacs::security::build_iti43_audit_message;
 using kcenon::pacs::security::recording_xds_audit_sink;
 using kcenon::pacs::security::xds_iti18_event;
+using kcenon::pacs::security::xds_iti41_event;
+using kcenon::pacs::security::xds_iti43_event;
 
 namespace {
 
@@ -605,4 +611,109 @@ TEST_CASE("ITI-18 emits a failure audit event for slot-literal injection",
     REQUIRE(sink->events().size() == 1);
     CHECK(sink->events()[0].iti18.outcome ==
           atna_event_outcome::serious_failure);
+}
+
+// =============================================================================
+// RFC 3881 vocabulary conformance (reviewer Task-2 / AC4)
+//
+// These cases assert that the atna_sink message builders produce the
+// exact EventID / EventAction / EventTypeCode vocabulary the reviewer
+// pinned in their gap analysis. They hit the build_*_audit_message
+// functions directly so the assertions do not depend on a syslog
+// transport being reachable.
+// =============================================================================
+
+TEST_CASE("ITI-41 audit message uses DCM 110106 Export action C",
+          "[ihe][xds][atna][integration][iti41][rfc3881]") {
+    xds_iti41_event ev;
+    ev.source_id = "1.2.276.0.7230010.3.0.3.6.1";
+    ev.destination_endpoint = kIti41Endpoint;
+    ev.patient_id = kPatientId;
+    ev.submission_set_unique_id = "1.2.3.4.5";
+    ev.document_unique_ids = {kDocUid};
+    ev.outcome = atna_event_outcome::success;
+
+    const auto msg =
+        build_iti41_audit_message("PACS_TEST_SRC", ev, "1.2.276.0.7230010.3.0.3.6.1");
+
+    CHECK(msg.event_id.code == "110106");
+    CHECK(msg.event_id.code_system_name == "DCM");
+    CHECK(msg.event_id.display_name == "Export");
+    CHECK(msg.event_action == atna_event_action::create);
+
+    REQUIRE(msg.event_type_codes.size() == 1);
+    CHECK(msg.event_type_codes[0].code == "ITI-41");
+    CHECK(msg.event_type_codes[0].code_system_name == "IHETransactions");
+
+    CHECK(msg.event_outcome == atna_event_outcome::success);
+    CHECK(msg.audit_source.audit_source_id == "PACS_TEST_SRC");
+}
+
+TEST_CASE("ITI-43 audit message uses DCM 110107 Import action R",
+          "[ihe][xds][atna][integration][iti43][rfc3881]") {
+    xds_iti43_event ev;
+    ev.consumer_id = "1.2.276.0.7230010.3.0.3.6.4";
+    ev.source_endpoint = kIti43Endpoint;
+    ev.document_unique_id = kDocUid;
+    ev.repository_unique_id = kRepoUid;
+    ev.outcome = atna_event_outcome::serious_failure;
+    ev.failure_description = "simulated";
+
+    const auto msg =
+        build_iti43_audit_message("PACS_TEST_CON", ev,
+                                  "1.2.276.0.7230010.3.0.3.6.4");
+
+    CHECK(msg.event_id.code == "110107");
+    CHECK(msg.event_id.code_system_name == "DCM");
+    CHECK(msg.event_id.display_name == "Import");
+    CHECK(msg.event_action == atna_event_action::read);
+
+    REQUIRE(msg.event_type_codes.size() == 1);
+    CHECK(msg.event_type_codes[0].code == "ITI-43");
+    CHECK(msg.event_type_codes[0].code_system_name == "IHETransactions");
+
+    CHECK(msg.event_outcome == atna_event_outcome::serious_failure);
+
+    // Failure description must land somewhere in the participant
+    // objects so an auditor can recover it without the Result<T>.
+    bool saw_failure_detail = false;
+    for (const auto& po : msg.participant_objects) {
+        for (const auto& d : po.object_details) {
+            if (d.type == "FailureDescription" && d.value == "simulated") {
+                saw_failure_detail = true;
+            }
+        }
+    }
+    CHECK(saw_failure_detail);
+}
+
+TEST_CASE("ITI-18 audit message uses DCM 110112 Query action E with "
+          "IHETransactions event type",
+          "[ihe][xds][atna][integration][iti18][rfc3881]") {
+    xds_iti18_event ev;
+    ev.querier_id = "WORKSTATION_01";
+    ev.registry_endpoint = kIti18Endpoint;
+    ev.query_kind = xds_iti18_event::kind::find_documents;
+    ev.patient_id = kPatientId;
+    ev.outcome = atna_event_outcome::success;
+
+    const auto msg =
+        build_iti18_audit_message("PACS_TEST_QRY", ev, "WORKSTATION_01");
+
+    CHECK(msg.event_id.code == "110112");
+    CHECK(msg.event_id.code_system_name == "DCM");
+    CHECK(msg.event_id.display_name == "Query");
+    CHECK(msg.event_action == atna_event_action::execute);
+
+    REQUIRE(msg.event_type_codes.size() == 1);
+    CHECK(msg.event_type_codes[0].code ==
+          "urn:ihe:iti:2007:RegistryStoredQuery");
+    CHECK(msg.event_type_codes[0].code_system_name == "IHETransactions");
+
+    // Patient object is present for FindDocuments queries.
+    bool saw_patient = false;
+    for (const auto& po : msg.participant_objects) {
+        if (po.object_id == kPatientId) saw_patient = true;
+    }
+    CHECK(saw_patient);
 }


### PR DESCRIPTION
Closes #1131
Part of #1101

## What

Wires the three XDS.b actors (Document Source ITI-41, Document Consumer ITI-43, Registry Query ITI-18) into the existing ATNA audit pipeline, adds a Gazelle-lite integration test harness, and publishes the IHE Conformance Statement.

### Change Type
- [x] Feature (new functionality — audit wiring + test harness + documentation)
- [ ] Bugfix
- [ ] Refactor
- [ ] Documentation
- [ ] Test

### Affected Components
| Layer | Component | Change |
|-------|-----------|--------|
| Security | `src/security/xds_audit_events.{h,cpp}` | New abstract sink + ITI-18/41/43 message builders |
| Security | `atna_service_auditor::submit_audit_message` | New public shim over existing `send_audit` path |
| IHE XDS | `src/ihe/xds/{document_source,document_consumer,registry_query}.cpp` | `set_audit_sink()` + `do_audit()` hook on every return path |
| Tests | `tests/integration/ihe/xds/xds_atna_integration_test.cpp` | 12 Catch2 cases under new `pacs_xds_integration` CTest label |
| Docs | `docs/IHE_CONFORMANCE.md` | 8-section IHE Conformance Statement |
| Build | `cmake/targets.cmake`, `cmake/testing.cmake` | New source + test target + label registration |
| Changelog | `CHANGELOG.md` | Entry for ATNA wiring |

## Why

### Problem Solved
XDS.b actors built under #1128/#1129/#1130 landed without ATNA audit emission and without a published Conformance Statement. Any XDS.b actor without audit output fails IHE Connectathon conformance testing. Integration tests are required to prevent regressions as the actors evolve, and the Conformance Statement is the published contract downstream systems rely on when integrating.

### Related Issues
- Closes #1131
- Part of #1101 (XDS.b / ATNA umbrella)

### Alternatives Considered
For ITI-18, the first implementation delegated to the existing `atna_service_auditor::audit_query` facade. Round 1 review flagged this as a Major gap — that facade emits a bare DCM 110112 record with no IHE `EventTypeCode="ITI-18"` tag, breaking AC4. The fix commit replaces the facade-delegation path with direct `atna_audit_message` builders (`build_iti41/43/18_audit_message`) that lock RFC 3881 / IHE event codes at the XDS layer and route through a new `submit_audit_message` shim. This keeps all three transactions in one file with a consistent builder shape and makes them testable without the syslog transport.

## Who

### Reviewers
- Team lead (final sign-off)
- Anyone touching ATNA or IHE code paths

### Required Approvals
- [ ] Code owner for `src/security/`
- [ ] Code owner for `src/ihe/xds/`

## When

### Urgency
- [x] Normal — part of v1.0 readiness for pacs_system
- [ ] High Priority
- [ ] Hotfix

### Target Release
v1.0 pacs_system readiness (XDS.b / ATNA compliance milestone). Unblocks downstream Connectathon preparation.

### Deployment Notes
No schema or runtime migration required. The audit sink is opt-in: actors constructed without `set_audit_sink()` behave exactly as before (null sink via `make_null_xds_audit_sink`). Existing ATNA syslog transport + configuration are reused unchanged.

## Where

### Files Changed
| Directory | Files | Type |
|-----------|-------|------|
| `include/kcenon/pacs/security/` | `xds_audit_events.h`, `atna_service_auditor.h` (+23 lines) | New header + existing header extended |
| `src/security/` | `xds_audit_events.cpp` (new), `atna_service_auditor.cpp` (+8 lines) | Implementation |
| `include/kcenon/pacs/ihe/xds/` | `document_source.h`, `document_consumer.h`, `registry_query.h` | `set_audit_sink` declaration each |
| `src/ihe/xds/` | `document_source.cpp`, `document_consumer.cpp`, `registry_query.cpp` | Audit hook only — no semantic change |
| `tests/integration/ihe/xds/` | `xds_atna_integration_test.cpp` (new, 719 lines) | 12 test cases |
| `docs/` | `IHE_CONFORMANCE.md` (new, 268 lines) | IHE Conformance Statement |
| `cmake/` | `targets.cmake` (+1), `testing.cmake` (+31) | Build + label registration |

Total: +1877 / -53 lines across 15 files.

### Architecture Impact
Introduces a new shared dependency: `pacs_ihe_xds` now depends on `pacs_security` (via the `xds_audit_sink` interface). The three XDS actors retain their existing thread-safety contract ("`submit()` is NOT reentrant; one instance per worker thread"). Audit emission reuses `atna_service_auditor`'s existing serialized `send_audit` path — no new lock, no new socket, no new state machine.

### API Changes
- **Public (new)**: `kcenon::pacs::security::xds_audit_sink`, `make_null_xds_audit_sink()`, `make_atna_xds_audit_sink()`, `build_iti41/43/18_audit_message()`
- **Public (new)**: `atna_service_auditor::submit_audit_message(const atna_audit_message&)`
- **Public (extended)**: `document_source::set_audit_sink()`, `document_consumer::set_audit_sink()`, `registry_query::set_audit_sink()` — optional, default behavior unchanged when not called

No breaking changes. No database or schema changes.

## How

### Implementation Highlights

1. **Zero-regression actor edits.** Each of the three XDS actor TUs adds only a `#include`, a `set_audit_sink` member, and wraps each `make_error<T>(...)` return through a `do_audit()` closure that passes the Result<T> through unchanged. `git diff develop..HEAD -- src/ihe/xds/` shows only additive changes; SOAP envelope construction, MTOM packaging, HTTP POST, signature verification, and error code propagation are byte-identical to develop.
2. **RFC 3881 / IHE ATNA vocabulary locked per transaction** (per reviewer Task-2 checklist and Connectathon spec):
   - ITI-41 Provide and Register: EventID `(110106, DCM, Export)`, action `C`, EventTypeCode `(ITI-41, IHETransactions, …)`
   - ITI-43 Retrieve Document Set: EventID `(110107, DCM, Import)`, action `R`, EventTypeCode `(ITI-43, IHETransactions, …)`
   - ITI-18 Registry Stored Query: EventID `(110112, DCM, Query)`, action `E`, EventTypeCode `(urn:ihe:iti:2007:RegistryStoredQuery, IHETransactions, …)`
3. **Structured ParticipantObjects.** Patient ID uses RFC 3881 `patient_number` type; document unique-id uses `urn:ihe:iti:xds:2013:uniqueId`; submission-set uses `urn:ihe:iti:xds:2013:submissionSet.uniqueId`; entry UUIDs use `urn:ihe:iti:xds:2013:entryUUID`; repository OID uses DCM `node_id`. Failure records carry a `FailureDescription` `object_detail` attached to the last ParticipantObject (or a synthesized placeholder when no context exists yet, e.g., envelope-build errors).
4. **In-process test harness.** Uses the existing `detail::set_http_transport_override` hook to stub HTTPS entirely in-process — zero socket opens, zero DNS lookups, no docker-compose, no external Gazelle dependency. Keeps CI hermetic.
5. **Conformance Statement.** 8-section IHE document at `docs/IHE_CONFORMANCE.md`: Actors, Transactions, Integration Profiles, Options, Configuration Parameters, Security, Limitations, References.

### Testing Done

| Suite | Result |
|-------|--------|
| `pacs_ihe_xds_tests` (existing unit tests) | 221 assertions / 36 cases PASS — no regressions |
| `pacs_xds_atna_integration_tests` (new, label `pacs_xds_integration`) | 95 assertions / 12 cases PASS |

The 12 integration cases cover:
- **ITI-41** × 3: success / registry-rejects-submission / metadata-validation-failure
- **ITI-43** × 3: success / transport TLS error / empty input validation
- **ITI-18** × 3: FindDocuments success / GetDocuments failure (registry reports Failure status) / slot-literal injection rejection
- **RFC 3881 conformance** × 3: direct assertions on `build_iti41/43/18_audit_message` output — EventID code/code_system/display_name, EventAction letter, EventTypeCode code/code_system, ParticipantObject membership

### Test Plan for Reviewers

```bash
# Fast unit loop (no regressions)
cmake --build build --target pacs_ihe_xds_tests
cd build && ctest -R '^pacs_ihe_xds_tests' --output-on-failure

# New integration bucket — gated behind label
cmake --build build --target pacs_xds_atna_integration_tests
cd build && ctest -L pacs_xds_integration --output-on-failure

# Confirm the label excludes them from default runs
cd build && ctest -N -LE pacs_xds_integration | grep -v pacs_xds_atna_integration   # should list everything
cd build && ctest -N -L pacs_xds_integration                                         # should list only the 12 cases
```

### Breaking Changes
None. The audit sink is strictly opt-in. Actors constructed without `set_audit_sink()` behave identically to the develop baseline.

### Rollback Plan
Revert the four commits. No data migration. No schema changes.

## Review Findings and Resolution

Two-round producer/reviewer cycle. Full record:

| ID | Severity | Finding | Resolution |
|----|----------|---------|-----------|
| **M1** | Major | ITI-18 audit path delegated to `audit_query` facade which emits bare DCM 110112 with no IHE `EventTypeCode="ITI-18"` tag — breaks AC4 and Connectathon conformance | **Resolved in `057e3513`** — replaced facade delegation with direct `build_iti18_audit_message` builder that locks `(urn:ihe:iti:2007:RegistryStoredQuery, IHETransactions, …)` EventTypeCode; structured ParticipantObjects for patient / entry UUIDs with `query` role replace the free-form `query_level` string |
| **m1** | Minor | `repository_unique_id` captured in event struct but never threaded through to the emitted ATNA record on the ITI-43 path | **Resolved in `057e3513`** — `build_iti43_audit_message` now emits `e.repository_unique_id` as a ParticipantObject with `object_id_type_code = atna_object_id_types::node_id` |
| m2 | Minor | ITI-18 emitted patient_id / UUIDs as a free-form `"ITI-18 FindDocuments PatientID=…"` string | **Resolved in `057e3513`** (fell out of the M1 fix — now structured ParticipantObjects) |
| i1 | Info | `atna_syslog_transport` has no documented thread-safety contract | **Out of scope** — pre-existing on develop; not introduced by this PR. Flagged for a separate follow-up under #1101 |
| i2 | Info | Test framework is Catch2 (not Google Test) | Acknowledged — tests correctly use `TEST_CASE` macros |
| i3 | Info | `recording_xds_audit_sink::captured_event` carries three full event members per entry (only one populated) | Acknowledged — test-only helper, `std::variant` would add template friction |

Cross-cutting checks (reviewer Task-2 checklist):
- **§1 Zero actor semantic change** — diff-verified in all three TUs
- **§2 PII handling** — patient_id as RFC 3881 object_id only; no DICOM header dump, no payload bytes; `FailureDescription` is `Result<T>::error().message` only
- **§3 Thread safety** — all emission via `atna_service_auditor::submit_audit_message` → existing `send_audit` path; atomic `enabled_` check, shared transport
- **§4 No silent swallow** — audit sink failure updates `events_failed_` counter (observable via accessors); Result<T> is never mutated by audit emission
- **§5 Mock registry isolation** — in-process transport override; zero socket opens, zero DNS, no public hosts
- **§6 CTest filters** — `TEST_PREFIX "integration::"` + `LABELS "pacs_xds_integration"`; both `ctest --exclude-regex "integration::"` and `ctest -LE pacs_xds_integration` exclude them from default runs

## Conformance Statement Summary

`docs/IHE_CONFORMANCE.md` (268 lines, 8 sections):

1. **Introduction** — scope, intended audience, reference to IHE profile
2. **Supported Actors** — Document Source (ITI-41), Document Consumer (ITI-43), Registry Query (ITI-18)
3. **Supported Transactions** — wire protocol, SOAP action URIs, required/optional elements
4. **Integration Profiles** — XDS.b (core), ATNA (audit wiring in this PR)
5. **Options** — none; baseline conformance only
6. **Configuration Parameters** — endpoint URL, WS-Security signing material, ATNA audit source ID
7. **Security** — TLS 1.2+, WS-Security X.509 signature, ATNA audit emission
8. **References** — cross-links to DICOM conformance and existing `IHE_INTEGRATION_STATEMENT.md`

### Known Limitations (documented in §7 of the doc)
- WS-Security signature uses project-local canonicalization URI (`urn:kcenon:xds:c14n:pugixml-format-raw-v1`), NOT the IHE-required exc-c14n. Self-verifiable but not interoperable with third-party exc-c14n verifiers. Tracked under a separate follow-up issue.
- Document Registry and Document Repository actors are not implemented in this tier — only the three client-side actors listed above.
- No IHE Connectathon testing has been performed yet; conformance is structural/unit-level.

## Commits (4)

| SHA | Subject |
|-----|---------|
| `8bbf2f24` | feat(ihe/xds): wire ATNA audit emission for ITI-18/41/43 |
| `50facd2b` | test(ihe/xds): integration harness for ITI-18/41/43 ATNA audit |
| `057e3513` | fix(ihe/xds): align ATNA event codes with RFC 3881 / IHE ATNA profile |
| `c2e7fa6b` | docs(ihe): publish XDS.b Conformance Statement and ATNA entry |

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed (two review rounds with reviewer teammate)
- [x] Tests added (+12 Catch2 cases, 3 RFC 3881 conformance assertions)
- [x] Documentation updated (new `IHE_CONFORMANCE.md` + CHANGELOG entry)
- [x] No sensitive data exposed (no PHI in audit payloads beyond IHE requirements)
- [x] Commits are atomic and well-described
- [x] Related issue linked with closing keyword (`Closes #1131`)
- [x] Base branch is `develop` (per branching strategy)
