### PR TITLE
chore(deps): bump container_system pin to fa56dc5e (EPIC #531 verification)

### DIFF
--- a/.github/actions/checkout-kcenon-deps/action.yml
+++ b/.github/actions/checkout-kcenon-deps/action.yml
@@ -23,7 +23,7 @@ runs:
         # Pinned commit SHAs for IEC 62304 SOUP traceability
         # Last verified: 2026-05-01
         COMMON_SYSTEM_SHA: '47be5fd27650f0ebfa2d029ebed35a1c262e55c4'
-        CONTAINER_SYSTEM_SHA: '0b95a0c10edf53315581b7f3fa458f0193e8c039'
+        CONTAINER_SYSTEM_SHA: 'fa56dc5ed77df9cea2dce1bebd4aec75bd91916d'
         THREAD_SYSTEM_SHA: 'db8d36f15cf2dfb679474b20cb47160494a6c8be'
         LOGGER_SYSTEM_SHA: 'f119ecd698fb5a8b25dd730647b9d038034aad5a'
         MONITORING_SYSTEM_SHA: '221bf3d2645a2bfd54b07fd84b1c24c2e32d754f'
@@ -51,7 +51,7 @@ runs:
       shell: pwsh
       env:
         COMMON_SYSTEM_SHA: '47be5fd27650f0ebfa2d029ebed35a1c262e55c4'
-        CONTAINER_SYSTEM_SHA: '0b95a0c10edf53315581b7f3fa458f0193e8c039'
+        CONTAINER_SYSTEM_SHA: 'fa56dc5ed77df9cea2dce1bebd4aec75bd91916d'
         THREAD_SYSTEM_SHA: 'db8d36f15cf2dfb679474b20cb47160494a6c8be'
         LOGGER_SYSTEM_SHA: 'f119ecd698fb5a8b25dd730647b9d038034aad5a'
         MONITORING_SYSTEM_SHA: '221bf3d2645a2bfd54b07fd84b1c24c2e32d754f'

--- a/dependency-manifest.json
+++ b/dependency-manifest.json
@@ -18,7 +18,7 @@
       "name": "container_system",
       "source": "add_subdirectory or sibling checkout",
       "resolution": "../container_system",
-      "version": "0b95a0c10edf53315581b7f3fa458f0193e8c039",
+      "version": "fa56dc5ed77df9cea2dce1bebd4aec75bd91916d",
       "license": "BSD-3-Clause"
     },
     {

--- a/docs/SOUP.md
+++ b/docs/SOUP.md
@@ -32,7 +32,7 @@ category: "PROJ"
 | ID | Name | Manufacturer | Version (Commit SHA) | License | Usage in pacs_system | Safety Class | Known Anomalies |
 |----|------|-------------|----------------------|---------|---------------------|-------------|-----------------|
 | SOUP-001 | [common_system](https://github.com/kcenon/common_system) | kcenon | `47be5fd2` | BSD-3-Clause | Result&lt;T&gt; pattern, error handling primitives | B | None |
-| SOUP-002 | [container_system](https://github.com/kcenon/container_system) | kcenon | `0b95a0c1` | BSD-3-Clause | DICOM data serialization containers | B | None |
+| SOUP-002 | [container_system](https://github.com/kcenon/container_system) | kcenon | `fa56dc5e` | BSD-3-Clause | DICOM data serialization containers | B | None |
 | SOUP-003 | [thread_system](https://github.com/kcenon/thread_system) | kcenon | `db8d36f1` | BSD-3-Clause | Thread pool, async task scheduling | B | None |
 | SOUP-004 | [logger_system](https://github.com/kcenon/logger_system) | kcenon | `f119ecd6` | BSD-3-Clause | Structured logging infrastructure | A | None |
 | SOUP-005 | [monitoring_system](https://github.com/kcenon/monitoring_system) | kcenon | `221bf3d2` | BSD-3-Clause | Performance metrics collection | A | None |


### PR DESCRIPTION
## What

Bump the pinned `CONTAINER_SYSTEM_SHA` from `0b95a0c1` to `fa56dc5e` (current `develop` HEAD of kcenon/container_system, which is also the squash-merge commit of PR #541 — the final sub-issue of EPIC #531).

| Item | Before | After |
|------|--------|-------|
| `CONTAINER_SYSTEM_SHA` (Unix block) | `0b95a0c10edf53315581b7f3fa458f0193e8c039` | `fa56dc5ed77df9cea2dce1bebd4aec75bd91916d` |
| `CONTAINER_SYSTEM_SHA` (Windows block) | `0b95a0c10edf53315581b7f3fa458f0193e8c039` | `fa56dc5ed77df9cea2dce1bebd4aec75bd91916d` |
| SOUP-002 entry | `0b95a0c1` | `fa56dc5e` |
| dependency-manifest container_system version | `0b95a0c10ed...` | `fa56dc5ed77...` |

## Why

EPIC #531 (kcenon/container_system) just landed across 5 PRs (#537–#541) and restructured the public layout:
- Headers consolidated under `include/kcenon/container/<subdir>/`
- Sources moved under `src/<subdir>/`; root-level `core/`, `internal/`, `integration/`, `messaging/` dirs removed
- Single legacy forwarder `include/container/optimizations/fast_parser.h` retained with `#pragma message` deprecation
- Top-level CMake decomposed into 11 `cmake/<area>.cmake` modules
- Doxyfile + install rule cleanup

The EPIC's last acceptance criterion explicitly named pacs_system as a downstream consumer to verify. Static analysis against pacs_system HEAD shows every contact point is preserved (single `<container.h>` entry, `container_module = kcenon::container` namespace alias, both `container_system` target and `ContainerSystem::container` alias, all expected CMake options) — no breakage signal found by reading code. But pacs_system's CI builds container_system at the pinned SHA `0b95a0c1`, which predates the EPIC, so the green CI we have is not actually exercising the new layout. This pin bump converts inferred compatibility into observed compatibility.

## Where

| File | Change |
|------|--------|
| `.github/actions/checkout-kcenon-deps/action.yml` | Update `CONTAINER_SYSTEM_SHA` in both Unix and Windows env blocks |
| `docs/SOUP.md` | Update SOUP-002 commit SHA (short form) |
| `dependency-manifest.json` | Update `internal_ecosystem.container_system.version` (full SHA) |

All three files are kept in sync per the file-level comment in `action.yml`: *All SHAs should match entries in docs/SOUP.md*.

## How

### Implementation
Configuration-only change — no source code modifications needed (verified via static analysis).

### Test Plan for Reviewers
1. Verify diff is exactly 4 SHA replacements across 3 files (4 insertions, 4 deletions)
2. Confirm CI matrix is green:
   - Multi-platform build: Ubuntu GCC, Ubuntu Clang, macOS, Windows MSVC
   - Integration tests
   - Sanitizers (ASan, TSan, UBSan)
   - DCMTK interop
   - Coverage
   - Static analysis
   - Fuzzing (smoke)
   - Doc audit (triggered by SOUP.md change)
3. If anything fails, the failure is signal that pacs_system's contact points need adjustment for the new container_system layout — that would be a follow-up, not a blocker for this PR.

### Acceptance Criteria
- [x] `CONTAINER_SYSTEM_SHA` updated to a SHA that includes container_system EPIC #531
- [ ] CI green on the bump PR across all required workflows
- [ ] PR merged

### Breaking Changes
None — configuration update only.

### Rollback
`git revert` of the squash commit; reverts all three files atomically.

## Issue linkage

Closes #1148
Relates to kcenon/container_system#531