### PR TITLE
chore(release): verify SHA512 against actual archive (#1152)

### DIFF
--- a/.github/workflows/on-release-sync-registry.yml
+++ b/.github/workflows/on-release-sync-registry.yml
@@ -5,7 +5,57 @@ on:
     types: [published]
 
 jobs:
+  verify-archive:
+    name: Verify release archive SHA512
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify SHA512 against actual GitHub archive
+        env:
+          TAG: ${{ github.event.release.tag_name }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Independent SHA512 verification against the released archive.
+          # The reusable sync workflow at kcenon/common_system already performs
+          # this check internally (see kcenon/common_system#675, PR #676), but
+          # repeating it here on the caller side guards against drift if the
+          # reusable workflow changes or is repointed in the future.
+          # Reference: kcenon/pacs_system#1152, EPIC kcenon/common_system#674.
+          set -euo pipefail
+          ARCHIVE_URL="https://github.com/${REPO}/archive/refs/tags/${TAG}.tar.gz"
+          VERIFY_FILE="$(mktemp)"
+
+          echo "Fetching ${ARCHIVE_URL} for SHA512 verification..."
+          # Download to a file (not piped into sha512sum) so a fetch failure
+          # cannot silently produce the empty-input hash cf83e1357eefb8bdf...
+          if ! curl -fsSL --retry 3 --retry-delay 2 -o "${VERIFY_FILE}" "${ARCHIVE_URL}"; then
+            echo "::error::Failed to download release archive: ${ARCHIVE_URL}"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ARCHIVE_SIZE=$(stat -c %s "${VERIFY_FILE}" 2>/dev/null || stat -f %z "${VERIFY_FILE}")
+          if [ "${ARCHIVE_SIZE}" -lt 1024 ]; then
+            echo "::error::Downloaded archive is suspiciously small (${ARCHIVE_SIZE} bytes)"
+            rm -f "${VERIFY_FILE}"
+            exit 1
+          fi
+
+          ACTUAL_SHA=$(sha512sum "${VERIFY_FILE}" | awk '{print $1}')
+          rm -f "${VERIFY_FILE}"
+
+          # Empty-input SHA-512 sentinel guard.
+          EMPTY_SHA="cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+          if [ "${ACTUAL_SHA}" = "${EMPTY_SHA}" ]; then
+            echo "::error::Computed SHA512 matches the empty-input constant; download likely failed."
+            exit 1
+          fi
+
+          echo "SHA512 of ${ARCHIVE_URL}:"
+          echo "  ${ACTUAL_SHA}"
+          echo "Archive size: ${ARCHIVE_SIZE} bytes"
+
   sync:
+    needs: verify-archive
     uses: kcenon/common_system/.github/workflows/sync-vcpkg-registry.yml@main
     with:
       port-name: kcenon-pacs-system


### PR DESCRIPTION
## What

Add a caller-side `verify-archive` job to `.github/workflows/on-release-sync-registry.yml` that independently verifies the SHA512 of the GitHub release archive before the reusable `sync-vcpkg-registry.yml` workflow runs.

## Why

`pacs_system` currently delegates SHA512 computation entirely to `kcenon/common_system`'s reusable sync workflow. Without a caller-side verification, a drift in the reusable workflow (or a silent fetch failure inside it) could cause the vcpkg overlay registry to receive an invalid SHA, breaking cold-cache `vcpkg install` runs for all downstream consumers.

Mirrors the proven pattern already landed in 6 sibling repositories:

| Repo | PR |
|------|----|
| common_system | #676 |
| thread_system | #692 |
| container_system | #543 |
| logger_system | #635 |
| monitoring_system | #688 |
| database_system | #589 |

Part of EPIC kcenon/common_system#674.

## Where

| Item | Value |
|------|-------|
| File | `.github/workflows/on-release-sync-registry.yml` |
| Change | +50 / -0 |
| New job | `verify-archive` |
| Job dependency | `sync` now `needs: verify-archive` |

## How

1. New `verify-archive` job downloads the release archive to a temp file (`curl -fsSL -o "$VERIFY_FILE"`) — never piped — so a fetch failure cannot silently produce the empty-input SHA-512 constant `cf83e1357...`.
2. Minimum archive size check (1024 bytes) catches truncated downloads.
3. Explicit empty-input SHA-512 sentinel rejects the cached-empty case as an additional belt-and-braces guard.
4. `sync` job gains `needs: verify-archive`, so the SHA write to the vcpkg overlay only proceeds after the caller-side check passes.

### Acceptance criteria

- [x] Audit identifies all release workflow files in this repo that compute or trigger SHA512 (`on-release-sync-registry.yml` only; `release.yml` does not compute SHA).
- [x] `on-release-sync-registry.yml` includes a `verify-archive` job that runs **before** the reusable `sync` job that ultimately commits the portfile.
- [x] Verification uses **file-based hashing** (`curl -o` then `sha512sum file`), not the pipe form.
- [x] Empty-input SHA-512 sentinel guard (`cf83e1357...`) explicitly rejected.
- [x] Minimum-size sanity check (1024 bytes) on the downloaded archive.

### Notes

- No composite action extraction needed (single workflow only computes SHA).
- The reusable workflow at `kcenon/common_system` already performs the same SHA verification internally; this PR adds a redundant caller-side check as drift insurance.

## References

- Parent EPIC: kcenon/common_system#674
- Reference sub-issue: kcenon/common_system#675 (PR #676)
- Sibling implementations: monitoring_system PR #688, thread_system PR #692, container_system PR #543, logger_system PR #635, database_system PR #589
- First finding: kcenon/common_system#653 (microsoft/vcpkg#51511)
- Cross-port audit: kcenon/vcpkg-registry#87

Closes #1152
