### PR TITLE
task(api): v1.0 API freeze audit of public headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- API freeze for v1.0: enumerate the 290-header public surface under `include/kcenon/pacs/` in `docs/v1.0-api-surface.md`; confirm zero `[[deprecated]]` symbols and no experimental staging area; mark `network/detail/accept_worker.h` as the only implementation-detail header outside the v1.0 stability promise ([#1156](https://github.com/kcenon/pacs_system/issues/1156))
 - Remove committed `.key` files from version control; regenerate via `generate_test_certs.sh` in CI and local development ([#1092](https://github.com/kcenon/pacs_system/issues/1092))
 - Consolidate directory layout: `samples/` renamed to `examples/` (5 progressive tutorials) and `examples/` renamed to `tools/` (32 CLI utility binaries) so that the role split matches the ecosystem standard. CMake option names (`PACS_BUILD_EXAMPLES`, `PACS_BUILD_SAMPLES`) are preserved for backward compatibility ([#1139](https://github.com/kcenon/pacs_system/issues/1139))
 - Align `cmake/*.cmake` modules with the canonical ecosystem template at `common_system/cmake/template`; pacs-specific modules (`pacs_system-config.cmake.in`, `summary.cmake`) and intentional design divergences are documented in `cmake/DEVIATIONS.md`, and the aligned template version is recorded in `cmake/VERSION` ([#1140](https://github.com/kcenon/pacs_system/issues/1140))

--- a/docs/v1.0-api-surface.md
+++ b/docs/v1.0-api-surface.md
@@ -1,0 +1,609 @@
+---
+doc_id: "PAC-API-V10-001"
+doc_title: "v1.0 Public API Surface — Frozen"
+doc_version: "1.0.0"
+doc_date: "2026-05-10"
+doc_status: "Frozen"
+project: "pacs_system"
+category: "API"
+---
+
+# v1.0 Public API Surface — Frozen
+
+> **Status**: Frozen for v1.0 release. No breaking changes will be introduced
+> until the v2.0 SemVer bump. See [Issue #1156](https://github.com/kcenon/pacs_system/issues/1156)
+> and the parent EPIC [#1095](https://github.com/kcenon/pacs_system/issues/1095).
+
+This document is the authoritative inventory of the public API surface that v1.0
+guarantees as stable. The v1.0 contract follows the ecosystem-wide rule from
+`common_system` issue [#639](https://github.com/kcenon/common_system/issues/639):
+public symbols listed here will not be removed, renamed, or have signatures
+broken before v2.0. Additive changes (new functions, new fields with defaults,
+new enumerators at the end of an enumeration) are permitted.
+
+## Scope
+
+- **Public**: Any header reachable through the configured `target_include_directories(... PUBLIC ...)`
+  declarations in `cmake/targets.cmake`. All such headers live under
+  `include/kcenon/pacs/` and are installed to `<prefix>/include/kcenon/pacs/` by
+  the install rules in `cmake/install.cmake`.
+- **Out of scope (private)**: Anything under `src/`, `tests/`, `tools/`,
+  `examples/`, `benchmarks/`, `fuzz/`, and the `build*/` trees. Headers under
+  `src/.../detail/` (project-internal helpers used only inside translation
+  units) are also private and are documented per-file in their headers.
+- **Implementation detail (public path, internal use)**: Headers under
+  `network/detail/` are reachable through `PUBLIC` include directories for
+  packaging convenience but are documented as implementation details. They are
+  not part of the v1.0 stability promise. See the per-module table below.
+
+## Conventions
+
+- Public namespace: `kcenon::pacs::*`. The legacy alias `pacs::*` is kept alive
+  through `compat/namespace_compat.h` and is part of the v1.0 surface.
+- Headers use `.h` suffix; the only public C++20 module declaration is in
+  `cmake/targets.cmake` (no `.cppm` files in this surface). Translation-unit
+  consumers can include any header listed below directly.
+- All headers carry Doxygen `@since` tags. Symbols introduced in 1.0.0 carry
+  `@since 1.0.0`; the legacy alias header carries `@since 2.0.0` from a prior
+  iteration and is intentionally retained.
+
+## Modules and Headers
+
+The 290 public headers are grouped by module. Each row is the relative path
+inside `include/kcenon/pacs/`. Counts are reported below.
+
+### `ai/` — AI service connector and assessment management (4)
+
+| Header | Stability |
+|--------|-----------|
+| `ai/ai_result_handler.h` | Frozen |
+| `ai/ai_service_connector.h` | Frozen |
+| `ai/aira_assessment.h` | Frozen |
+| `ai/aira_assessment_manager.h` | Frozen |
+
+### `client/` — Job, prefetch, routing, sync managers (10)
+
+| Header | Stability |
+|--------|-----------|
+| `client/job_manager.h` | Frozen |
+| `client/job_types.h` | Frozen |
+| `client/prefetch_manager.h` | Frozen |
+| `client/prefetch_types.h` | Frozen |
+| `client/remote_node.h` | Frozen |
+| `client/remote_node_manager.h` | Frozen |
+| `client/routing_manager.h` | Frozen |
+| `client/routing_types.h` | Frozen |
+| `client/sync_manager.h` | Frozen |
+| `client/sync_types.h` | Frozen |
+
+### `compat/` — Backward-compatibility shims (3)
+
+These shims exist so downstream code from earlier iterations continues to
+compile against v1.0. They are part of the v1.0 surface and stay until v2.0.
+
+| Header | Stability | Note |
+|--------|-----------|------|
+| `compat/format.h` | Frozen | Aliases `std::format` into `kcenon::pacs::compat`. |
+| `compat/namespace_compat.h` | Frozen | Provides `pacs::` namespace alias for migration from earlier major version. |
+| `compat/time.h` | Frozen | Time-utility shim. |
+
+### `core/` — DICOM dataset, dictionary, file I/O, Result type (12)
+
+| Header | Stability |
+|--------|-----------|
+| `core/dicom_dataset.h` | Frozen |
+| `core/dicom_dictionary.h` | Frozen |
+| `core/dicom_element.h` | Frozen |
+| `core/dicom_file.h` | Frozen |
+| `core/dicom_tag.h` | Frozen |
+| `core/dicom_tag_constants.h` | Frozen |
+| `core/events.h` | Frozen |
+| `core/memory_mapped_file.h` | Frozen |
+| `core/pool_manager.h` | Frozen |
+| `core/private_tag_registry.h` | Frozen |
+| `core/result.h` | Frozen |
+| `core/tag_info.h` | Frozen |
+
+### `di/` — Dependency-injection contracts (4)
+
+| Header | Stability |
+|--------|-----------|
+| `di/ilogger.h` | Frozen |
+| `di/service_interfaces.h` | Frozen |
+| `di/service_registration.h` | Frozen |
+| `di/test_support.h` | Frozen |
+
+### `encoding/` — Transfer syntaxes, VR, character set, byte order (10)
+
+| Header | Stability |
+|--------|-----------|
+| `encoding/byte_order.h` | Frozen |
+| `encoding/byte_swap.h` | Frozen |
+| `encoding/character_set.h` | Frozen |
+| `encoding/dataset_charset.h` | Frozen |
+| `encoding/explicit_vr_big_endian_codec.h` | Frozen |
+| `encoding/explicit_vr_codec.h` | Frozen |
+| `encoding/implicit_vr_codec.h` | Frozen |
+| `encoding/transfer_syntax.h` | Frozen |
+| `encoding/vr_info.h` | Frozen |
+| `encoding/vr_type.h` | Frozen |
+
+### `encoding/compression/` — Pixel-data codecs (12)
+
+| Header | Stability |
+|--------|-----------|
+| `encoding/compression/codec_factory.h` | Frozen |
+| `encoding/compression/compression_codec.h` | Frozen |
+| `encoding/compression/frame_deflate_codec.h` | Frozen |
+| `encoding/compression/hevc_codec.h` | Frozen |
+| `encoding/compression/htj2k_codec.h` | Frozen |
+| `encoding/compression/image_params.h` | Frozen |
+| `encoding/compression/jpeg2000_codec.h` | Frozen |
+| `encoding/compression/jpeg_baseline_codec.h` | Frozen |
+| `encoding/compression/jpeg_lossless_codec.h` | Frozen |
+| `encoding/compression/jpeg_ls_codec.h` | Frozen |
+| `encoding/compression/jpegxl_codec.h` | Frozen |
+| `encoding/compression/rle_codec.h` | Frozen |
+
+### `encoding/simd/` — SIMD acceleration primitives (6)
+
+| Header | Stability |
+|--------|-----------|
+| `encoding/simd/simd_config.h` | Frozen |
+| `encoding/simd/simd_photometric.h` | Frozen |
+| `encoding/simd/simd_rle.h` | Frozen |
+| `encoding/simd/simd_types.h` | Frozen |
+| `encoding/simd/simd_utils.h` | Frozen |
+| `encoding/simd/simd_windowing.h` | Frozen |
+
+### `ihe/xds/` — IHE XDS.b document source/consumer/registry (6)
+
+| Header | Stability |
+|--------|-----------|
+| `ihe/xds/document_consumer.h` | Frozen |
+| `ihe/xds/document_source.h` | Frozen |
+| `ihe/xds/errors.h` | Frozen |
+| `ihe/xds/http_options.h` | Frozen |
+| `ihe/xds/registry_query.h` | Frozen |
+| `ihe/xds/submission_set.h` | Frozen |
+
+### `integration/` — Adapters to other ecosystem systems (8)
+
+| Header | Stability |
+|--------|-----------|
+| `integration/container_adapter.h` | Frozen |
+| `integration/dicom_session.h` | Frozen |
+| `integration/executor_adapter.h` | Frozen |
+| `integration/logger_adapter.h` | Frozen |
+| `integration/monitoring_adapter.h` | Frozen |
+| `integration/network_adapter.h` | Frozen |
+| `integration/thread_pool_adapter.h` | Frozen |
+| `integration/thread_pool_interface.h` | Frozen |
+
+### `monitoring/` — Health and metrics surfaces (5)
+
+| Header | Stability |
+|--------|-----------|
+| `monitoring/health_checker.h` | Frozen |
+| `monitoring/health_json.h` | Frozen |
+| `monitoring/health_status.h` | Frozen |
+| `monitoring/pacs_metrics.h` | Frozen |
+| `monitoring/pacs_monitor.h` | Frozen |
+
+### `monitoring/collectors/` — DICOM-specific metric collectors (5)
+
+| Header | Stability |
+|--------|-----------|
+| `monitoring/collectors/dicom_association_collector.h` | Frozen |
+| `monitoring/collectors/dicom_collector_base.h` | Frozen |
+| `monitoring/collectors/dicom_metrics_collector.h` | Frozen |
+| `monitoring/collectors/dicom_service_collector.h` | Frozen |
+| `monitoring/collectors/dicom_storage_collector.h` | Frozen |
+
+### `network/` — Association, PDU, server config (7)
+
+| Header | Stability |
+|--------|-----------|
+| `network/association.h` | Frozen |
+| `network/dicom_server.h` | Frozen |
+| `network/pdu_buffer_pool.h` | Frozen |
+| `network/pdu_decoder.h` | Frozen |
+| `network/pdu_encoder.h` | Frozen |
+| `network/pdu_types.h` | Frozen |
+| `network/server_config.h` | Frozen |
+
+### `network/detail/` — Implementation details (1)
+
+These are reachable via the `PUBLIC` include directory for packaging convenience
+but are not part of the v1.0 stability promise.
+
+| Header | Stability | Note |
+|--------|-----------|------|
+| `network/detail/accept_worker.h` | Implementation detail | Internal accept-loop helper. May change between minor versions. |
+
+### `network/dimse/` — DIMSE messages and N-services (9)
+
+| Header | Stability |
+|--------|-----------|
+| `network/dimse/command_field.h` | Frozen |
+| `network/dimse/dimse_message.h` | Frozen |
+| `network/dimse/n_action.h` | Frozen |
+| `network/dimse/n_create.h` | Frozen |
+| `network/dimse/n_delete.h` | Frozen |
+| `network/dimse/n_event_report.h` | Frozen |
+| `network/dimse/n_get.h` | Frozen |
+| `network/dimse/n_set.h` | Frozen |
+| `network/dimse/status_codes.h` | Frozen |
+
+### `network/pipeline/` — Pipeline coordinator (3)
+
+| Header | Stability |
+|--------|-----------|
+| `network/pipeline/pipeline_adapter.h` | Frozen |
+| `network/pipeline/pipeline_coordinator.h` | Frozen |
+| `network/pipeline/pipeline_job_types.h` | Frozen |
+
+### `network/pipeline/jobs/` — Pipeline job records (6)
+
+| Header | Stability |
+|--------|-----------|
+| `network/pipeline/jobs/dimse_process_job.h` | Frozen |
+| `network/pipeline/jobs/pdu_decode_job.h` | Frozen |
+| `network/pipeline/jobs/receive_network_io_job.h` | Frozen |
+| `network/pipeline/jobs/response_encode_job.h` | Frozen |
+| `network/pipeline/jobs/send_network_io_job.h` | Frozen |
+| `network/pipeline/jobs/storage_query_exec_job.h` | Frozen |
+
+### `network/pipeline/metrics/` — Pipeline metrics (1)
+
+| Header | Stability |
+|--------|-----------|
+| `network/pipeline/metrics/pipeline_metrics.h` | Frozen |
+
+### `network/v2/` — network_system v2 integration (2)
+
+The `v2/` suffix denotes the second-generation server built on the
+`network_system::messaging_server`. It coexists with `network/dicom_server.h`;
+both are part of the v1.0 surface, and consumers may pick either.
+
+| Header | Stability |
+|--------|-----------|
+| `network/v2/dicom_association_handler.h` | Frozen |
+| `network/v2/dicom_server_v2.h` | Frozen |
+
+### `security/` — RBAC, audit, anonymization, TLS, signing (20)
+
+| Header | Stability |
+|--------|-----------|
+| `security/access_control_manager.h` | Frozen |
+| `security/anonymization_profile.h` | Frozen |
+| `security/anonymizer.h` | Frozen |
+| `security/atna_audit_logger.h` | Frozen |
+| `security/atna_config.h` | Frozen |
+| `security/atna_service_auditor.h` | Frozen |
+| `security/atna_syslog_transport.h` | Frozen |
+| `security/audit_log_cipher.h` | Frozen |
+| `security/certificate.h` | Frozen |
+| `security/digital_signature.h` | Frozen |
+| `security/permission.h` | Frozen |
+| `security/role.h` | Frozen |
+| `security/security_storage_interface.h` | Frozen |
+| `security/signature_types.h` | Frozen |
+| `security/tag_action.h` | Frozen |
+| `security/tls_policy.h` | Frozen |
+| `security/uid_mapping.h` | Frozen |
+| `security/user.h` | Frozen |
+| `security/user_context.h` | Frozen |
+| `security/xds_audit_events.h` | Frozen |
+
+### `services/` — SCP/SCU service implementations (21)
+
+| Header | Stability |
+|--------|-----------|
+| `services/mpps_scp.h` | Frozen |
+| `services/mpps_scu.h` | Frozen |
+| `services/n_get_scp.h` | Frozen |
+| `services/n_get_scu.h` | Frozen |
+| `services/print_scp.h` | Frozen |
+| `services/print_scu.h` | Frozen |
+| `services/query_scp.h` | Frozen |
+| `services/query_scu.h` | Frozen |
+| `services/retrieve_scp.h` | Frozen |
+| `services/retrieve_scu.h` | Frozen |
+| `services/scp_service.h` | Frozen |
+| `services/sop_class_registry.h` | Frozen |
+| `services/storage_commitment_scp.h` | Frozen |
+| `services/storage_commitment_scu.h` | Frozen |
+| `services/storage_commitment_types.h` | Frozen |
+| `services/storage_scp.h` | Frozen |
+| `services/storage_scu.h` | Frozen |
+| `services/storage_status.h` | Frozen |
+| `services/verification_scp.h` | Frozen |
+| `services/worklist_scp.h` | Frozen |
+| `services/worklist_scu.h` | Frozen |
+
+### `services/cache/` — Query cache and streaming helpers (6)
+
+| Header | Stability |
+|--------|-----------|
+| `services/cache/database_cursor.h` | Frozen |
+| `services/cache/parallel_query_executor.h` | Frozen |
+| `services/cache/query_cache.h` | Frozen |
+| `services/cache/query_result_stream.h` | Frozen |
+| `services/cache/simple_lru_cache.h` | Frozen |
+| `services/cache/streaming_query_handler.h` | Frozen |
+
+### `services/monitoring/` — Database metrics service (1)
+
+| Header | Stability |
+|--------|-----------|
+| `services/monitoring/database_metrics_service.h` | Frozen |
+
+### `services/pir/` — Patient Identity Reconciliation (1)
+
+| Header | Stability |
+|--------|-----------|
+| `services/pir/patient_reconciliation_service.h` | Frozen |
+
+### `services/sop_classes/` — Modality-specific Storage SOP class records (15)
+
+| Header | Stability |
+|--------|-----------|
+| `services/sop_classes/ct_storage.h` | Frozen |
+| `services/sop_classes/dx_storage.h` | Frozen |
+| `services/sop_classes/mg_storage.h` | Frozen |
+| `services/sop_classes/mr_storage.h` | Frozen |
+| `services/sop_classes/nm_storage.h` | Frozen |
+| `services/sop_classes/ophthalmic_storage.h` | Frozen |
+| `services/sop_classes/parametric_map_storage.h` | Frozen |
+| `services/sop_classes/pet_storage.h` | Frozen |
+| `services/sop_classes/rt_storage.h` | Frozen |
+| `services/sop_classes/seg_storage.h` | Frozen |
+| `services/sop_classes/sr_storage.h` | Frozen |
+| `services/sop_classes/us_storage.h` | Frozen |
+| `services/sop_classes/waveform_storage.h` | Frozen |
+| `services/sop_classes/wsi_storage.h` | Frozen |
+| `services/sop_classes/xa_storage.h` | Frozen |
+
+### `services/ups/` — Unified Procedure Step actors (5)
+
+| Header | Stability |
+|--------|-----------|
+| `services/ups/ups_push_scp.h` | Frozen |
+| `services/ups/ups_push_scu.h` | Frozen |
+| `services/ups/ups_query_scp.h` | Frozen |
+| `services/ups/ups_watch_scp.h` | Frozen |
+| `services/ups/ups_watch_scu.h` | Frozen |
+
+### `services/validation/` — Per-modality IOD validators (18)
+
+| Header | Stability |
+|--------|-----------|
+| `services/validation/ct_iod_validator.h` | Frozen |
+| `services/validation/ct_processing_iod_validator.h` | Frozen |
+| `services/validation/dx_iod_validator.h` | Frozen |
+| `services/validation/heightmap_seg_iod_validator.h` | Frozen |
+| `services/validation/label_map_seg_iod_validator.h` | Frozen |
+| `services/validation/mg_iod_validator.h` | Frozen |
+| `services/validation/mr_iod_validator.h` | Frozen |
+| `services/validation/nm_iod_validator.h` | Frozen |
+| `services/validation/ophthalmic_iod_validator.h` | Frozen |
+| `services/validation/parametric_map_iod_validator.h` | Frozen |
+| `services/validation/pet_iod_validator.h` | Frozen |
+| `services/validation/rt_iod_validator.h` | Frozen |
+| `services/validation/seg_iod_validator.h` | Frozen |
+| `services/validation/sr_iod_validator.h` | Frozen |
+| `services/validation/us_iod_validator.h` | Frozen |
+| `services/validation/waveform_ps_iod_validator.h` | Frozen |
+| `services/validation/wsi_iod_validator.h` | Frozen |
+| `services/validation/xa_iod_validator.h` | Frozen |
+
+### `services/xds/` — Imaging document source/consumer for XDS (2)
+
+| Header | Stability |
+|--------|-----------|
+| `services/xds/imaging_document_consumer.h` | Frozen |
+| `services/xds/imaging_document_source.h` | Frozen |
+
+### `storage/` — Repositories, records, backends (52)
+
+| Header | Stability |
+|--------|-----------|
+| `storage/annotation_record.h` | Frozen |
+| `storage/annotation_repository.h` | Frozen |
+| `storage/audit_record.h` | Frozen |
+| `storage/audit_repository.h` | Frozen |
+| `storage/azure_blob_storage.h` | Frozen |
+| `storage/base_repository.h` | Frozen |
+| `storage/base_repository_impl.h` | Frozen |
+| `storage/commitment_repository.h` | Frozen |
+| `storage/file_storage.h` | Frozen |
+| `storage/hsm_migration_service.h` | Frozen |
+| `storage/hsm_storage.h` | Frozen |
+| `storage/hsm_types.h` | Frozen |
+| `storage/index_database.h` | Frozen |
+| `storage/instance_record.h` | Frozen |
+| `storage/instance_repository.h` | Frozen |
+| `storage/job_repository.h` | Frozen |
+| `storage/key_image_record.h` | Frozen |
+| `storage/key_image_repository.h` | Frozen |
+| `storage/measurement_record.h` | Frozen |
+| `storage/measurement_repository.h` | Frozen |
+| `storage/migration_record.h` | Frozen |
+| `storage/migration_runner.h` | Frozen |
+| `storage/mpps_record.h` | Frozen |
+| `storage/mpps_repository.h` | Frozen |
+| `storage/node_repository.h` | Frozen |
+| `storage/pacs_database_adapter.h` | Frozen |
+| `storage/patient_record.h` | Frozen |
+| `storage/patient_repository.h` | Frozen |
+| `storage/prefetch_history_repository.h` | Frozen |
+| `storage/prefetch_repository.h` | Frozen |
+| `storage/prefetch_rule_repository.h` | Frozen |
+| `storage/recent_study_repository.h` | Frozen |
+| `storage/repository_factory.h` | Frozen |
+| `storage/routing_repository.h` | Frozen |
+| `storage/s3_storage.h` | Frozen |
+| `storage/series_record.h` | Frozen |
+| `storage/series_repository.h` | Frozen |
+| `storage/sqlite_security_storage.h` | Frozen |
+| `storage/storage_interface.h` | Frozen |
+| `storage/study_record.h` | Frozen |
+| `storage/study_repository.h` | Frozen |
+| `storage/sync_config_repository.h` | Frozen |
+| `storage/sync_conflict_repository.h` | Frozen |
+| `storage/sync_history_repository.h` | Frozen |
+| `storage/sync_repository.h` | Frozen |
+| `storage/ups_repository.h` | Frozen |
+| `storage/ups_workitem.h` | Frozen |
+| `storage/viewer_state_record.h` | Frozen |
+| `storage/viewer_state_record_repository.h` | Frozen |
+| `storage/viewer_state_repository.h` | Frozen |
+| `storage/worklist_record.h` | Frozen |
+| `storage/worklist_repository.h` | Frozen |
+
+### `web/` — REST server, types, services (5)
+
+| Header | Stability |
+|--------|-----------|
+| `web/metadata_service.h` | Frozen |
+| `web/rest_config.h` | Frozen |
+| `web/rest_server.h` | Frozen |
+| `web/rest_types.h` | Frozen |
+| `web/thumbnail_service.h` | Frozen |
+
+### `web/auth/` — OAuth2 / JWT validation (4)
+
+| Header | Stability |
+|--------|-----------|
+| `web/auth/jwks_provider.h` | Frozen |
+| `web/auth/jwt_validator.h` | Frozen |
+| `web/auth/oauth2_config.h` | Frozen |
+| `web/auth/oauth2_middleware.h` | Frozen |
+
+### `web/endpoints/` — Per-domain HTTP endpoint handlers (21)
+
+| Header | Stability |
+|--------|-----------|
+| `web/endpoints/annotation_endpoints.h` | Frozen |
+| `web/endpoints/association_endpoints.h` | Frozen |
+| `web/endpoints/audit_endpoints.h` | Frozen |
+| `web/endpoints/dicomweb_endpoints.h` | Frozen |
+| `web/endpoints/jobs_endpoints.h` | Frozen |
+| `web/endpoints/key_image_endpoints.h` | Frozen |
+| `web/endpoints/measurement_endpoints.h` | Frozen |
+| `web/endpoints/metadata_endpoints.h` | Frozen |
+| `web/endpoints/metrics_endpoints.h` | Frozen |
+| `web/endpoints/patient_endpoints.h` | Frozen |
+| `web/endpoints/remote_nodes_endpoints.h` | Frozen |
+| `web/endpoints/routing_endpoints.h` | Frozen |
+| `web/endpoints/security_endpoints.h` | Frozen |
+| `web/endpoints/series_endpoints.h` | Frozen |
+| `web/endpoints/storage_commitment_endpoints.h` | Frozen |
+| `web/endpoints/study_endpoints.h` | Frozen |
+| `web/endpoints/system_endpoints.h` | Frozen |
+| `web/endpoints/thumbnail_endpoints.h` | Frozen |
+| `web/endpoints/viewer_state_endpoints.h` | Frozen |
+| `web/endpoints/wado_uri_endpoints.h` | Frozen |
+| `web/endpoints/worklist_endpoints.h` | Frozen |
+
+### `workflow/` — Auto-prefetch and task scheduling (5)
+
+| Header | Stability |
+|--------|-----------|
+| `workflow/auto_prefetch_service.h` | Frozen |
+| `workflow/prefetch_config.h` | Frozen |
+| `workflow/study_lock_manager.h` | Frozen |
+| `workflow/task_scheduler.h` | Frozen |
+| `workflow/task_scheduler_config.h` | Frozen |
+
+## Summary
+
+| Category | Count |
+|----------|-------|
+| Public headers (Frozen) | 289 |
+| Implementation detail (subject to change between minor versions) | 1 |
+| Total headers under `include/kcenon/pacs/` | 290 |
+
+## `[[deprecated]]` Inventory
+
+A repository-wide grep for `[[deprecated` over `include/kcenon/pacs/` returns
+no occurrences:
+
+```
+$ grep -rn "\[\[deprecated" include/kcenon/pacs/
+(no output)
+```
+
+A wider case-insensitive scan for the word `deprecated` finds a single
+descriptive comment in `ihe/xds/submission_set.h` referring to XDS document
+availability status (a domain term, not a C++ attribute):
+
+```
+include/kcenon/pacs/ihe/xds/submission_set.h:
+ * behavior for most deployments). Callers that need Deprecated documents or
+```
+
+There are therefore **no `[[deprecated]]` symbols to retain or remove** in the
+v1.0 surface. Future deprecations introduced after the v1.0 freeze will follow
+the lifecycle:
+
+1. Add `[[deprecated("reason; replacement: …")]]` and a Doxygen `@deprecated`
+   block in the header.
+2. Record the deprecation under "Deprecated" in `CHANGELOG.md` `[Unreleased]`.
+3. Schedule removal for the v2.0 release; do not remove during v1.x.
+
+A follow-up issue [#1160](https://github.com/kcenon/pacs_system/issues/1160)
+covers any future removal pass; this freeze audit only enumerates and confirms
+the empty inventory.
+
+## Experimental Headers
+
+A scan for the keywords `experimental`, `EXPERIMENTAL`, `@experimental`, and
+the literal directory `experimental/` returns no matches under
+`include/kcenon/pacs/`. There is no experimental staging area and nothing to
+move under an `experimental/` subtree for v1.0.
+
+The `network/v2/` subdirectory is **not** experimental: it is the second-
+generation network server built on `network_system::messaging_server` and is
+documented as `@since 1.0.0`. Both `network/dicom_server.h` and
+`network/v2/dicom_server_v2.h` are part of the frozen surface.
+
+## Stability Promise
+
+For the v1.0 line:
+
+- Public symbols listed above will not be removed or renamed.
+- Public function signatures will not be broken (existing parameters keep their
+  names, types, defaults, and ordering).
+- Public class layouts may add private members at the end of the class body
+  but will not reorder or remove existing members.
+- Enumerations may grow with new enumerators at the end; existing enumerators
+  keep their numeric values.
+- Header file paths under `include/kcenon/pacs/` will not move.
+
+The single exception is `network/detail/accept_worker.h`, listed as
+"Implementation detail" above. Consumers should not include it directly.
+
+## Related References
+
+- Parent EPIC: [#1095](https://github.com/kcenon/pacs_system/issues/1095) v1.0 release readiness.
+- Issue: [#1156](https://github.com/kcenon/pacs_system/issues/1156) v1.0 API freeze audit of public headers.
+- Ecosystem v1.0 contract: [common_system #639](https://github.com/kcenon/common_system/issues/639).
+- Existing API documentation:
+  - [`docs/API_REFERENCE.md`](API_REFERENCE.md) — entry point for the per-module references.
+  - [`docs/API_REFERENCE_CORE.md`](API_REFERENCE_CORE.md), [`API_REFERENCE_NETWORK.md`](API_REFERENCE_NETWORK.md), [`API_REFERENCE_SERVICES.md`](API_REFERENCE_SERVICES.md), [`API_REFERENCE_WEB.md`](API_REFERENCE_WEB.md), [`API_REFERENCE_SECURITY.md`](API_REFERENCE_SECURITY.md).
+  - [`docs/API_QUICK_REFERENCE.md`](API_QUICK_REFERENCE.md) — quick-start cheat sheet.
+- Install rules: `cmake/install.cmake`, `cmake/targets.cmake`.
+
+## How to Regenerate
+
+If the public header tree changes during v1.x, regenerate the inventory with:
+
+```bash
+find include/kcenon/pacs -type f \( -name "*.h" -o -name "*.hpp" \) \
+  | sed 's|include/kcenon/pacs/||' | sort
+```
+
+Compare the result against the tables above. Any addition is a new public
+symbol that must keep the v1.0 stability promise from its first release.


### PR DESCRIPTION
## What

Audits the public API surface under `include/kcenon/pacs/` and freezes it for the v1.0 release. The audit is documentation-only — no public symbol is added, removed, renamed, or moved.

- Adds `docs/v1.0-api-surface.md`: 290 public headers enumerated and grouped by 33 modules with per-module counts that match the filesystem.
- Each header is tagged with a stability marker. The only "Implementation detail" entry is `network/detail/accept_worker.h`; the remaining 289 headers are "Frozen" for v1.0.
- Records the `[[deprecated]]` inventory as empty (a repository-wide grep over `include/kcenon/pacs/` returns no `[[deprecated` matches; the only `deprecated` text is a domain-term comment in `ihe/xds/submission_set.h` describing XDS document availability).
- Records the experimental-headers inventory as empty (no `experimental/` directory exists; no header is annotated `@experimental`). `network/v2/` is documented as part of the frozen surface, not experimental.
- Adds a `[Unreleased]` "Changed" entry to `CHANGELOG.md` summarizing the freeze.

## Why

- v1.0 promises no breaking changes for one minor cycle (see [common_system #639](https://github.com/kcenon/common_system/issues/639) for the ecosystem-wide v1.0 contract).
- This is the last audit pass before the freeze: it gives downstream consumers an authoritative list of which headers will not move, and it gives the project a regenerable baseline to detect accidental ABI/API drift in v1.x.
- The empty `[[deprecated]]` inventory means there is no removal work for #1160 to absorb beyond what may be added in future PRs.

Closes #1156
Part of #1095

## How

- Walked the public-include tree (`find include/kcenon/pacs -type f \( -name "*.h" -o -name "*.hpp" \)`) and grouped 290 headers into the 33 module directories that exist on disk.
- Wrote each module's header table in `docs/v1.0-api-surface.md` and cross-checked the row counts against `find ... | sed ... | uniq -c`. Total table rows in the document: 290 (verified via `grep -c '^| `' docs/v1.0-api-surface.md`).
- Inspected `cmake/targets.cmake` to confirm `target_include_directories(... PUBLIC ...)` exposes only `include/` (no extra `INTERFACE` paths), so the freeze surface is exactly the `include/kcenon/pacs/` tree.
- Ran `grep -rn "\[\[deprecated" include/kcenon/pacs/` (zero matches) and `grep -ri "deprecated" include/` (one match, a comment in `submission_set.h` about XDS document availability — unrelated to the C++ attribute).
- Searched for the `experimental` keyword/directory; none found.
- Documented the v1.0 stability promise (no removal, no rename, no signature break, no header relocation until v2.0) and the regeneration command for future audits.

## Where

- `docs/v1.0-api-surface.md` (new)
- `CHANGELOG.md`

## Test Plan

This is a documentation-only PR. Verification is mechanical:

1. **Header count**: `find include/kcenon/pacs -type f \( -name "*.h" -o -name "*.hpp" \) | wc -l` → 290.
2. **Per-module counts**: `find ... | sed 's|/[^/]*$||' | sort | uniq -c` matches the per-module counts in the doc tables.
3. **Document table rows**: `grep -c '^| \`' docs/v1.0-api-surface.md` → 290.
4. **Deprecated inventory**: `grep -rn "\[\[deprecated" include/kcenon/pacs/` returns no output.
5. **Experimental inventory**: `find include/ -type d -name experimental` returns no output.
6. **Build sanity**: No source files were touched; `cmake --build build` is unaffected. CI on `develop` will validate the markdown doesn't break Doxygen ingestion.

## Notes for reviewers

- The Korean changelog mirror (`docs/CHANGELOG.kr.md`) and the doc-mirror at `docs/CHANGELOG.md` are not touched here. Translation/sync of these auxiliary files is out of scope for the freeze audit and can be picked up in a follow-up doc-sync issue alongside the next translated entries.
- The issue body refers to `include/pacs_system/`; the actual canonical path is `include/kcenon/pacs/` (post namespace migration). The doc records this so future readers don't get confused by the older path.
- `network/v2/dicom_server_v2.h` is intentionally part of the frozen surface, not "experimental". Its `@since 1.0.0` tag and the prior namespace-migration work make it a first-class v1.0 entry that coexists with `network/dicom_server.h`.
