### PR TITLE
task(api): audit and clean up deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Audited public and internal source for `[[deprecated]]` markers ahead of v1.0 freeze; no deprecated APIs were found, so no symbols were removed in this audit. Inventory recorded in [`docs/v1.0-deprecation-inventory.md`](docs/v1.0-deprecation-inventory.md) ([#1160](https://github.com/kcenon/pacs_system/issues/1160))
+
 ### Added
 
 - IHE XDS.b Document Source actor (ITI-41) at `src/ihe/xds/` with pugixml + libcurl transport stack ([#1128](https://github.com/kcenon/pacs_system/issues/1128))

--- a/docs/v1.0-deprecation-inventory.md
+++ b/docs/v1.0-deprecation-inventory.md
@@ -1,0 +1,118 @@
+# v1.0 Deprecation Inventory
+
+**Audit date**: 2026-05-10
+**Tracking issue**: [#1160](https://github.com/kcenon/pacs_system/issues/1160)
+**Parent epic**: [#1095](https://github.com/kcenon/pacs_system/issues/1095)
+**Audit scope**: All `[[deprecated]]` markers across `include/` and `src/`
+
+## Executive Summary
+
+**No deprecated APIs as of v1.0 freeze.**
+
+A full audit of the public and internal source tree (`include/` and `src/`) was
+performed using a recursive scan for the C++ `[[deprecated]]` attribute as well
+as legacy markers (`__deprecated`, `__attribute__((deprecated))`, `DEPRECATED`
+macros, and `deprecated_msg`). Zero matches were found in either tree.
+
+## Audit Methodology
+
+### Search commands
+
+The following commands were run from the repository root:
+
+```bash
+# Canonical C++20 attribute scan
+grep -rn '\[\[deprecated' include/ src/
+
+# Legacy marker scan
+grep -rn 'DEPRECATED\|__deprecated\|attribute((deprecated\|deprecated_msg' \
+  --include='*.h' --include='*.hpp' --include='*.cpp' --include='*.cc' \
+  include/ src/
+
+# Whole-tree fallback (catches comments, strings, and pragmas)
+grep -rn 'deprecat' include/
+```
+
+### Results
+
+| Scan | Matches in `include/` | Matches in `src/` |
+|------|----------------------|-------------------|
+| `[[deprecated]]` attribute | 0 | 0 |
+| Legacy `DEPRECATED` macros / `__attribute__((deprecated))` | 0 | 0 |
+| Any string containing `deprecat` | 0 | 3 (all comments, see below) |
+
+The three string matches in `src/` are not API deprecations:
+
+| File | Context |
+|------|---------|
+| `src/integration/thread_pool_adapter.cpp:171` | Code comment noting that `job_builder` replaces an upstream `thread_system` API; not a pacs_system deprecation. |
+| `src/integration/network_adapter.cpp:91` | Code comment explaining that an upstream `network_system` synchronous-connect path uses callbacks deprecated in newer `network_system` releases. |
+| `src/integration/network_adapter.cpp:95` | `#pragma GCC diagnostic ignored "-Wdeprecated-declarations"` to suppress upstream deprecation warnings during transition. Not a pacs_system API. |
+
+These three locations track *upstream ecosystem* deprecations and have no
+counterpart in the pacs_system public surface. They are tracked separately by
+the integration adapter rewrite work (out of scope for #1160).
+
+## Inventory Table
+
+| Symbol | Location | Deprecated since | v1.x removal target | Disposition |
+|--------|----------|------------------|---------------------|-------------|
+| _(none)_ | — | — | — | — |
+
+The inventory is intentionally empty: the v1.0 public surface has no
+`[[deprecated]]` markers to either remove or retain.
+
+## Disposition Summary
+
+| Category | Count |
+|----------|------:|
+| Symbols inventoried | 0 |
+| Symbols removed in this PR | 0 |
+| Symbols retained for v1.x removal | 0 |
+
+## Why This Is the Expected Outcome
+
+The pacs_system project is a fresh implementation written for the v1.0 release
+window; the public API has been shaped by issue-driven design rather than by
+incremental migration from a v0 line. As a result, no APIs have accumulated
+formal deprecation markers. Backwards-compatibility shims that *do* exist
+(for example the preserved `PACS_BUILD_EXAMPLES` / `PACS_BUILD_SAMPLES`
+CMake option names from #1139) are compatibility aliases at the build-system
+layer rather than deprecated C++ symbols, and are documented in CHANGELOG
+under the relevant Changed entry.
+
+## Maintenance Policy Going Forward
+
+To keep this inventory meaningful after v1.0 freeze:
+
+1. **New deprecations after v1.0**: any C++ symbol marked with
+   `[[deprecated("reason; removal target=vX.Y")]]` MUST include an explicit
+   `removal_target=vX.Y` token in the deprecation message. The audit script
+   in this document can then parse the target on the next sweep.
+2. **Inventory refresh cadence**: re-run the grep commands at the start of
+   each minor-version release cycle and update the table above. Symbols whose
+   stated `removal_target` has been reached must either be removed in that
+   cycle's PR or have their target deferred with rationale.
+3. **CHANGELOG discipline**: every deletion of a deprecated symbol after
+   v1.0 must appear under the matching minor or major release's `Removed`
+   section per Keep a Changelog conventions.
+
+## Acceptance Criteria Mapping
+
+The acceptance criteria from issue #1160 map to this inventory as follows:
+
+- [x] **Inventory of all `[[deprecated]]` markers committed** — this file
+  records the scan result of zero markers.
+- [x] **All removal-targeted symbols deleted in dedicated PRs** —
+  vacuously satisfied; no removal-targeted symbols exist.
+- [x] **Retained symbols document their v1.x removal target** —
+  vacuously satisfied; no retained deprecated symbols exist.
+- [x] **CHANGELOG lists removed APIs under "Removed"** — the `[Unreleased]`
+  section gains a `Removed` entry confirming "no deprecated APIs at v1.0
+  freeze" so readers can verify the audit was performed.
+
+## References
+
+- Issue [#1160](https://github.com/kcenon/pacs_system/issues/1160) — task spec
+- Issue [#1095](https://github.com/kcenon/pacs_system/issues/1095) — v1.0 freeze epic
+- [CHANGELOG.md](../CHANGELOG.md) — `[Unreleased]` -> `Removed`


### PR DESCRIPTION
## What

Audits the public and internal source tree for `[[deprecated]]` markers ahead of
the v1.0 API freeze and produces a committed inventory of the result.

**Scan result:** zero `[[deprecated]]` markers in `include/` or `src/`.

This is a documentation-only PR. No source code was deleted because there were
no deprecated symbols to remove or retain.

### Change Type
- [x] Documentation
- [x] Chore (CHANGELOG bookkeeping)

### Affected Components
- `docs/v1.0-deprecation-inventory.md` (new) — full inventory + audit methodology
- `CHANGELOG.md` — `[Unreleased]` -> `Removed` entry recording the audit

## Why

### Problem Solved
v1.0 is the cleanest moment to remove deprecated APIs because, after freeze,
removal becomes a SemVer major bump (v2.0). The audit confirms whether any
removal-targeted symbols exist before the freeze window closes.

### Related Issues
- Closes #1160
- Part of #1095 (v1.0 freeze epic)

## Where

| Path | Change |
|------|--------|
| `docs/v1.0-deprecation-inventory.md` | New file: scan results, methodology, post-v1.0 maintenance policy |
| `CHANGELOG.md` | Added `Removed` entry under `[Unreleased]` linking to the inventory |

## How

### Audit Methodology
The following commands were run from the repository root:

```bash
# Canonical C++20 attribute scan
grep -rn '\[\[deprecated' include/ src/

# Legacy marker scan
grep -rn 'DEPRECATED\|__deprecated\|attribute((deprecated\|deprecated_msg' \
  --include='*.h' --include='*.hpp' --include='*.cpp' --include='*.cc' \
  include/ src/

# Whole-tree fallback
grep -rn 'deprecat' include/
```

### Deprecated Symbols Inventoried
**Total: 0**

| Symbol | Disposition |
|--------|-------------|
| _(none)_ | — |

- Symbols inventoried: **0**
- Symbols removed in this PR: **0**
- Symbols retained for v1.x removal: **0**

### Excluded matches (not pacs_system APIs)
Three string matches in `src/integration/` reference upstream ecosystem
deprecations and are explicitly excluded:

- `src/integration/thread_pool_adapter.cpp:171` — comment about upstream `job_builder` replacing `future_job` in `thread_system`.
- `src/integration/network_adapter.cpp:91,95` — comment plus `#pragma GCC diagnostic ignored "-Wdeprecated-declarations"` for a synchronous-connect path in upstream `network_system`.

These are tracked by the integration adapter rewrite work (out of scope for #1160).

### Acceptance Criteria
- [x] Inventory of all `[[deprecated]]` markers committed (`docs/v1.0-deprecation-inventory.md`)
- [x] All removal-targeted symbols deleted in dedicated PRs (vacuously satisfied — no removal targets)
- [x] Retained symbols document their v1.x removal target (vacuously satisfied — no retained symbols)
- [x] CHANGELOG lists removed APIs under "Removed" (entry added under `[Unreleased]` confirming empty result)

### Test Plan
- This is a documentation-only change; no header or source code is modified.
- CI will exercise the existing build matrix to confirm no regression.
- Reviewers can independently re-run the grep commands above to verify the zero-match result.

### Breaking Changes
None.

### Rollback
Revert this PR. No runtime or build behavior changes.
