### PR TITLE
doc(v1.0): review documentation completeness

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,12 +46,12 @@ TLS test certificates are not stored in version control. Generate them before ru
 ## Development Workflow
 
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/your-feature`)
+2. Branch from `develop` (the integration branch) — `git checkout develop && git pull && git checkout -b feature/your-feature`
 3. Make your changes
 4. Run tests and ensure they pass
 5. Commit your changes (see commit message guidelines below)
 6. Push to your fork (`git push origin feature/your-feature`)
-7. Open a Pull Request
+7. Open a Pull Request targeting `develop`. Releases to `main` are cut by maintainers via a separate `develop` -> `main` PR.
 
 ### Commit Message Guidelines
 
@@ -120,13 +120,17 @@ All code contributions must include tests:
 
 ### Writing Tests
 
-Use Google Test framework:
+Use Catch2 v3 (the project-wide test framework — note this differs from the kcenon
+ecosystem default of Google Test; see [`docs/ECOSYSTEM.md`](docs/ECOSYSTEM.md) and
+[#1141](https://github.com/kcenon/pacs_system/issues/1141)):
 
 ```cpp
-#include <gtest/gtest.h>
+#include <catch2/catch_test_macros.hpp>
 
-TEST(ComponentTest, BasicFunctionality) {
-    // Test implementation
+TEST_CASE("Component: basic functionality", "[component]") {
+    SECTION("default state") {
+        // Test implementation
+    }
 }
 ```
 

--- a/Doxyfile
+++ b/Doxyfile
@@ -5,7 +5,7 @@
 #---------------------------------------------------------------------------
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "PACS System"
-PROJECT_NUMBER         = "0.1.0"
+PROJECT_NUMBER         = "1.0.0"
 PROJECT_BRIEF          = "PACS DICOM system library"
 PROJECT_LOGO           =
 OUTPUT_DIRECTORY       = documents

--- a/README.md
+++ b/README.md
@@ -46,14 +46,26 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 
 ## Project Status
 
-**Current Phase**: ✅ Phase 4 Complete - Advanced Services & Production Hardening
+**Current Version**: 1.0.0 — Stable Public API
+**Project Phase**: Phase 4 Complete — Advanced Services & Production Hardening
+
+The v1.0 contract freezes the public header surface under `include/kcenon/pacs/`, the
+`pacs_system::pacs_system` aggregate CMake target, and the documented Doxygen API. See
+[`docs/v1.0-api-surface.md`](docs/v1.0-api-surface.md) for the frozen header inventory,
+[`docs/v1.0-throw-policy.md`](docs/v1.0-throw-policy.md) for the exception/Result<T> contract,
+and [`docs/v1.0-deprecation-inventory.md`](docs/v1.0-deprecation-inventory.md) for the
+pre-freeze deprecation audit.
+
+Upgrading from 0.x? See the [CHANGELOG](CHANGELOG.md) for the 0.x → 1.0 change set including the
+`samples/` → `examples/` and `examples/` → `tools/` directory relocation (#1139) and the
+`pacs_system::pacs_system` CMake contract (#1158).
 
 | Phase | Scope | Status |
 |-------|-------|--------|
-| **Phase 1**: Foundation | DICOM Core, Tag Dictionary, File I/O (Part 10), Transfer Syntax | ✅ Complete |
-| **Phase 2**: Network Protocol | Upper Layer Protocol (PDU), Association State Machine, DIMSE-C, Compression Codecs | ✅ Complete |
-| **Phase 3**: Core Services | Storage SCP/SCU, File Storage, Index Database, Query/Retrieve, Logging, Monitoring | ✅ Complete |
-| **Phase 4**: Advanced Services | REST API, DICOMweb, AI Integration, Client Module, Cloud Storage, Print Management, Security, Workflow, Annotation/Viewer | ✅ Complete |
+| **Phase 1**: Foundation | DICOM Core, Tag Dictionary, File I/O (Part 10), Transfer Syntax | Complete |
+| **Phase 2**: Network Protocol | Upper Layer Protocol (PDU), Association State Machine, DIMSE-C, Compression Codecs | Complete |
+| **Phase 3**: Core Services | Storage SCP/SCU, File Storage, Index Database, Query/Retrieve, Logging, Monitoring | Complete |
+| **Phase 4**: Advanced Services | REST API, DICOMweb, AI Integration, Client Module, Cloud Storage, Print Management, Security, Workflow, Annotation/Viewer | Complete |
 
 **Test Coverage**: 1,980+ tests passing across 141+ test files | [![codecov](https://codecov.io/gh/kcenon/pacs_system/branch/main/graph/badge.svg)](https://codecov.io/gh/kcenon/pacs_system)
 
@@ -73,6 +85,9 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 │  └────┬─────┘ └────┬─────┘ └────┬────┘ └────┬─────┘ └─────┬─────┘  │
 │       └─────────────┼───────────┼───────────┼──────────────┘        │
 │  ┌──────────────────▼───────────▼───────────▼────────────────────┐  │
+│  │  IHE Actors (XDS.b Source / Consumer / Registry Query + ATNA) │  │
+│  └──────────────────────────────┬────────────────────────────────┘  │
+│  ┌──────────────────────────────▼────────────────────────────────┐  │
 │  │  Services (Storage/Query/Retrieve/Worklist/MPPS/Commit/Print) │  │
 │  └──────────────────────────────┬────────────────────────────────┘  │
 │  ┌──────────────────────────────▼────────────────────────────────┐  │
@@ -87,7 +102,7 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 │  │   S3/Azure) │  │   Prefetch/RemoteNode) │  │   Metrics)      │  │
 │  └──────┬──────┘  └────────────────────────┘  └─────────────────┘  │
 ├─────────┼────────────────────────────────────────────────────────────┤
-│         │             Integration Adapters                           │
+│         │             Integration Adapters + DI                      │
 │  container │ network │ thread │ logger │ monitoring                  │
 ├─────────┼────────────────────────────────────────────────────────────┤
 │         │              kcenon Ecosystem                               │
@@ -443,30 +458,36 @@ This project leverages the following kcenon ecosystem components:
 
 ## Project Structure
 
+Public headers live under `include/kcenon/pacs/<module>/`. The legacy `include/pacs/...`
+path was retired; all consumers should `#include <kcenon/pacs/...>`.
+
 | Module | Location | Description |
 |--------|----------|-------------|
-| **Core** | `include/pacs/core/` | DICOM tags, elements, datasets, Part 10 file I/O, tag dictionary |
-| **Encoding** | `include/pacs/encoding/` | VR types, transfer syntaxes, compression codecs (JPEG, JP2K, JPLS, RLE) |
-| **Network** | `include/pacs/network/` | PDU encoding/decoding, association state machine, DIMSE protocol |
-| **Services** | `include/pacs/services/` | SCP/SCU implementations, SOP class registry, IOD validators |
-| **Storage** | `include/pacs/storage/` | File storage, SQLite indexing, cloud storage (S3/Azure), HSM |
-| **Security** | `include/pacs/security/` | RBAC, anonymization (PS3.15), digital signatures, TLS |
-| **Monitoring** | `include/pacs/monitoring/` | Health checks, Prometheus metrics |
-| **Web** | `include/pacs/web/` | REST API (Crow), DICOMweb (WADO/STOW/QIDO) |
-| **Client** | `include/pacs/client/` | Job, routing, sync, prefetch, remote node management |
-| **Workflow** | `include/pacs/workflow/` | Auto prefetch, task scheduler, study lock manager |
-| **AI** | `include/pacs/ai/` | AI service connector, result handler (SR/SEG) |
-| **Integration** | `include/pacs/integration/` | Ecosystem adapters (container, network, thread, logger, monitoring) |
+| **Core** | `include/kcenon/pacs/core/` | DICOM tags, elements, datasets, Part 10 file I/O, tag dictionary |
+| **Encoding** | `include/kcenon/pacs/encoding/` | VR types, transfer syntaxes, compression codecs (JPEG, JP2K, JPLS, RLE) |
+| **Network** | `include/kcenon/pacs/network/` | PDU encoding/decoding, association state machine, DIMSE protocol |
+| **Services** | `include/kcenon/pacs/services/` | SCP/SCU implementations, SOP class registry, IOD validators |
+| **Storage** | `include/kcenon/pacs/storage/` | File storage, SQLite indexing, cloud storage (S3/Azure), HSM |
+| **Security** | `include/kcenon/pacs/security/` | RBAC, anonymization (PS3.15), digital signatures, TLS |
+| **Monitoring** | `include/kcenon/pacs/monitoring/` | Health checks, Prometheus metrics |
+| **Web** | `include/kcenon/pacs/web/` | REST API (Crow), DICOMweb (WADO/STOW/QIDO) |
+| **Client** | `include/kcenon/pacs/client/` | Job, routing, sync, prefetch, remote node management |
+| **Workflow** | `include/kcenon/pacs/workflow/` | Auto prefetch, task scheduler, study lock manager |
+| **AI** | `include/kcenon/pacs/ai/` | AI service connector, result handler (SR/SEG) |
+| **Integration** | `include/kcenon/pacs/integration/` | Ecosystem adapters (container, network, thread, logger, monitoring) |
+| **IHE** | `include/kcenon/pacs/ihe/` | IHE actors (XDS.b Document Source/Consumer, Registry Query, ATNA audit) |
+| **DI** | `include/kcenon/pacs/di/` | Dependency injection utilities for service composition |
+| **Compat** | `include/kcenon/pacs/compat/` | Compatibility shims for cross-platform and legacy include paths |
 
 ```
 pacs_system/
-├── include/pacs/         # Public headers (222 files)
-├── src/                  # Source implementations (148 files)
-├── tests/                # Test suites (141+ files, 1,980+ tests)
+├── include/kcenon/pacs/  # Public headers (290 files)
+├── src/                  # Source implementations (217 files)
+├── tests/                # Test suites (189 files, 2,657+ tests)
 ├── examples/             # Tutorials (5 progressive learning steps)
 ├── tools/                # CLI utility binaries (32 apps)
-├── docs/                 # Documentation (57 files)
-└── CMakeLists.txt        # Build configuration (v0.2.0)
+├── docs/                 # Documentation (87 markdown files)
+└── CMakeLists.txt        # Build configuration (v1.0.0)
 ```
 
 > For the full file-level directory tree, see [Project Structure](docs/PROJECT_STRUCTURE.md).
@@ -597,8 +618,8 @@ cmake --build build --target run_full_benchmarks
 | **Example Programs** | 6 apps |
 | **Documentation** | 87 markdown files |
 | **CI/CD Workflows** | 15 workflows |
-| **Version** | 0.1.0 |
-| **Last Updated** | 2026-05-01 |
+| **Version** | 1.0.0 |
+| **Last Updated** | 2026-05-13 |
 
 <!-- STATS_END -->
 


### PR DESCRIPTION
## What

Refresh the top-level documentation surface to match the v1.0.0 state of `pacs_system`.

Three files touched: `README.md`, `Doxyfile`, `CONTRIBUTING.md`.

### Change type
- [x] Documentation
- [ ] Feature
- [ ] Bugfix

### Affected components
- `README.md` — Project Status section, Architecture diagram, Project Structure module table, STATS block
- `Doxyfile` — `PROJECT_NUMBER` field
- `CONTRIBUTING.md` — Development Workflow, Writing Tests example

## Why

The v1.0 epic ([#1095](https://github.com/kcenon/pacs_system/issues/1095)) requires the documentation surface to communicate v1.0 status, install, integration, and migration guidance, and to refresh architecture material if the module layout has changed. The pre-PR state had four documentation defects against that acceptance set:

1. **README still framed the project as "Phase 4 Complete" with no v1.0 banner.** `CMakeLists.txt` declares `VERSION 1.0.0` and the v1.0 contract documents (`docs/v1.0-api-surface.md`, `docs/v1.0-throw-policy.md`, `docs/v1.0-deprecation-inventory.md`) all exist and are referenced from `CHANGELOG.md`, but the README home page did not surface any of them.
2. **README's Project Structure table used the retired `include/pacs/...` path layout.** The actual public headers live at `include/kcenon/pacs/<module>/`. The table also omitted three modules that ship in the v1.0 surface: `ihe/` (XDS.b actors and ATNA audit, added by #1128/#1129/#1130/#1131), `di/` (DI utilities), and `compat/` (compatibility shims). The README directory-tree block also stated counts that no longer match the codebase ("222 headers", "148 sources", "v0.2.0" build), inconsistent with the STATS_START block immediately below it.
3. **Doxyfile `PROJECT_NUMBER` reported "0.1.0".** The generated Doxygen header therefore advertised a pre-v1.0 release number on the hosted API reference page.
4. **CONTRIBUTING.md instructed contributors to use Google Test.** The project uses Catch2 v3 — this is documented as an explicit ecosystem exception in `docs/ECOSYSTEM.md` and tracked by [#1141](https://github.com/kcenon/pacs_system/issues/1141), but the contributor onboarding doc still showed `#include <gtest/gtest.h>` and `TEST(Suite, Case)` examples, which would actively mislead new contributors writing their first test. The same file also instructed contributors to create a feature branch without specifying that PRs must target `develop` per the project's branching-strategy rule.

These four defects are the exact items the issue acceptance criteria call out (README v1.0 framing + migration link, Doxygen surface accuracy, architecture refresh, CONTRIBUTING currency).

### Related issues
- Closes [#1161](https://github.com/kcenon/pacs_system/issues/1161)
- Part of [#1095](https://github.com/kcenon/pacs_system/issues/1095) (v1.0 epic)

## Who

- Reviewers: @kcenon
- Stakeholders: downstream consumers reading the README and the hosted Doxygen page

## When

- Urgency: Normal
- Target release: v1.0.0
- No deployment side-effects (docs-only)

## Where

| File | What changed |
|------|--------------|
| `README.md` | Project Status section rewritten to lead with "Current Version: 1.0.0 — Stable Public API" plus links to the three v1.0 contract docs (api-surface, throw-policy, deprecation-inventory) and `CHANGELOG.md` for the 0.x to 1.0 change set; Architecture diagram gains an IHE Actors row (XDS.b Source / Consumer / Registry Query + ATNA) and an explicit `DI` label on the integration-adapter row; Project Structure include-path column rewritten from `include/pacs/...` to `include/kcenon/pacs/<module>/` for all 12 existing entries; three new module rows added (`ihe/`, `di/`, `compat/`); directory tree counts refreshed to `290 headers / 217 sources / 189 tests / 2,657+ tests / 87 docs / v1.0.0`; STATS_START block `Version` bumped from `0.1.0` to `1.0.0` and `Last Updated` to today. |
| `Doxyfile` | `PROJECT_NUMBER` field changed from `"0.1.0"` to `"1.0.0"` so the generated Doxygen header advertises the v1.0 release. |
| `CONTRIBUTING.md` | Development Workflow item 2 and 7 updated to require branching from and targeting `develop` per `.claude/rules/workflow/branching-strategy.md`; "Writing Tests" snippet rewritten from `#include <gtest/gtest.h>` / `TEST(...)` to `#include <catch2/catch_test_macros.hpp>` / `TEST_CASE` + `SECTION`, with a note linking `docs/ECOSYSTEM.md` and the [#1141](https://github.com/kcenon/pacs_system/issues/1141) ecosystem-exception tracker. |

No API, CMake, or runtime surface is touched. No source file under `src/`, `include/`, `tests/`, or `tools/` is modified.

## How

### Implementation
- README sentinel sections (`<!-- STATS_START -->` / `<!-- STATS_END -->`) are preserved so the existing STATS regeneration tooling continues to function.
- The Project Structure table was reordered to keep the original 12 modules in their original positions; the three new rows (`IHE`, `DI`, `Compat`) are appended so existing anchor links into the section remain stable.
- The Architecture ASCII diagram only adds one new row (IHE actors) and one new label (DI) — column widths and box characters are kept identical to the original to minimize visual diff.
- `Doxyfile` change is a single-field surgical edit (only `PROJECT_NUMBER` line touched).
- `CONTRIBUTING.md` retains the existing Google Test-style narrative around "Use ... framework" but swaps in Catch2 idioms verbatim from the canonical `tests/` directory style.

### Testing done
- `git diff --stat`: 3 files, +57 / -32.
- `grep` verified no remaining `include/pacs/...` path references in the README (the canonical layout under `include/kcenon/pacs/` is the sole spelling).
- `grep` verified `Doxyfile` `PROJECT_NUMBER` is now `1.0.0` and matches the CMakeLists `VERSION 1.0.0`.
- `grep` verified CONTRIBUTING no longer references `gtest` or `GoogleTest` outside the link to ECOSYSTEM.md.
- Local `doxygen` is unavailable in the dev sandbox so Doxygen warning count cannot be re-verified here; the CI build-Doxygen workflow on this PR will exercise it.

### Test plan for reviewers
1. Pull the branch and open `README.md` — confirm the new "Current Version: 1.0.0" banner block at the top of Project Status, the three v1.0-contract links resolve, and the Architecture diagram now shows an "IHE Actors" row above Services.
2. Scroll to Project Structure and confirm all module include paths read `include/kcenon/pacs/<module>/`, the three new rows (`IHE`, `DI`, `Compat`) appear at the bottom, and the directory tree counts (290 / 217 / 189 / 2,657+ / 87 / v1.0.0) match the STATS block.
3. Open `Doxyfile` and confirm line 8 reads `PROJECT_NUMBER         = "1.0.0"`.
4. Open `CONTRIBUTING.md` and confirm the "Writing Tests" snippet uses `TEST_CASE` + `SECTION` and that the workflow points contributors at `develop`.
5. Wait for the `build-Doxygen.yaml` CI job to finish and verify the generated header on the artifact reports `1.0.0` and warning count for public headers stays at 0.

### Breaking changes
None. The retired `include/pacs/...` path was already removed from the codebase prior to this PR; this PR only updates the README that still referenced it.

### Rollback plan
Single squash-commit revert. No state outside the working tree is mutated.
