### PR TITLE
doc(changelog): convert CHANGELOG to keep-a-changelog format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Removed
-
-- Audited public and internal source for `[[deprecated]]` markers ahead of v1.0 freeze; no deprecated APIs were found, so no symbols were removed in this audit. Inventory recorded in [`docs/v1.0-deprecation-inventory.md`](docs/v1.0-deprecation-inventory.md) ([#1160](https://github.com/kcenon/pacs_system/issues/1160))
+## [1.0.0] - TBD
 
 ### Added
 
@@ -17,30 +15,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IHE XDS.b Document Consumer actor (ITI-43) at `src/ihe/xds/` with retrieve envelope builder and MTOM/XOP response parser ([#1129](https://github.com/kcenon/pacs_system/issues/1129))
 - IHE XDS.b Registry Query actor (ITI-18) at `src/ihe/xds/` with FindDocuments and GetDocuments stored queries against a conformant XDS.b Document Registry ([#1130](https://github.com/kcenon/pacs_system/issues/1130))
 - ATNA audit emission for IHE XDS.b transactions (ITI-18/41/43) with Gazelle-lite integration test harness, and published `docs/IHE_CONFORMANCE.md` ([#1131](https://github.com/kcenon/pacs_system/issues/1131))
+- v1.0.0 migration guide at [`docs/migration/0.x-to-1.0.md`](docs/migration/0.x-to-1.0.md): every breaking change between the 0.1.0 baseline and the 1.0.0 freeze documented with before/after snippets, an end-to-end `Result<T>` migration walkthrough, and an upgrade self-audit checklist. Linked from README "Upgrading" ([#1162](https://github.com/kcenon/pacs_system/issues/1162))
 
 ### Changed
 
 - API freeze for v1.0: enumerate the 290-header public surface under `include/kcenon/pacs/` in `docs/v1.0-api-surface.md`; confirm zero `[[deprecated]]` symbols and no experimental staging area; mark `network/detail/accept_worker.h` as the only implementation-detail header outside the v1.0 stability promise ([#1156](https://github.com/kcenon/pacs_system/issues/1156))
 - Migrate `decode_rle_segment` (file-scope helper in `src/encoding/compression/rle_codec.cpp`) from `throw std::runtime_error` to `Result<std::vector<uint8_t>>` so malformed RLE segments surface through the public `rle_codec::decode()` `Result<T>` contract instead of escaping as exceptions. Document the remaining 10 throws in `src/integration/` and `src/storage/hsm_storage.cpp` as constructor-invariant or `std::future`-boundary ABI escapes in the new `docs/v1.0-throw-policy.md`. Public headers under `include/kcenon/pacs/` continue to contain zero non-comment `throw` statements ([#1157](https://github.com/kcenon/pacs_system/issues/1157))
 - Remove committed `.key` files from version control; regenerate via `generate_test_certs.sh` in CI and local development ([#1092](https://github.com/kcenon/pacs_system/issues/1092))
-- Consolidate directory layout: `samples/` renamed to `examples/` (5 progressive tutorials) and `examples/` renamed to `tools/` (32 CLI utility binaries) so that the role split matches the ecosystem standard. CMake option names (`PACS_BUILD_EXAMPLES`, `PACS_BUILD_SAMPLES`) are preserved for backward compatibility ([#1139](https://github.com/kcenon/pacs_system/issues/1139))
+- **BREAKING**: Consolidate directory layout: `samples/` renamed to `examples/` (5 progressive tutorials) and `examples/` renamed to `tools/` (32 CLI utility binaries) so that the role split matches the ecosystem standard. CMake option names (`PACS_BUILD_EXAMPLES`, `PACS_BUILD_SAMPLES`) are preserved for backward compatibility. Downstream consumers that referenced the old paths must update to the new locations: tutorials are now under `examples/`, and CLI utility sources live under `tools/`. Build outputs for tutorials moved from `${CMAKE_BINARY_DIR}/samples` to `${CMAKE_BINARY_DIR}/examples` ([#1139](https://github.com/kcenon/pacs_system/issues/1139))
 - Align `cmake/*.cmake` modules with the canonical ecosystem template at `common_system/cmake/template`; pacs-specific modules (`pacs_system-config.cmake.in`, `summary.cmake`) and intentional design divergences are documented in `cmake/DEVIATIONS.md`, and the aligned template version is recorded in `cmake/VERSION` ([#1140](https://github.com/kcenon/pacs_system/issues/1140))
 - Stabilize the v1.0 CMake export contract: bump `project(pacs_system VERSION ...)` to `1.0.0`, add a canonical `pacs_system::pacs_system` aggregate INTERFACE target that links every required and built optional component, expose a `kcenon::pacs_system` alias for the legacy README spelling, and document the contract in the README "CMake Integration" section so downstream consumers can write `find_package(pacs_system 1.0 REQUIRED)` followed by `target_link_libraries(... PRIVATE pacs_system::pacs_system)`. Adds a regression consumer project at `tests/cmake_consumer/` ([#1158](https://github.com/kcenon/pacs_system/issues/1158))
-
-### BREAKING
-
-- Downstream consumers that referenced the old paths (`samples/...` for tutorials or `examples/...` for the CLI utilities) must update to the new locations: tutorials are now under `examples/`, and CLI utility sources live under `tools/`. Build outputs for tutorials moved from `${CMAKE_BINARY_DIR}/samples` to `${CMAKE_BINARY_DIR}/examples` ([#1139](https://github.com/kcenon/pacs_system/issues/1139))
-
-### Documentation
-
+- Replace POSIX iconv with ICU (ucnv_convert) for DICOM character set encoding/decoding ([#1012](https://github.com/kcenon/pacs_system/issues/1012))
+- Implement memory-mapped I/O for DICOM file loading ([#989](https://github.com/kcenon/pacs_system/issues/989))
+- Replace global singleton `pool_manager` with thread-local instances to eliminate cross-thread contention ([#992](https://github.com/kcenon/pacs_system/issues/992))
 - Modernize Doxygen with doxygen-awesome-css theme, dark mode toggle, and standardized mainpage ([#1066](https://github.com/kcenon/pacs_system/issues/1066))
 - Confirm canonical namespace is `kcenon::pacs::` across all source, with no remaining `pacs_system::` references; record ecosystem alignment ([#1138](https://github.com/kcenon/pacs_system/issues/1138))
 - Document Catch2 test framework retention as an explicit ecosystem exception in README, `docs/ECOSYSTEM.md`, and the master EPIC ([#1141](https://github.com/kcenon/pacs_system/issues/1141))
 
-### Performance
+### Removed
 
-- Implement memory-mapped I/O for DICOM file loading ([#989](https://github.com/kcenon/pacs_system/issues/989))
-- Replace global singleton `pool_manager` with thread-local instances to eliminate cross-thread contention ([#992](https://github.com/kcenon/pacs_system/issues/992))
+- Audited public and internal source for `[[deprecated]]` markers ahead of v1.0 freeze; no deprecated APIs were found, so no symbols were removed in this audit. Inventory recorded in [`docs/v1.0-deprecation-inventory.md`](docs/v1.0-deprecation-inventory.md) ([#1160](https://github.com/kcenon/pacs_system/issues/1160))
+
+### Fixed
+
+- Replace thread-unsafe `std::localtime` with `localtime_r`/`localtime_s` ([#990](https://github.com/kcenon/pacs_system/issues/990))
 
 ### Security
 
@@ -49,17 +47,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set `non_downgrading=true` in BCP195 basic TLS profile to prevent version downgrade attacks ([#991](https://github.com/kcenon/pacs_system/issues/991))
 - Handle patient age in basic anonymization profile per HIPAA Safe Harbor requirements ([#993](https://github.com/kcenon/pacs_system/issues/993))
 
-### Changed
-
-- Replace POSIX iconv with ICU (ucnv_convert) for DICOM character set encoding/decoding ([#1012](https://github.com/kcenon/pacs_system/issues/1012))
-
-### Fixed
-
-- Replace thread-unsafe `std::localtime` with `localtime_r`/`localtime_s` ([#990](https://github.com/kcenon/pacs_system/issues/990))
-
 ## [0.1.0] - 2026-03-13
 
 ### Added
+
 - DICOM protocol implementation (C-ECHO, C-STORE, C-FIND, C-MOVE, C-GET)
 - Transfer syntax support (Implicit VR Little Endian, Explicit VR, JPEG, JPEG2000, HTJ2K, JPEG-LS, RLE)
 - PACS storage with SQLite backend
@@ -69,15 +60,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - AWS S3 and Azure Blob storage integration
 - AI inference pipeline integration
 - CLI tools (pacs_echo, pacs_store, pacs_find, pacs_move, pacs_get, pacs_server)
-- Network layer migration to public tcp_facade API (#934)
-- vcpkg overlay port with feature-based dependency declaration (#921)
-- CMake install/export infrastructure (#920)
-- Release workflow for version tagging (#925)
-
-### Infrastructure
+- Network layer migration to public tcp_facade API ([#934](https://github.com/kcenon/pacs_system/issues/934))
+- vcpkg overlay port with feature-based dependency declaration ([#921](https://github.com/kcenon/pacs_system/issues/921))
+- CMake install/export infrastructure ([#920](https://github.com/kcenon/pacs_system/issues/920))
+- Release workflow for version tagging ([#925](https://github.com/kcenon/pacs_system/issues/925))
 - GitHub Actions CI/CD with sanitizer testing
 - Integration test workflow
 - SBOM generation workflow
 - Doxygen documentation with GitHub Pages deployment
 - vcpkg manifest with feature-based codecs, storage, and cloud features
 - Cross-platform support (Linux, macOS, Windows)
+
+[Unreleased]: https://github.com/kcenon/pacs_system/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/kcenon/pacs_system/compare/v0.1.0...v1.0.0
+[0.1.0]: https://github.com/kcenon/pacs_system/releases/tag/v0.1.0


### PR DESCRIPTION
Closes #1163

## What

Convert `CHANGELOG.md` to strict [keep-a-changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format and stage a `[1.0.0] - TBD` slot beneath `[Unreleased]` so v1.0.0 release tagging can promote the slot in one edit.

### Change Type
- [x] Documentation
- [ ] Feature
- [ ] Bugfix
- [ ] Refactor
- [ ] Test
- [ ] Chore

### Affected Components
- `CHANGELOG.md` (only file touched)

## Why

The v1.0.0 release contract requires keep-a-changelog 1.1.0 conformance (common_system #639, ecosystem-wide). The previous file had three structural deviations that would block a clean v1.0.0 cut:

1. **Non-standard section headers**: `BREAKING`, `Documentation`, `Performance`, `Infrastructure` are not part of the six categories enumerated by keep-a-changelog 1.1.0 (Added / Changed / Deprecated / Removed / Fixed / Security).
2. **Duplicate `Changed` section** appearing twice within the same `[Unreleased]` block.
3. **Missing `[1.0.0]` release slot**: every in-flight v1.0 change was sitting in `[Unreleased]` with no version stub to promote to at tag time.

Fixing this now sets the format precedent for the entire v1.x line and unblocks #1095.

## Where

- `CHANGELOG.md` at repo root
- Coordinates with open PR #1172 (migration guide, also touches CHANGELOG) - see "Coordination" below

## How

### Implementation Notes

- Restructured all historical entries to use only the six keep-a-changelog 1.1.0 sections.
- Folded the non-standard sections into the appropriate canonical ones:
  - `Documentation` -> `Changed` (doc improvements) or `Added` (new docs like the migration guide)
  - `Performance` -> `Changed`
  - `Infrastructure` -> `Added` (CI/CD, SBOM, vcpkg manifest were new in 0.1.0)
  - `BREAKING` -> inline `**BREAKING**:` prefix on the affected `Changed` entries
- Added explicit `[Unreleased]` (empty) at the top and `[1.0.0] - TBD` immediately below as the staging slot for all in-flight v1.0 work.
- Added semver compare links at the bottom of the file for `[Unreleased]`, `[1.0.0]`, and `[0.1.0]`.
- Promoted bare `(#934)` issue references in the 0.1.0 block to full Markdown links to match the style used elsewhere in the file.
- Preserved the migration-guide entry contributed by PR #1172 (`docs/migration/0.x-to-1.0.md`, #1162) under `[1.0.0] -> Added`.

### Acceptance Criteria

- [x] `CHANGELOG.md` follows keep-a-changelog 1.1.0 format
- [x] All historical releases have proper section headers (Added/Changed/Deprecated/Removed/Fixed/Security)
- [x] `[Unreleased]` section present at top
- [x] `[1.0.0]` stub added at top (immediately below `[Unreleased]`)

### Testing Done

- Docs-only change: no build verification required.
- Verified `CHANGELOG.md` renders correctly on GitHub.
- Verified no Markdown syntax errors with a local renderer.

### Breaking Changes

None for code. Tooling that parses `CHANGELOG.md` may need updating to handle the new section structure (the previous structure was not standards-conformant, so this is unlikely to be an issue).

## Coordination with PR #1172

PR #1172 (issue #1162, "write 0.x to 1.0 migration guide") modifies the `[Unreleased] -> Documentation` section of `CHANGELOG.md` to add a link to the new migration guide. This PR converts that same file to keep-a-changelog 1.1.0 format and removes the `Documentation` section as a non-standard heading.

**Resolution strategy**: I have already incorporated #1172's migration-guide CHANGELOG entry into this PR under `[1.0.0] -> Added` (with full prose and the same `#1162` issue link), so #1172's CHANGELOG addition is preserved in spirit. After this PR merges, #1172 will need a small rebase to drop its `CHANGELOG.md` hunk (the entry will already be present on `develop`); the migration guide itself (`docs/migration/0.x-to-1.0.md`) is unaffected and will merge cleanly.

If this PR merges second instead, the merge conflict on `CHANGELOG.md` will be straightforward to resolve by keeping the keep-a-changelog structure and ensuring the migration-guide entry lands under `[1.0.0] -> Added`.
