### PR TITLE
doc(migration): write 0.x to 1.0 migration guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,11 @@ The v1.0 contract freezes the public header surface under `include/kcenon/pacs/`
 and [`docs/v1.0-deprecation-inventory.md`](docs/v1.0-deprecation-inventory.md) for the
 pre-freeze deprecation audit.
 
-Upgrading from 0.x? See the [CHANGELOG](CHANGELOG.md) for the 0.x → 1.0 change set including the
-`samples/` → `examples/` and `examples/` → `tools/` directory relocation (#1139) and the
-`pacs_system::pacs_system` CMake contract (#1158).
+Upgrading from 0.x? Start with the [0.x → 1.0 Migration Guide](docs/migration/0.x-to-1.0.md)
+for the full upgrade walkthrough (include paths, namespaces, CMake contract, `Result<T>` migration,
+and the directory relocation), and consult the [CHANGELOG](CHANGELOG.md) for the underlying change
+set including the `samples/` → `examples/` and `examples/` → `tools/` directory relocation (#1139)
+and the `pacs_system::pacs_system` CMake contract (#1158).
 
 | Phase | Scope | Status |
 |-------|-------|--------|

--- a/docs/migration/0.x-to-1.0.md
+++ b/docs/migration/0.x-to-1.0.md
@@ -1,0 +1,501 @@
+---
+doc_id: "PAC-MIGR-V10-001"
+doc_title: "Migration Guide: 0.x to 1.0"
+doc_version: "1.0.0"
+doc_date: "2026-05-13"
+doc_status: "Released"
+project: "pacs_system"
+category: "MIGR"
+---
+
+# Migration Guide: 0.x to 1.0
+
+> **Scope**: This document is the canonical upgrade walkthrough for consumers
+> moving from the `0.1.0` baseline (released 2026-03-13) to the `1.0.0`
+> frozen public API. Every breaking change between the two versions is listed
+> here with a before/after snippet and a remediation step.
+>
+> **Tracking issue**: [#1162](https://github.com/kcenon/pacs_system/issues/1162)
+> **Parent epic**: [#1095](https://github.com/kcenon/pacs_system/issues/1095) — v1.0 release readiness
+> **Companion documents**: [`CHANGELOG.md`](../../CHANGELOG.md),
+> [`v1.0-api-surface.md`](../v1.0-api-surface.md),
+> [`v1.0-throw-policy.md`](../v1.0-throw-policy.md),
+> [`v1.0-deprecation-inventory.md`](../v1.0-deprecation-inventory.md).
+
+## Audience
+
+You should read this guide if your project:
+
+- Includes any header from `include/pacs/` or uses the legacy `pacs::`
+  namespace alias.
+- Pins `pacs_system` via `find_package(pacs_system 0.1 REQUIRED)`.
+- Builds tutorials from `samples/` or CLI utilities from the pre-1.0
+  `examples/` directory layout.
+- Catches `std::runtime_error` or `std::invalid_argument` from the codec or
+  storage public APIs that have since migrated to `Result<T>`.
+- Bundles test TLS material from `tests/data/**/*.key` directly.
+
+## Upgrade Self-Audit Checklist
+
+Run through this checklist once before you start; each item links to a
+section below that explains the remediation. Tick boxes as you go.
+
+- [ ] **Include paths** updated from `include/pacs/<module>/` to
+      `include/kcenon/pacs/<module>/` ([§ Include paths](#include-paths)).
+- [ ] **Namespaces** updated from `pacs_system::` to `kcenon::pacs::`. If
+      compat shim is acceptable, the legacy `pacs::` alias still resolves
+      ([§ Namespaces](#namespaces)).
+- [ ] **CMake `find_package` / target names** updated to the v1.0
+      contract: `find_package(pacs_system 1.0 REQUIRED)` +
+      `target_link_libraries(... PRIVATE pacs_system::pacs_system)`
+      ([§ CMake contract](#cmake-contract)).
+- [ ] **`Result<T>` migration** applied at each call site previously
+      relying on exceptions from `rle_codec::decode()` and other
+      Result-returning public APIs ([§ Result migration](#resultt-migration)).
+- [ ] **Directory relocation** consumed if you reference paths under
+      `samples/` (tutorials) or the pre-1.0 `examples/` (CLI utilities).
+      Tutorials are now under `examples/`; CLI utility sources live under
+      `tools/` ([§ Directory relocation](#directory-relocation)).
+- [ ] **Test TLS material** regenerated via
+      `scripts/generate_test_certs.sh` rather than read from the repository
+      ([§ Test TLS material](#test-tls-material)).
+- [ ] **Encoding integration** unchanged at the API level, but link line
+      now resolves through ICU instead of iconv. If you maintain a custom
+      sysroot, ICU must be present ([§ ICU replaces iconv](#icu-replaces-iconv)).
+- [ ] **Public API freeze** acknowledged. Any header outside
+      `docs/v1.0-api-surface.md` is private; do not include it
+      ([§ Public API freeze](#public-api-freeze)).
+- [ ] **CHANGELOG `[Unreleased]` → `[1.0.0]`** reviewed to spot any
+      additional incidental change relevant to your usage
+      ([§ Other notable changes](#other-notable-changes)).
+
+If every box ticks cleanly, the upgrade is done.
+
+## Include paths
+
+The 0.x public headers lived under `include/pacs/<module>/`. The v1.0 surface
+canonicalises them under `include/kcenon/pacs/<module>/` so the
+ecosystem-wide `include/kcenon/<system>/` prefix is honoured across all
+kcenon repositories.
+
+### Before — 0.x
+
+```cpp
+#include <pacs/core/dicom_dataset.h>
+#include <pacs/network/dicom_server.h>
+#include <pacs/services/storage_scp.h>
+```
+
+### After — 1.0
+
+```cpp
+#include <kcenon/pacs/core/dicom_dataset.h>
+#include <kcenon/pacs/network/dicom_server.h>
+#include <kcenon/pacs/services/storage_scp.h>
+```
+
+The relative path under the new prefix is identical to the 0.x layout, so a
+bulk rewrite is sufficient:
+
+```bash
+# Find affected files
+grep -rln 'include <pacs/' src/ include/
+
+# Rewrite (POSIX sed)
+grep -rln 'include <pacs/' src/ include/ \
+  | xargs sed -i.bak 's|include <pacs/|include <kcenon/pacs/|g'
+```
+
+The full v1.0 inventory of public headers is enumerated in
+[`docs/v1.0-api-surface.md`](../v1.0-api-surface.md). Any header not listed
+there is private and was not part of the 0.x public surface either; if you
+were including private headers in 0.x you must move to the public
+equivalents listed in the surface document.
+
+## Namespaces
+
+The canonical v1.0 namespace is `kcenon::pacs::`. The 0.x line shipped types
+in `pacs_system::` for some translation units and `pacs::` for others; both
+have been consolidated into `kcenon::pacs::` (#1138).
+
+### Before — 0.x
+
+```cpp
+using pacs_system::core::DicomDataset;
+using pacs::network::DicomServer;
+```
+
+### After — 1.0 (canonical)
+
+```cpp
+using kcenon::pacs::core::DicomDataset;
+using kcenon::pacs::network::DicomServer;
+```
+
+### Compatibility shim
+
+If you cannot rewrite call sites immediately, the v1.0 surface ships a
+namespace-level alias:
+
+```cpp
+#include <kcenon/pacs/compat/namespace_compat.h>
+
+// `pacs::` resolves to `kcenon::pacs::` for the remainder of the
+// translation unit.
+using pacs::core::DicomDataset;
+using pacs::network::DicomServer;
+```
+
+The shim is part of the v1.0 stability contract and will remain available
+through every v1.x release. It is removed in v2.0. There is **no**
+`pacs_system::` shim; if your code referenced `pacs_system::` you must
+rewrite to either `kcenon::pacs::` or the `pacs::` alias.
+
+## CMake contract
+
+The v1.0 CMake export contract (#1158) gives you three guarantees that
+were not stable in 0.x:
+
+1. A package version of `1.0.0` (set by `project(pacs_system VERSION 1.0.0)`).
+2. An aggregate INTERFACE target named `pacs_system::pacs_system` that links
+   every required and built optional component.
+3. A `kcenon::pacs_system` alias for callers using the ecosystem-wide
+   `kcenon::<system>` spelling.
+
+### Before — 0.x
+
+```cmake
+find_package(pacs_system 0.1 REQUIRED)
+
+target_link_libraries(my_app PRIVATE
+  pacs_system::pacs_core
+  pacs_system::pacs_network
+  pacs_system::pacs_services
+  pacs_system::pacs_storage
+  # ... pick-and-mix component list
+)
+```
+
+### After — 1.0
+
+```cmake
+find_package(pacs_system 1.0 REQUIRED)
+
+target_link_libraries(my_app PRIVATE pacs_system::pacs_system)
+# or, equivalently:
+# target_link_libraries(my_app PRIVATE kcenon::pacs_system)
+```
+
+The per-component targets (`pacs_system::pacs_core`,
+`pacs_system::pacs_network`, ...) still exist and remain part of the v1.0
+contract for callers that want to link a narrow subset. The aggregate
+target is the recommended default.
+
+The CMake regression consumer at
+[`tests/cmake_consumer/`](../../tests/cmake_consumer) is the executable
+example of the recommended `find_package` + aggregate-target pattern.
+
+## `Result<T>` migration
+
+The v1.0 throw policy ([`docs/v1.0-throw-policy.md`](../v1.0-throw-policy.md))
+is: **public APIs return `kcenon::common::Result<T>` for recoverable
+failures**. In 0.x a small number of paths threw `std::runtime_error` or
+`std::invalid_argument` from the public surface. Those have been migrated;
+the inventory of remaining throws is restricted to constructor invariants
+and `std::future`-boundary escapes documented in the throw policy.
+
+The single migration that affects external callers is the RLE codec
+(#1157): `rle_codec::decode_rle_segment` previously threw on malformed
+input. The public entry point `rle_codec::decode()` was already returning
+`Result<T>` in 0.x, but the underlying helper threw on insufficient literal
+data and missing replicate bytes; those errors now surface through the
+Result return path instead of as exceptions.
+
+### Before — 0.x
+
+```cpp
+#include <kcenon/pacs/encoding/compression/rle_codec.h>
+
+try {
+    auto frame = rle_codec::decode(encoded);  // could still throw from
+                                              // internal helper
+    process(frame);
+} catch (const std::runtime_error& e) {
+    log_error("RLE decode failed: {}", e.what());
+}
+```
+
+### After — 1.0 (end-to-end Result)
+
+```cpp
+#include <kcenon/pacs/encoding/compression/rle_codec.h>
+#include <kcenon/common/result.h>
+
+auto result = rle_codec::decode(encoded);
+if (!result) {
+    // result.error() is a kcenon::common::Error with code + message
+    log_error("RLE decode failed: code={}, msg={}",
+              static_cast<int>(result.error().code),
+              result.error().message);
+    return;
+}
+
+process(*result);
+```
+
+### Migration mechanics
+
+The general pattern for migrating from try/catch to `Result<T>` is:
+
+| Step | What you replace                            | What you write                                  |
+|------|---------------------------------------------|-------------------------------------------------|
+| 1    | `try { auto x = api(); use(x); }`           | `auto r = api(); if (r) use(*r);`               |
+| 2    | `catch (const std::runtime_error&)`         | `else if (r.error().code == decompression_error) ...` |
+| 3    | `catch (const std::invalid_argument&)`      | `else if (r.error().code == invalid_argument) ...`    |
+| 4    | `catch (...)`                               | fall-through `else { /* unknown */ }`           |
+
+`kcenon::common::Result<T>` is contextually convertible to `bool`, exposes
+`operator*()` and `operator->()` for value access on success, and
+`.error()` for the error record on failure. See
+[`include/kcenon/pacs/core/result.h`](../../include/kcenon/pacs/core/result.h)
+for the local re-export and the `kcenon::common::Result<T>` upstream
+definition for the full surface.
+
+### Documented ABI escapes
+
+A small set of throws remains in `src/` and is documented in
+[`docs/v1.0-throw-policy.md`](../v1.0-throw-policy.md). They fall into two
+classes:
+
+- **Constructor invariants**: `thread_pool_adapter`, `executor_adapter`,
+  and `hsm_storage` reject null dependencies at construction time via
+  `std::invalid_argument`. There is no Result return path for a
+  constructor; callers that want a no-throw construction path can use the
+  no-arg constructors or planned `try_make_*` factories.
+- **`std::future` boundary escapes**: `thread_pool_adapter::submit()`
+  returns `std::future<void>`; failures inside the submitted task
+  propagate at `future::get()` as the idiomatic re-throw. This matches the
+  standard library's documented contract for `std::future`.
+
+If your call site already wraps `submit()` in a try/catch around
+`future::get()`, no change is required.
+
+## Directory relocation
+
+Issue [#1139](https://github.com/kcenon/pacs_system/issues/1139) consolidates
+the directory layout to match the ecosystem standard. Two relocations apply:
+
+| 0.x path     | v1.0 path     | Contents                                |
+|--------------|---------------|-----------------------------------------|
+| `samples/`   | `examples/`   | 5 progressive tutorials                  |
+| `examples/`  | `tools/`      | 32 CLI utility binaries (sources)        |
+
+### Before — 0.x build
+
+```cmake
+add_subdirectory(samples)          # tutorials
+add_subdirectory(examples)         # CLI utilities (pacs_echo, pacs_store, ...)
+```
+
+### After — 1.0 build
+
+```cmake
+add_subdirectory(examples)         # tutorials (formerly samples/)
+add_subdirectory(tools)            # CLI utilities (formerly examples/)
+```
+
+### Build outputs
+
+Build artefacts moved along with the source paths:
+
+- 0.x: tutorial executables emitted to `${CMAKE_BINARY_DIR}/samples/`.
+- v1.0: tutorial executables emitted to `${CMAKE_BINARY_DIR}/examples/`.
+
+CLI utility binaries (`pacs_echo`, `pacs_store`, `pacs_find`, `pacs_move`,
+`pacs_get`, `pacs_server`) install under the same install destination as
+before; only their source directory changed.
+
+### Preserved CMake option names
+
+To minimise consumer churn, the option **names** were intentionally not
+renamed:
+
+- `PACS_BUILD_EXAMPLES` (OFF) — still gates the 32 CLI utility binaries
+  whose sources now live under `tools/`.
+- `PACS_BUILD_SAMPLES` (OFF) — still gates the 5 tutorials whose sources
+  now live under `examples/`.
+
+If your project sets these options in a parent build, no change is
+required. The compatibility-alias mapping is documented in
+`CHANGELOG.md` entry for #1139.
+
+## Test TLS material
+
+Issue [#1092](https://github.com/kcenon/pacs_system/issues/1092) removed
+committed `.key` files from version control to satisfy the macOS signing
+posture required for the v1.0 cross-platform contract. Test TLS material is
+now generated on demand.
+
+### Before — 0.x
+
+```bash
+# Test data including private keys was committed to the repo.
+ls tests/data/tls/
+# server.crt  server.key  ca.crt  ca.key
+```
+
+### After — 1.0
+
+```bash
+# Run the regeneration script (idempotent; safe to re-run).
+./scripts/generate_test_certs.sh
+ls tests/data/tls/
+# server.crt  server.key  ca.crt  ca.key  (regenerated locally)
+```
+
+The script is invoked automatically in CI before any test job that needs
+TLS material. Local developers must run it once after cloning, and again
+whenever the certificates expire (the default validity is 365 days).
+
+If you vendor a copy of the `tests/` tree into a separate test harness,
+mirror the script invocation in your own preflight step. The generated
+material is gitignored to prevent re-introducing key files into version
+control.
+
+## ICU replaces iconv
+
+Issue [#1012](https://github.com/kcenon/pacs_system/issues/1012) replaces the
+POSIX `iconv` dependency with ICU (`ucnv_convert`) for DICOM character set
+encoding and decoding. The public API of
+`include/kcenon/pacs/encoding/character_set.h` is unchanged; the swap is
+internal.
+
+The only consumer-visible impact is the link line:
+
+### Before — 0.x
+
+```cmake
+# 0.x implicitly required iconv via the public link interface.
+find_package(Iconv REQUIRED)
+target_link_libraries(my_app PRIVATE pacs_system::pacs_encoding Iconv::Iconv)
+```
+
+### After — 1.0
+
+```cmake
+# v1.0 carries ICU through the aggregate target's public link interface.
+find_package(ICU 60 REQUIRED COMPONENTS uc i18n data)
+target_link_libraries(my_app PRIVATE pacs_system::pacs_system)
+```
+
+If you build against the aggregate target, ICU is brought in transitively.
+If you build against `pacs_system::pacs_encoding` directly, you must
+provide ICU on your link line.
+
+### Custom sysroot consumers
+
+If you cross-compile against a custom sysroot, ensure ICU is present.
+Recommended minimum versions: ICU 60 on Linux distributions, ICU 65 on
+macOS, ICU 70 on Windows (via vcpkg). The vcpkg manifest at
+[`vcpkg.json`](../../vcpkg.json) lists `icu` as a required feature.
+
+## Public API freeze
+
+The v1.0 contract enumerates 289 frozen public headers and 1
+implementation-detail header in
+[`docs/v1.0-api-surface.md`](../v1.0-api-surface.md). Any header path not
+listed there is private. The following classes of headers are explicitly
+private:
+
+- Anything under `src/`, `tests/`, `tools/`, `examples/`, `benchmarks/`,
+  `fuzz/`, or `build*/`.
+- Any header under `<module>/detail/`. The single exception is
+  `network/detail/accept_worker.h`, which is reachable through the
+  `PUBLIC` include path for packaging convenience but is marked as
+  "Implementation detail" in the surface document and may change between
+  minor versions.
+
+If your 0.x code included private headers, locate the public alternative
+in the surface document and migrate. The v1.0 line will not relax this
+boundary; the breakage will only get more frequent as we use private
+helpers for performance work.
+
+## Other notable changes
+
+These are not strictly source-breaking for most consumers but are worth
+double-checking against your usage:
+
+- **`pool_manager` singleton replaced with thread-local instances**
+  (#992). If you snapshot the singleton state for telemetry, the snapshot
+  is now per-thread. Aggregate across threads via the public
+  `pool_manager::for_each_local` accessor.
+- **`std::localtime` replaced with `localtime_r` / `localtime_s`** (#990).
+  Public API unchanged; behaviour is now thread-safe.
+- **`AES-256-GCM` for `anonymizer::encrypt_value()`** (#987). Cipher text
+  produced by 0.x is **not** decryptable by 1.0 and vice versa. If you
+  archived encrypted values from 0.x, decrypt under 0.x before upgrading.
+- **`SHA-256` replaces `std::hash` in `anonymizer::hash_value()`** (#988).
+  Hash output is different; re-anonymise any stored hashes if they
+  participate in cross-version equality checks.
+- **TLS profile non-downgrade**: BCP195 basic profile now sets
+  `non_downgrading=true` (#991). If you negotiated against older TLS
+  peers, they may now be refused.
+- **HIPAA Safe Harbor patient age handling** in the basic anonymization
+  profile (#993). Age > 89 is clamped per Safe Harbor.
+
+Each of these is recorded under the matching `CHANGELOG.md` v1.0.0 entry.
+
+## After upgrade: verify
+
+Once the checklist is complete, verify the upgrade with the following
+commands from your downstream project:
+
+```bash
+# 1. CMake configure picks up v1.0.
+cmake -S . -B build -DCMAKE_PREFIX_PATH=<install-prefix>
+grep 'pacs_system version' build/CMakeCache.txt    # should show 1.0.0
+
+# 2. Build picks up the v1.0 surface only.
+cmake --build build
+# expected: no warnings about <pacs/...> include paths.
+
+# 3. Tests pass.
+cd build && ctest --output-on-failure
+```
+
+If CMake reports a version mismatch or the build emits include-path
+warnings, return to the checklist; the most common cause is a missed
+`include/pacs/` reference in a translation unit.
+
+## Getting help
+
+- Open an issue against
+  [kcenon/pacs_system](https://github.com/kcenon/pacs_system/issues) with
+  the label `type:doc` and a description of where this guide was
+  insufficient.
+- Cross-reference the master v1.0 epic
+  ([#1095](https://github.com/kcenon/pacs_system/issues/1095)) for the
+  full set of v1.0 readiness sub-issues.
+- For ecosystem-wide v1.0 questions, see
+  [`common_system #639`](https://github.com/kcenon/common_system/issues/639).
+
+## Acceptance criteria mapping
+
+The acceptance criteria from issue
+[#1162](https://github.com/kcenon/pacs_system/issues/1162) map to this
+guide as follows:
+
+- [x] **`docs/migration/0.x-to-1.0.md` committed** — this file.
+- [x] **Every API freeze removal/rename has a migration section** —
+  Include paths (`include/pacs/` → `include/kcenon/pacs/`),
+  Namespaces (`pacs_system::` → `kcenon::pacs::`),
+  Directory relocation (`samples/` → `examples/`, `examples/` → `tools/`),
+  CMake contract (`pacs_system::pacs_system` aggregate),
+  ICU/iconv link-line change, Test TLS regeneration, and the
+  Result<T>-vs-throw migration are each covered above.
+- [x] **`Result<T>` migration documented end-to-end** — see
+  [§ Result migration](#resultt-migration), including the call-site
+  pattern table and the documented ABI escapes.
+- [x] **Linked from README "Upgrading" and from CHANGELOG v1.0.0 entry** —
+  the README "Upgrading" paragraph and the CHANGELOG `[1.0.0]` Added
+  entry both link to this file.


### PR DESCRIPTION
## What

Add the canonical 0.x to 1.0 upgrade guide at `docs/migration/0.x-to-1.0.md` documenting every breaking change between the `0.1.0` baseline (2026-03-13) and the `1.0.0` frozen surface, with before/after snippets and an upgrade self-audit checklist.

### Change type
- [x] Documentation

### Affected components
- `docs/migration/0.x-to-1.0.md` (new, 491 lines)
- `README.md` (1 paragraph: 'Upgrading' link rewritten to point at the new guide)

## Why

Issue [#1162](https://github.com/kcenon/pacs_system/issues/1162) is the migration-guide subtask of the v1.0 readiness EPIC [#1095](https://github.com/kcenon/pacs_system/issues/1095). The v1.0 contract from `common_system` [#639](https://github.com/kcenon/common_system/issues/639) requires a published migration guide before the v1.0 tag.

The CHANGELOG `[1.0.0]` Added entry already named `docs/migration/0.x-to-1.0.md` as the migration document; the README 'Upgrading' paragraph previously sent readers to the CHANGELOG instead. This PR fills the file the CHANGELOG already pointed at and retargets the README link, so the three reference points (CHANGELOG entry, README 'Upgrading' link, and the migration guide itself) form a closed loop.

### Related issues
- Closes [#1162](https://github.com/kcenon/pacs_system/issues/1162)
- Part of [#1095](https://github.com/kcenon/pacs_system/issues/1095) (v1.0 epic)

## Who

- Reviewers: @kcenon
- Stakeholders: downstream 0.x consumers planning the upgrade to v1.0

## When

- Urgency: Normal
- Target release: v1.0.0
- No deployment side-effects (docs-only)

## Where

| File | Change |
|------|--------|
| `docs/migration/0.x-to-1.0.md` | New file. Front-matter (`doc_id: PAC-MIGR-V10-001`, `doc_status: Released`) matches the convention used by `docs/MIGRATION_COMPLETE.md`. Self-audit checklist with 9 items, each linking to a remediation section: include paths, namespaces, CMake contract, Result<T> migration, directory relocation, test TLS material, ICU vs iconv, public API freeze, and other notable changes. Cross-references `docs/v1.0-api-surface.md`, `docs/v1.0-throw-policy.md`, `docs/v1.0-deprecation-inventory.md`, and `CHANGELOG.md`. |
| `README.md` | The 'Upgrading from 0.x?' paragraph rewritten to lead with the migration guide and keep the CHANGELOG reference as a secondary pointer. |

No `src/`, `include/`, `tests/`, `tools/`, `CMakeLists.txt`, or runtime surface is touched.

## How

### Implementation
- The breaking-change inventory was derived from the CHANGELOG `[Unreleased]` -> `[1.0.0]` section, filtered to changes that affect downstream consumers' source, link line, or build:
  - Include paths (`include/pacs/` -> `include/kcenon/pacs/`) — derived from the v1.0 API surface document.
  - Namespaces (`pacs_system::` -> `kcenon::pacs::`) and the `pacs::` compat shim — #1138.
  - CMake contract (`find_package(pacs_system 1.0)` + `pacs_system::pacs_system` aggregate target) — #1158.
  - Result<T> migration end-to-end with the call-site pattern table and the documented ABI escapes — #1157, `docs/v1.0-throw-policy.md`.
  - Directory relocation (`samples/` -> `examples/`, `examples/` -> `tools/`) with preserved option names — #1139.
  - Test TLS regeneration via `generate_test_certs.sh` — #1092.
  - ICU vs iconv link-line change — #1012.
  - Other notable changes (pool_manager thread-local, AES-256-GCM, SHA-256, TLS BCP195, HIPAA Safe Harbor age handling).
- Each breaking-change section includes a Before / After snippet pair in C++ or CMake plus a remediation step (often a one-liner like a `sed` invocation).
- The post-upgrade verify section shows the three commands a downstream maintainer should run after migrating: `cmake -S . -B build`, `cmake --build build`, and `ctest --output-on-failure`.
- The acceptance criteria from #1162 are mapped at the end of the document so a reviewer can tick them off against the table of contents.

### Testing done
- `grep` confirms the migration guide path is now referenced from CHANGELOG.md, README.md, and the migration guide itself.
- `git diff --stat`: 2 files, +506 / -3 lines.
- No source or build surface is touched, so no build/test regression is possible from this PR.

### Test plan for reviewers
1. Open `docs/migration/0.x-to-1.0.md` and walk the self-audit checklist; each item has a matching section below.
2. Open `README.md` and confirm the 'Upgrading' paragraph now leads with the migration guide link.
3. Confirm `CHANGELOG.md` `[1.0.0]` Added entry still points at the same path (no change to CHANGELOG.md in this PR).
4. Cross-check each Before / After snippet against the canonical referenced issue (#1138, #1158, #1157, #1139, #1092, #1012) for fidelity.

### Breaking changes
None. Documentation-only.

### Rollback plan
Single squash-commit revert. No state outside the working tree is mutated.
