### PR TITLE
fix(vcpkg): bump kcenon registry baseline to pick up corrected common_system v0.2.0 hash

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -8,7 +8,7 @@
     {
       "kind": "git",
       "repository": "https://github.com/kcenon/vcpkg-registry.git",
-      "baseline": "50d89f5b1962e811dfb779bc46fa3d251db42ce7",
+      "baseline": "1be52cbd3f11369cf9eb983c02c4404df3155cc3",
       "packages": [
         "kcenon-*"
       ]


### PR DESCRIPTION
## Root cause

The CI step **"Build application (fallback - Unix)"** (jobs `macos-14`/clang, `ubuntu-24.04`/clang, `ubuntu-24.04`/gcc) fails while resolving `kcenon-common-system`:

```
download from https://github.com/kcenon/common_system/archive/v0.2.0.tar.gz had an unexpected hash
note: Expected: 7385ba3a073fea06604f71a7ffc016425408c768444cec2ec897537411926a7e1fad99f7215e6724b3668a6e227f0716dbdcdda462764f5c4e52709087751e26
```

The `Expected` SHA512 `7385ba3a...` is **stale**. The actual `common_system` `v0.2.0` tarball hashes to `ac458878...`.

This is caused by `vcpkg-configuration.json` pinning the kcenon git registry to an **old baseline** (`50d89f5b1962e811dfb779bc46fa3d251db42ce7`), whose `ports/kcenon-common-system/portfile.cmake` still carried the wrong `7385ba3a...` hash. The central `kcenon/vcpkg-registry` has since corrected that portfile, but pacs's pinned baseline predates the fix.

The primary **"Build & Unit Tests"** jobs pass because their resolution path already sees the corrected hash; only the **fallback (Unix)** path is gated on the stale baseline.

## Fix

Bump the kcenon registry `baseline` in `vcpkg-configuration.json`:

- old: `50d89f5b1962e811dfb779bc46fa3d251db42ce7` -> portfile SHA512 `7385ba3a...` (stale / wrong)
- new: `1be52cbd3f11369cf9eb983c02c4404df3155cc3` -> portfile SHA512 `ac458878...` (correct)

The upstream `microsoft/vcpkg` builtin `default-registry` baseline (`d90a9b15...`) is **not** touched, and `vcpkg.json` has no `builtin-baseline` key, so no other pin changes. Only one line in `vcpkg-configuration.json` is modified.

## Verification

- `kcenon/vcpkg-registry` default branch (`main`) HEAD is `1be52cbd3f11369cf9eb983c02c4404df3155cc3`.
- At that commit, `ports/kcenon-common-system/portfile.cmake` carries `SHA512 ac458878395dbac632aa56a188f49d0c996e9334b67914d1e9a095d8f2bf45ea988232e31259758b595deb3374f833edfd91948a71a042f401a3db222600758c` and no longer contains the stale `7385ba3a...`.
- The `versions/k-/kcenon-common-system.json` entry for `0.2.0` (port-version 3) points at git-tree `023f95ca...`, whose `portfile.cmake` blob (`33d55815...`) carries the same corrected `ac458878...` hash. Versions DB and portfile are consistent.
- The old baseline `50d89f5b...` was confirmed to map to the stale `7385ba3a...` portfile, proving it is the source of the failure.

## Impact

Unblocks the **fallback-Unix CI** path for all pacs PRs, including **#1181** and **#1183**.
