### PR TITLE
fix(version): mark untagged 1.0.0 as pre-release (1.0.0-rc)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,13 @@ project(pacs_system
     LANGUAGES CXX
 )
 
+# Pre-release stage marker. The numeric PROJECT_VERSION (1.0.0) is the target
+# v1.0 API contract, but no v1.0.0 git tag exists yet (highest tag is v0.1.0),
+# so human-facing surfaces append this stage to avoid advertising a released,
+# stable 1.0.0. Bump to a clean 1.0.0 by clearing this marker (set to "") in
+# the same commit that cuts the v1.0.0 git tag (#1095).
+set(PACS_VERSION_STAGE "rc")
+
 ##################################################
 # C++ Standard and Build Configuration
 ##################################################

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A modern C++20 PACS (Picture Archiving and Communication System) implementation 
 
 ## Project Status
 
-**Current Version**: 1.0.0 — Stable Public API
+**Current Version**: 1.0.0-rc — release candidate, not yet tagged (v1.0.0 tag pending #1095)
 **Project Phase**: Phase 4 Complete — Advanced Services & Production Hardening
 
 The v1.0 contract freezes the public header surface under `include/kcenon/pacs/`, the
@@ -489,7 +489,7 @@ pacs_system/
 ├── examples/             # Tutorials (5 progressive learning steps)
 ├── tools/                # CLI utility binaries (32 apps)
 ├── docs/                 # Documentation (87 markdown files)
-└── CMakeLists.txt        # Build configuration (v1.0.0)
+└── CMakeLists.txt        # Build configuration (v1.0.0-rc)
 ```
 
 > For the full file-level directory tree, see [Project Structure](docs/PROJECT_STRUCTURE.md).
@@ -623,7 +623,7 @@ cmake --build build --target run_full_benchmarks
 | **Example Programs** | 6 apps |
 | **Documentation** | 87 markdown files |
 | **CI/CD Workflows** | 15 workflows |
-| **Version** | 1.0.0 |
+| **Version** | 1.0.0-rc (untagged) |
 | **Last Updated** | 2026-05-13 |
 
 <!-- STATS_END -->

--- a/cmake/summary.cmake
+++ b/cmake/summary.cmake
@@ -4,7 +4,11 @@
 
 message(STATUS "")
 message(STATUS "========================================")
-message(STATUS "PACS System v${PROJECT_VERSION}")
+if(PACS_VERSION_STAGE)
+    message(STATUS "PACS System v${PROJECT_VERSION}-${PACS_VERSION_STAGE} (untagged)")
+else()
+    message(STATUS "PACS System v${PROJECT_VERSION}")
+endif()
 message(STATUS "========================================")
 message(STATUS "")
 message(STATUS "Dependency Chain (Tier 5):")


### PR DESCRIPTION
## What

Stop advertising a released, stable v1.0.0 while pacs is untagged (highest real tag is v0.1.0). The same "documented-but-untagged 1.0.0" defect the ecosystem analysis flags for the libraries.

## How

- `CMakeLists.txt`: keep `project(... VERSION 1.0.0 ...)` numeric (target 1.0 API contract), add `set(PACS_VERSION_STAGE "rc")` with a revert-at-tag comment.
- `cmake/summary.cmake`: build summary now prints `PACS System v1.0.0-rc (untagged)` (guarded; degrades to `v1.0.0` when the stage is cleared).
- `README.md`: line 49 "1.0.0 — Stable Public API" -> "1.0.0-rc — release candidate, not yet tagged (v1.0.0 tag pending #1095)"; the stats table and a file-tree comment match.

## Deliberate scope decision (reviewed)

The **exported package version** (`cmake/pacs_system-config.cmake.in`, `cmake/install.cmake` `write_basic_package_version_file`) is left **numeric 1.0.0**. Injecting a non-numeric `-rc` token there would break SemVer comparison for downstream `find_package(pacs_system 1.0.0 ...)` consumers. The defect this issue targets is the human-facing "released/stable" assertion, not the numeric compatibility contract — so only human surfaces carry the stage. Clearing `PACS_VERSION_STAGE` at tag time makes exported / numeric / docs all coherent in one line.

The migration guide's "1.0.0 API freeze" wording (README:559) is unchanged — it describes the target API contract, not a release claim.

Closes #1190
Part of kcenon/pacs_system#1095
